### PR TITLE
Fix log directory typo in pod config examples.

### DIFF
--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -107,7 +107,7 @@ $ cat pod-config.json
         "attempt": 1,
         "uid": "hdishd83djaidwnduwk28bcsb"
     },
-    "logDirectory": "/tmp",
+    "log_directory": "/tmp",
     "linux": {
     }
 }
@@ -137,7 +137,7 @@ $ cat pod-config.json
         "attempt": 1,
         "uid": "hdishd83djaidwnduwk28bcsb"
     },
-    "logDirectory": "/tmp",
+    "log_directory": "/tmp",
     "linux": {
     }
 }


### PR DESCRIPTION
"log_directory" is the right key instead of "logDirectory". 