### PR TITLE
crictl inspecti fail to unmarshal

### DIFF
--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -170,6 +170,7 @@ var listImageCommand = cli.Command{
 				id := image.Id
 				if !noTrunc {
 					id = getTruncatedID(id, "sha256:")
+					repoDigest = getTruncatedID(repoDigest, "sha256:")
 				}
 				for _, repoTagPair := range repoTagPairs {
 					if showDigest {
@@ -194,8 +195,9 @@ var listImageCommand = cli.Command{
 				fmt.Printf("Uid: %v\n", image.Uid)
 			}
 			if image.Username != "" {
-				fmt.Printf("Username: %v\n\n", image.Username)
+				fmt.Printf("Username: %v\n", image.Username)
 			}
+			fmt.Printf("\n")
 		}
 		w.Flush()
 		return nil

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -224,7 +224,7 @@ func outputStatusInfo(status string, info map[string]string, format string) erro
 	for _, k := range keys {
 		var res interface{}
 		// We attempt to convert key into JSON if possible else use it directly
-		if err := json.Unmarshal([]byte(info[k]), res); err != nil {
+		if err := json.Unmarshal([]byte(info[k]), &res); err != nil {
 			jsonInfo += "\"" + k + "\"" + ":" + "\"" + info[k] + "\","
 		} else {
 			jsonInfo += "\"" + k + "\"" + ":" + info[k] + ","


### PR DESCRIPTION
Signed-off-by: yanxuean <yan.xuean@zte.com.cn>

The crictl inspecti can't work.
```
root@ubuntu:cloud# crictl inspecti -o json cd
FATA[0000] failed to output status for "cd": invalid character 'c' after object key:value pair

root@ubuntu:cloud# crictl --debug inspecti -o json cd
DEBU[0000] ImageStatusRequest: &ImageStatusRequest{Image:&ImageSpec{Image:cd,},Verbose:true,}
DEBU[0000] ImageStatusResponse: &ImageStatusResponse{Image:&Image{Id:sha256:cd6d8154f1e16e38493c3c2798977c5e142be5e5d41403ca89883840c6d51762,RepoTags:[docker.io/library/ubuntu:latest],RepoDigests:[docker.io/library/ubuntu@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378],Size_:31766713,Uid:nil,Username:,},Info:map[string]string{info: {"chainID":"sha256:2416e906f135eea2d08b4a8a8ae539328482eacb6cf39100f7c8f99e98a78d84","imageSpec":{"created":"2018-09-05T22:20:12.306501594Z","architecture":"amd64","os":"linux","config":{"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"Cmd":["/bin/bash"]},"rootfs":{"type":"layers","diff_ids":["sha256:a30b835850bfd4c7e9495edf7085cedfad918219227c7157ff71e8afe2661f63","sha256:6267b420796f78004358a36a2dd7ea24640e0d2cd9bbfdba43bb0c140ce73567","sha256:f73b2816c52ac5f8c1f64a1b309b70ff4318d11adff253da4320eee4b3236373","sha256:6a061ee02432e1472146296de3f6dab653f57c109316fa178b40a5052e695e41","sha256:8d7ea83e3c626d5ef1e6a05de454c3fe8b7a567db96293cb094e71930dba387d"]},"history":[{"created":"2018-09-05T22:20:09.604867469Z","created_by":"/bin/sh -c #(nop) ADD file:3df374a69ce696c21058366678c1ceb89e11349e52decfd35de0ee3bd8dc1162 in / "},{"created":"2018-09-05T22:20:10.334964985Z","created_by":"/bin/sh -c set -xe \t\t\u0026\u0026 echo '#!/bin/sh' \u003e /usr/sbin/policy-rc.d \t\u0026\u0026 echo 'exit 101' \u003e\u003e /usr/sbin/policy-rc.d \t\u0026\u0026 chmod +x /usr/sbin/policy-rc.d \t\t\u0026\u0026 dpkg-divert --local --rename --add /sbin/initctl \t\u0026\u0026 cp -a /usr/sbin/policy-rc.d /sbin/initctl \t\u0026\u0026 sed -i 's/^exit.*/exit 0/' /sbin/initctl \t\t\u0026\u0026 echo 'force-unsafe-io' \u003e /etc/dpkg/dpkg.cfg.d/docker-apt-speedup \t\t\u0026\u0026 echo 'DPkg::Post-Invoke { \"rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true\"; };' \u003e /etc/apt/apt.conf.d/docker-clean \t\u0026\u0026 echo 'APT::Update::Post-Invoke { \"rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true\"; };' \u003e\u003e /etc/apt/apt.conf.d/docker-clean \t\u0026\u0026 echo 'Dir::Cache::pkgcache \"\"; Dir::Cache::srcpkgcache \"\";' \u003e\u003e /etc/apt/apt.conf.d/docker-clean \t\t\u0026\u0026 echo 'Acquire::Languages \"none\";' \u003e /etc/apt/apt.conf.d/docker-no-languages \t\t\u0026\u0026 echo 'Acquire::GzipIndexes \"true\"; Acquire::CompressionTypes::Order:: \"gz\";' \u003e /etc/apt/apt.conf.d/docker-gzip-indexes \t\t\u0026\u0026 echo 'Apt::AutoRemove::SuggestsImportant \"false\";' \u003e /etc/apt/apt.conf.d/docker-autoremove-suggests"},{"created":"2018-09-05T22:20:10.930386558Z","created_by":"/bin/sh -c rm -rf /var/lib/apt/lists/*"},{"created":"2018-09-05T22:20:11.498676134Z","created_by":"/bin/sh -c sed -i 's/^#\\s*\\(deb.*universe\\)$/\\1/g' /etc/apt/sources.list"},{"created":"2018-09-05T22:20:12.131247691Z","created_by":"/bin/sh -c mkdir -p /run/systemd \u0026\u0026 echo 'docker' \u003e /run/systemd/container"},{"created":"2018-09-05T22:20:12.306501594Z","created_by":"/bin/sh -c #(nop)  CMD [\"/bin/bash\"]","empty_layer":true}]}},},}
FATA[0000] failed to output status for "cd": invalid character 'c' after object key:value pair
```

It always return error "err=json: Unmarshal(nil)" for json.Unmarshal.
```
func outputStatusInfo(status string, info map[string]string, format string) error {
	// Sort all keys
	var keys []string
	for k := range info {
		keys = append(keys, k)
	}
	sort.Strings(keys)

	jsonInfo := "{" + "\"status\":" + status + ","
	for _, k := range keys {
		var res interface{}
		// We attempt to convert key into JSON if possible else use it directly
		if err := json.Unmarshal([]byte(info[k]), res); err != nil {
			jsonInfo += "\"" + k + "\"" + ":" + "\"" + info[k] + "\","
		} else {
			jsonInfo += "\"" + k + "\"" + ":" + info[k] + ","
		}
	}

```