### PR TITLE
Make runtime and image client non-global variables

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -48,24 +48,24 @@ var runtimeAttachCommand = cli.Command{
 			return cli.ShowSubcommandHelp(context)
 		}
 
-		if err := getRuntimeClient(context); err != nil {
+		runtimeClient, conn, err := getRuntimeClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, conn)
 
 		var opts = attachOptions{
 			id:    id,
 			tty:   context.Bool("tty"),
 			stdin: context.Bool("stdin"),
 		}
-		err := Attach(runtimeClient, opts)
+		err = Attach(runtimeClient, opts)
 		if err != nil {
 			return fmt.Errorf("attaching running container failed: %v", err)
 
 		}
 		return nil
-
 	},
-	After: closeConnection,
 }
 
 // Attach sends an AttachRequest to server, and parses the returned AttachResponse

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -66,9 +66,11 @@ var runtimeExecCommand = cli.Command{
 			return cli.ShowSubcommandHelp(context)
 		}
 
-		if err := getRuntimeClient(context); err != nil {
+		runtimeClient, conn, err := getRuntimeClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, conn)
 
 		var opts = execOptions{
 			id:      context.Args().First(),
@@ -87,13 +89,12 @@ var runtimeExecCommand = cli.Command{
 			}
 			return nil
 		}
-		err := Exec(runtimeClient, opts)
+		err = Exec(runtimeClient, opts)
 		if err != nil {
 			return fmt.Errorf("execing command in container failed: %v", err)
 		}
 		return nil
 	},
-	After: closeConnection,
 }
 
 // ExecSync sends an ExecSyncRequest to the server, and parses

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -72,9 +72,11 @@ var pullImageCommand = cli.Command{
 			return cli.ShowSubcommandHelp(context)
 		}
 
-		if err := getImageClient(context); err != nil {
+		imageClient, conn, err := getImageClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, conn)
 
 		auth, err := getAuth(context.String("creds"), context.String("auth"))
 		if err != nil {
@@ -126,9 +128,11 @@ var listImageCommand = cli.Command{
 		},
 	},
 	Action: func(context *cli.Context) error {
-		if err := getImageClient(context); err != nil {
+		imageClient, conn, err := getImageClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, conn)
 
 		r, err := ListImages(imageClient, context.Args().First())
 		if err != nil {
@@ -222,9 +226,12 @@ var imageStatusCommand = cli.Command{
 		if context.NArg() == 0 {
 			return cli.ShowSubcommandHelp(context)
 		}
-		if err := getImageClient(context); err != nil {
+		imageClient, conn, err := getImageClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, conn)
+
 		verbose := !(context.Bool("quiet"))
 		output := context.String("output")
 		if output == "" { // default to json output
@@ -284,9 +291,12 @@ var removeImageCommand = cli.Command{
 		if context.NArg() == 0 {
 			return cli.ShowSubcommandHelp(context)
 		}
-		if err := getImageClient(context); err != nil {
+		imageClient, conn, err := getImageClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, conn)
+
 		for i := 0; i < context.NArg(); i++ {
 			id := context.Args().Get(i)
 
@@ -323,9 +333,12 @@ var imageFsInfoCommand = cli.Command{
 		},
 	},
 	Action: func(context *cli.Context) error {
-		if err := getImageClient(context); err != nil {
+		imageClient, conn, err := getImageClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, conn)
+
 		output := context.String("output")
 		if output == "" { // default to json output
 			output = "json"

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -43,14 +43,18 @@ var runtimeStatusCommand = cli.Command{
 		},
 	},
 	Action: func(context *cli.Context) error {
-		err := Info(context, runtimeClient)
+		runtimeClient, runtimeConn, err := getRuntimeClient(context)
+		if err != nil {
+			return err
+		}
+		defer closeConnection(context, runtimeConn)
+
+		err = Info(context, runtimeClient)
 		if err != nil {
 			return fmt.Errorf("getting status of runtime failed: %v", err)
 		}
 		return nil
 	},
-	Before: getRuntimeClient,
-	After:  closeConnection,
 }
 
 // Info sends a StatusRequest to the server, and parses the returned StatusResponse.

--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -94,7 +94,6 @@ var logsCommand = cli.Command{
 		}
 		return logs.ReadLogs(context.Background(), logPath, status.GetId(), logOptions, runtimeService, os.Stdout, os.Stderr)
 	},
-	After: closeConnection,
 }
 
 // parseTimestamp parses timestamp string as golang duration,

--- a/cmd/crictl/portforward.go
+++ b/cmd/crictl/portforward.go
@@ -42,15 +42,17 @@ var runtimePortForwardCommand = cli.Command{
 			return cli.ShowSubcommandHelp(context)
 		}
 
-		if err := getRuntimeClient(context); err != nil {
+		runtimeClient, runtimeConn, err := getRuntimeClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, runtimeConn)
 
 		var opts = portforwardOptions{
 			id:    args[0],
 			ports: args[1:],
 		}
-		err := PortForward(runtimeClient, opts)
+		err = PortForward(runtimeClient, opts)
 		if err != nil {
 			return fmt.Errorf("port forward failed: %v", err)
 
@@ -58,7 +60,6 @@ var runtimePortForwardCommand = cli.Command{
 		return nil
 
 	},
-	After: closeConnection,
 }
 
 // PortForward sends an PortForwardRequest to server, and parses the returned PortForwardResponse

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -57,9 +57,11 @@ var runPodCommand = cli.Command{
 			return cli.ShowSubcommandHelp(context)
 		}
 
-		if err := getRuntimeClient(context); err != nil {
+		runtimeClient, runtimeConn, err := getRuntimeClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, runtimeConn)
 
 		podSandboxConfig, err := loadPodSandboxConfig(sandboxSpec)
 		if err != nil {
@@ -84,9 +86,11 @@ var stopPodCommand = cli.Command{
 		if context.NArg() == 0 {
 			return cli.ShowSubcommandHelp(context)
 		}
-		if err := getRuntimeClient(context); err != nil {
+		runtimeClient, runtimeConn, err := getRuntimeClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, runtimeConn)
 		for i := 0; i < context.NArg(); i++ {
 			id := context.Args().Get(i)
 			err := StopPodSandbox(runtimeClient, id)
@@ -112,9 +116,11 @@ var removePodCommand = cli.Command{
 		if ctx.NArg() == 0 {
 			return cli.ShowSubcommandHelp(ctx)
 		}
-		if err := getRuntimeClient(ctx); err != nil {
+		runtimeClient, runtimeConn, err := getRuntimeClient(ctx)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(ctx, runtimeConn)
 		for i := 0; i < ctx.NArg(); i++ {
 			id := ctx.Args().Get(i)
 
@@ -162,9 +168,11 @@ var podStatusCommand = cli.Command{
 		if context.NArg() == 0 {
 			return cli.ShowSubcommandHelp(context)
 		}
-		if err := getRuntimeClient(context); err != nil {
+		runtimeClient, runtimeConn, err := getRuntimeClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, runtimeConn)
 		for i := 0; i < context.NArg(); i++ {
 			id := context.Args().Get(i)
 
@@ -234,9 +242,11 @@ var listPodCommand = cli.Command{
 	},
 	Action: func(context *cli.Context) error {
 		var err error
-		if err = getRuntimeClient(context); err != nil {
+		runtimeClient, runtimeConn, err := getRuntimeClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, runtimeConn)
 
 		opts := listOptions{
 			id:                 context.String("id"),

--- a/cmd/crictl/stats.go
+++ b/cmd/crictl/stats.go
@@ -84,10 +84,11 @@ var statsCommand = cli.Command{
 		},
 	},
 	Action: func(context *cli.Context) error {
-		var err error
-		if err = getRuntimeClient(context); err != nil {
+		runtimeClient, runtimeConn, err := getRuntimeClient(context)
+		if err != nil {
 			return err
 		}
+		defer closeConnection(context, runtimeConn)
 
 		opts := statsOptions{
 			all:    context.Bool("all"),

--- a/cmd/crictl/version.go
+++ b/cmd/crictl/version.go
@@ -33,14 +33,17 @@ var runtimeVersionCommand = cli.Command{
 	Name:  "version",
 	Usage: "Display runtime version information",
 	Action: func(context *cli.Context) error {
-		err := Version(runtimeClient, criClientVersion)
+		runtimeClient, runtimeConn, err := getRuntimeClient(context)
+		if err != nil {
+			return err
+		}
+		defer closeConnection(context, runtimeConn)
+		err = Version(runtimeClient, criClientVersion)
 		if err != nil {
 			return fmt.Errorf("getting the runtime version failed: %v", err)
 		}
 		return nil
 	},
-	Before: getRuntimeClient,
-	After:  closeConnection,
 }
 
 // Version sends a VersionRequest to the server, and parses the returned VersionResponse.


### PR DESCRIPTION
This commits removed the three global variables:

```
var runtimeClient pb.RuntimeServiceClient
var imageClient pb.ImageServiceClient
var conn *grpc.ClientConn
```

and scopes them to their actual used functions. This avoids usage of the
variables if they are uninitialized and provides a more clear control
flow.

All related functions have been adapted to work with the new functions.