### PR TITLE
Enable windows CI on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ sudo: required
 dist: trusty
 
 go:
-  - "1.11.1"
+  - 1.11.x
+
+os:
+  - linux
+  - windows
 
 go_import_path: github.com/kubernetes-sigs/cri-tools
 
@@ -11,8 +15,14 @@ services:
   - docker
 
 before_install:
-  - hack/install-docker.sh
-  - hack/install-kubelet.sh
+  - |
+    (
+      set -Eeuo pipefail
+      if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+        choco install -y make mingw
+        export PATH="/c/tools/mingw64/bin:/c/ProgramData/chocolatey/bin;$PATH"
+      fi
+    )
 
 install:
   - make install.tools
@@ -20,13 +30,30 @@ install:
 jobs:
   include:
     - stage: Static check
+      os: linux # Only need to run on Linux
       script:
         - make lint
         - make gofmt
     - stage: Build
+      os: linux # Only need to run on Linux
       script:
-        - make release
+        -  make release
     - stage: Test
+      os: linux
       script:
         - make
+        - hack/install-docker.sh
+        - hack/install-kubelet.sh
         - sudo env PATH=$PATH GOPATH=$GOPATH hack/run-critest.sh
+    - stage: Test
+      os: windows
+      script:
+        - make
+        - powershell -c "Set-ExecutionPolicy Bypass -Scope CURRENTUSER -Force"
+        - powershell hack/install-kubelet.ps1
+        # Skip hack/run-critest.sh temporarily.
+
+stages:
+  - Static check
+  - Build
+  - Test

--- a/hack/install-docker.sh
+++ b/hack/install-docker.sh
@@ -34,4 +34,3 @@ rm -f docker.tgz
 
 # Restart docker daemon.
 sudo service docker restart
-

--- a/hack/install-kubelet.ps1
+++ b/hack/install-kubelet.ps1
@@ -1,0 +1,43 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stop on any error.
+$ErrorActionPreference = "Stop"
+$VerbosePreference = "Continue"
+
+# Install kubelet
+$gopath = [System.Environment]::GetEnvironmentVariable("GOPATH")
+$k8siopath = $gopath + "/src/k8s.io"
+$kubernetespath = $k8siopath + "/kubernetes"
+mkdir -p $k8siopath
+cd $k8siopath
+git clone -c core.symlinks=true https://github.com/kubernetes/kubernetes
+
+cd $kubernetespath
+$branch = [System.Environment]::GetEnvironmentVariable("TRAVIS_BRANCH")
+if ( ! "$branch".Equals("master") ) {
+  # We can do this because cri-tools have the same branch name with kubernetes.
+  git checkout "$branch"
+}
+
+# Build kubelet
+$version = git describe --tags --dirty --always
+go build -ldflags "-X k8s.io/kubernetes/vendor/k8s.io/client-go/pkg/version.gitVersion=$version -X k8s.io/kubernetes/pkg/version.gitVersion=$version" ./cmd/kubelet/kubelet.go
+cp ./kubelet.exe "$gopath/bin/"
+
+# Dump version
+echo "Kubelet version:"
+kubelet.exe --version
+echo "Docker version:"
+docker version


### PR DESCRIPTION
Travis now adds support for [Windows environment](https://docs.travis-ci.com/user/reference/windows/). This PR adds initial support for Windows building on travis and critest are disabled for Windows.

A few of following PRs will be added to fully support windows.