### PR TITLE
Add a stress test to test concurrent image pull.

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -69,5 +69,11 @@ func (f *Framework) AfterEach() {
 
 // KubeDescribe is a wrapper on Describe.
 func KubeDescribe(text string, body func()) bool {
+	return FDescribe("[k8s.io] "+text, body)
+}
+
+// KubeOptionalDescribe is a wrapper on Describe.
+// Tests only run when focused should use this.
+func KubeOptionalDescribe(text string, body func()) bool {
 	return Describe("[k8s.io] "+text, body)
 }


### PR DESCRIPTION
The stress test uses 100 different container images, concurrently pull them, run containers and cleanup.

This PR also added "optional" test, which doesn't run unless focused.

/cc @yujuhong @dchen1107 

Signed-off-by: Lantao Liu <lantaol@google.com>