### PR TITLE
crictl: add option to filter by container name in ps

### DIFF
--- a/cmd/crictl/constants.go
+++ b/cmd/crictl/constants.go
@@ -19,6 +19,7 @@ package main
 const (
 	// This labels are copied from kubelet directly, and may change
 	// without warning in the future.
-	kubePodNameLabel      = "io.kubernetes.pod.name"
-	kubePodNamespaceLabel = "io.kubernetes.pod.namespace"
+	kubePodNameLabel       = "io.kubernetes.pod.name"
+	kubePodNamespaceLabel  = "io.kubernetes.pod.namespace"
+	kubeContainerNameLabel = "io.kubernetes.container.name"
 )

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -48,8 +49,8 @@ type listOptions struct {
 	id string
 	// podID of container
 	podID string
-	// Regular expression pattern to match pod name
-	podNameRegexp string
+	// Regular expression pattern to match pod or container
+	nameRegexp string
 	// Regular expression pattern to match the pod namespace
 	podNamespaceRegexp string
 	// state of the sandbox
@@ -307,4 +308,16 @@ func getTruncatedID(id, prefix string) string {
 		id = id[:truncatedIDLen]
 	}
 	return id
+}
+
+func matchesRegex(pattern, target string) bool {
+	if pattern == "" {
+		return true
+	}
+	matched, err := regexp.MatchString(pattern, target)
+	if err != nil {
+		// Assume it's not a match if an error occurs.
+		return false
+	}
+	return matched
 }

--- a/cmd/crictl/util_test.go
+++ b/cmd/crictl/util_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 )
 
-func TestPodFilterByRegex(t *testing.T) {
+func TestNameFilterByRegex(t *testing.T) {
 	testCases := []struct {
-		desc      string
-		pattern   string
-		podString string
-		isMatch   bool
+		desc    string
+		pattern string
+		name    string
+		isMatch bool
 	}{
 		{
 			"exact name should match",
@@ -60,7 +60,7 @@ func TestPodFilterByRegex(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			r := podMatchesRegex(tc.pattern, tc.podString)
+			r := matchesRegex(tc.pattern, tc.name)
 			if r != tc.isMatch {
 				t.Errorf("expected matched to be %v; actual result is %v", tc.isMatch, r)
 			}


### PR DESCRIPTION
This way users can do one liner like this one to grab logs out of a particular container:
```
crictl logs $(crictl ps --pod $(crictl pods --name kube-dns -q) --name kubedns -q)
```

Signed-off-by: Antonio Murdaca <runcom@linux.com>