### PR TITLE
fix Crictl config cannot set debug to false

### DIFF
--- a/cmd/crictl/config.go
+++ b/cmd/crictl/config.go
@@ -119,9 +119,11 @@ var configCommand = cli.Command{
 			var debug bool
 			if value == "true" {
 				debug = true
+			} else if value == "false" {
+                                debug = false
 			} else {
-				logrus.Fatal("use true|false for debug")
-			}
+                                logrus.Fatal("use true|false for debug")
+                        }
 			config.Debug = debug
 		default:
 			logrus.Fatalf("No section named %s", key)


### PR DESCRIPTION
Issue Description:
When I tested the sub option of crictl config, I found that "crictl config" cannot set debug to false。
Then，I found that “ if” statement is missing the setting for value=“false” in config.go file。

For details, please refer to issue#440
https://github.com/kubernetes-sigs/cri-tools/issues/440