### PR TITLE
Add `runtime-handler` flag in critest.

### DIFF
--- a/pkg/benchmark/pod.go
+++ b/pkg/benchmark/pod.go
@@ -54,7 +54,7 @@ var _ = framework.KubeDescribe("PodSandbox", func() {
 
 			// TODO: add support of runtime
 			operation := b.Time("create PodSandbox", func() {
-				podID, err = c.RunPodSandbox(config, "")
+				podID, err = c.RunPodSandbox(config, framework.TestContext.RuntimeHandler)
 			})
 
 			framework.ExpectNoError(err, "failed to create PodSandbox: %v", err)

--- a/pkg/framework/test_context.go
+++ b/pkg/framework/test_context.go
@@ -35,6 +35,7 @@ type TestContextType struct {
 	ImageServiceTimeout   time.Duration
 	RuntimeServiceAddr    string
 	RuntimeServiceTimeout time.Duration
+	RuntimeHandler        string
 
 	// Benchmark setting.
 	Number int
@@ -65,5 +66,6 @@ func RegisterFlags() {
 	}
 	flag.StringVar(&TestContext.RuntimeServiceAddr, "runtime-endpoint", svcaddr, "Runtime service socket for client to connect..")
 	flag.DurationVar(&TestContext.RuntimeServiceTimeout, "runtime-service-timeout", 300*time.Second, "Timeout when trying to connect to a runtime service.")
+	flag.StringVar(&TestContext.RuntimeHandler, "runtime-handler", "", "Runtime handler to use in the test.")
 	flag.IntVar(&TestContext.Number, "number", 5, "Number of PodSandbox/container in listing benchmark test.")
 }

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -148,8 +148,7 @@ func BuildPodSandboxMetadata(podSandboxName, uid, namespace string, attempt uint
 
 // RunPodSandbox runs a PodSandbox.
 func RunPodSandbox(c internalapi.RuntimeService, config *runtimeapi.PodSandboxConfig) string {
-	// TODO: add support of runtime handler.
-	podID, err := c.RunPodSandbox(config, "")
+	podID, err := c.RunPodSandbox(config, TestContext.RuntimeHandler)
 	ExpectNoError(err, "failed to create PodSandbox: %v", err)
 	return podID
 }


### PR DESCRIPTION
Add RuntimeHandler support in `critest`.

Signed-off-by: Lantao Liu <lantaol@google.com>