### PR TITLE
Use arch specific hostnet-nginx image.

### DIFF
--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -186,7 +186,7 @@ const (
 
 	// Linux defaults
 	webServerLinuxImage        = "nginx"
-	hostNetWebServerLinuxImage = "gcr.io/cri-tools/hostnet-nginx"
+	hostNetWebServerLinuxImage = "gcr.io/cri-tools/hostnet-nginx-" + runtime.GOARCH
 
 	// Windows defaults
 	webServerWindowsImage        = "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"


### PR DESCRIPTION
Critest "runtime should support port mapping
with host port and container port" fails on non-amd64
archs as hostnet-ngins image used in the test is
amd64 specific.

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>