### PR TITLE
Revert "Skip test "image status should support all kinds of references" for docker runtime"

### DIFF
--- a/pkg/validate/image.go
+++ b/pkg/validate/image.go
@@ -33,11 +33,9 @@ var _ = framework.KubeDescribe("Image Manager", func() {
 	f := framework.NewDefaultCRIFramework()
 
 	var c internalapi.ImageManagerService
-	var r internalapi.RuntimeService
 
 	BeforeEach(func() {
 		c = f.CRIClient.CRIImageClient
-		r = f.CRIClient.CRIRuntimeClient
 	})
 
 	It("public image with tag should be pulled and removed [Conformance]", func() {
@@ -60,13 +58,6 @@ var _ = framework.KubeDescribe("Image Manager", func() {
 	})
 
 	It("image status should support all kinds of references [Conformance]", func() {
-		version := getVersion(r)
-		if version.RuntimeName == "docker" {
-			// Refer https://github.com/kubernetes-sigs/cri-tools/issues/473. Dockershim would refuse
-			// the image inspect requests for digest-only references.
-			Skip("docker runtime (dockershim) doesn't support image status from digest-only references")
-		}
-
 		imageName := testImageWithTag
 		// Make sure image does not exist before testing.
 		removeImage(c, imageName)


### PR DESCRIPTION
Reverts kubernetes-sigs/cri-tools#475.

The issue has been fixed in https://github.com/kubernetes/kubernetes/pull/78603.

Fix #473.