### PR TITLE
crictl stats: complain if user is not root

### DIFF
--- a/cmd/crictl/stats.go
+++ b/cmd/crictl/stats.go
@@ -82,6 +82,10 @@ var statsCommand = cli.Command{
 	},
 	Action: func(context *cli.Context) error {
 		var err error
+		if userID := os.Geteuid(); userID != 0 {
+			logrus.Fatalf("You're probably not root, your effective user id is %d", userID)
+			os.Exit(1)
+		}
 		if err = getRuntimeClient(context); err != nil {
 			return err
 		}


### PR DESCRIPTION
$ ./bin/crictl stats
FATA[0000] You're probably not root, your effective user id is 1000

 $ sudo ./bin/crictl stats
CONTAINER           CPU %               MEM                 DISK                INODES
07ac205b107e5       0.00                2.273MB             0B                  0

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>