### PR TITLE
Reduce the default connection timeout value

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	defaultTimeout = 10 * time.Second
+	defaultTimeout = 2 * time.Second
 )
 
 var (


### PR DESCRIPTION
In interactive use, if user doesn't sudo or running as root
then has to wait too long before getting a connection failure.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

@runcom @Random-Liu ptal
cc: @lsm5