### PR TITLE
Fix grpc dial timeout

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -57,7 +57,7 @@ func getRuntimeClientConnection(context *cli.Context) (*grpc.ClientConn, error) 
 		return nil, err
 	}
 
-	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(Timeout), grpc.WithDialer(dialer))
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(Timeout), grpc.WithDialer(dialer))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect: %v", err)
 	}
@@ -77,7 +77,7 @@ func getImageClientConnection(context *cli.Context) (*grpc.ClientConn, error) {
 		return nil, err
 	}
 
-	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(Timeout), grpc.WithDialer(dialer))
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(Timeout), grpc.WithDialer(dialer))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect: %v", err)
 	}


### PR DESCRIPTION
The `WithTimeout` option in `grpc.Dial` is only valid if `WithBlock()` is present see https://godoc.org/google.golang.org/grpc#WithTimeout

As a result using `crictl` on a non existing socket with this fix has a different behavior because the timeout is honored:

before: `FATA[0000] getting status of runtime failed: rpc error: code = Unavailable desc = grpc: the connection is unavailable`

after: `FATA[0010] failed to connect: failed to connect: context deadline exceeded`