### PR TITLE
Improve error message for failed to connect

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -59,7 +59,7 @@ func getRuntimeClientConnection(context *cli.Context) (*grpc.ClientConn, error) 
 
 	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(Timeout), grpc.WithDialer(dialer))
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect: %v", err)
+		return nil, fmt.Errorf("failed to connect, make sure you are running as root and the runtime has been started: %v", err)
 	}
 	return conn, nil
 }
@@ -79,7 +79,7 @@ func getImageClientConnection(context *cli.Context) (*grpc.ClientConn, error) {
 
 	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(Timeout), grpc.WithDialer(dialer))
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect: %v", err)
+		return nil, fmt.Errorf("failed to connect, make sure you are running as root and the runtime has been started: %v", err)
 	}
 	return conn, nil
 }


### PR DESCRIPTION
Add more info to the error message when crictl fails to connect
to the runtime either due to permissions or the runtime not being
started.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>