### PR TITLE
Set SelinuxRelabel to true for bind mounts

### DIFF
--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -425,8 +425,9 @@ func createVolumeContainer(rc internalapi.RuntimeService, ic internalapi.ImageMa
 		// mount host path to the same directory in container, and will check if hostPath isn't empty
 		Mounts: []*runtimeapi.Mount{
 			{
-				HostPath:      hostPath,
-				ContainerPath: hostPath,
+				HostPath:       hostPath,
+				ContainerPath:  hostPath,
+				SelinuxRelabel: true,
 			},
 		},
 	}


### PR DESCRIPTION
The volume mount tests were not setting selinuxRelabel to
true, which was causing the paths mounted in to not have the
correct label. We caught this with the SELinux rework we are
doing in cri-o.

The Selinux rework PR: https://github.com/cri-o/cri-o/pull/2096

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>