### PR TITLE
crictl: do not error out if one rm operation fails

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -209,7 +209,7 @@ var removeContainerCommand = cli.Command{
 			containerID := context.Args().Get(i)
 			err := RemoveContainer(runtimeClient, containerID)
 			if err != nil {
-				return fmt.Errorf("Removing the container %q failed: %v", containerID, err)
+				fmt.Printf("Removing the container %q failed: %v\n", containerID, err)
 			}
 		}
 		return nil


### PR DESCRIPTION
crictl would stop trying to remove other containers in case of error.

crictl rm 95bfe31395ba 95bf0e31395b
FATA[0000] Removing the container "95bfe31395ba" failed: rpc error: code = Unknown desc = container with ID starting with 95bfe31395ba not found: ID does not exist

Signed-off-by: Nirmoy Das <ndas@suse.de>