### PR TITLE
Add MacOS to the release platforms

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -22,6 +22,7 @@ set -o pipefail
 
 VERSION=$(git describe --abbrev=0 --tag)
 CRI_CTL_PLATFORMS=(
+    darwin/amd64
     linux/amd64
     linux/386
     linux/arm


### PR DESCRIPTION
Looks like we are missing `darwin/amd64`

Change-Id: I788b4d0c88dc4d9d07de4ac09c90d3a08220ed7c