### PR TITLE
Switch to multi-arch nonewprivs image.

### DIFF
--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -37,7 +37,7 @@ import (
 const (
 	nginxContainerImage string = "nginx"
 	localhost           string = "localhost/"
-	noNewPrivsImage     string = "gcr.io/google_containers/nonewprivs:1.2"
+	noNewPrivsImage     string = "gcr.io/kubernetes-e2e-test-images/nonewprivs:1.1"
 )
 
 var _ = framework.KubeDescribe("Security Context", func() {


### PR DESCRIPTION
The current image in use "gcr.io/google_containers/nonewprivs:1.2"
"exec format error" on non amd64 archs. Thus running tests on such
arch fails. Lets move to a multi-arch image then.

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>