### PR TITLE
fix error way of parsing URL for cmd exec and attach

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -89,14 +88,19 @@ func Attach(client pb.RuntimeServiceClient, opts attachOptions) error {
 		return err
 	}
 	attachURL := r.Url
-	if !strings.HasPrefix(attachURL, "http") {
-		attachURL = kubeletURLPrefix + attachURL
-	}
 
 	URL, err := url.Parse(attachURL)
 	if err != nil {
 		return err
 	}
+
+	if URL.Host == "" {
+		URL.Host = kubeletURLHost
+	}
+	if URL.Scheme == "" {
+		URL.Scheme = kubeletURLSchema
+	}
+
 	logrus.Debugf("Attach URL: %v", URL)
 	return stream(opts.stdin, opts.tty, URL)
 }

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"net/url"
-	"strings"
 
 	dockerterm "github.com/docker/docker/pkg/term"
 	"github.com/sirupsen/logrus"
@@ -33,7 +32,8 @@ import (
 
 const (
 	// TODO: make this configurable in kubelet.
-	kubeletURLPrefix = "http://127.0.0.1:10250"
+	kubeletURLSchema = "http"
+	kubeletURLHost   = "http://127.0.0.1:10250"
 )
 
 var runtimeExecCommand = cli.Command{
@@ -134,14 +134,18 @@ func Exec(client pb.RuntimeServiceClient, opts execOptions) error {
 		return err
 	}
 	execURL := r.Url
-	if !strings.HasPrefix(execURL, "http") {
-		execURL = kubeletURLPrefix + execURL
-
-	}
 
 	URL, err := url.Parse(execURL)
 	if err != nil {
 		return err
+	}
+
+	if URL.Host == "" {
+		URL.Host = kubeletURLHost
+	}
+
+	if URL.Scheme == "" {
+		URL.Scheme = kubeletURLSchema
 	}
 
 	logrus.Debugf("Exec URL: %v", URL)

--- a/cmd/crictl/portforward.go
+++ b/cmd/crictl/portforward.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -78,14 +77,20 @@ func PortForward(client pb.RuntimeServiceClient, opts portforwardOptions) error 
 		return err
 	}
 	portforwardURL := r.Url
-	if !strings.HasPrefix(portforwardURL, "http") {
-		portforwardURL = kubeletURLPrefix + portforwardURL
-	}
 
 	URL, err := url.Parse(portforwardURL)
 	if err != nil {
 		return err
 	}
+
+	if URL.Host == "" {
+		URL.Host = kubeletURLHost
+	}
+
+	if URL.Scheme == "" {
+		URL.Scheme = kubeletURLSchema
+	}
+
 	logrus.Debugf("PortForward URL: %v", URL)
 	transport, upgrader, err := spdy.RoundTripperFor(&restclient.Config{})
 	if err != nil {


### PR DESCRIPTION
Parsing URL with url.schema other than prefix of URL.

Signed-off-by: t00416110 <tanyifeng1@huawei.com>