### PR TITLE
Use a dedicated image for all reference test.

### DIFF
--- a/hack/make-rules/Makefile.manifest
+++ b/hack/make-rules/Makefile.manifest
@@ -18,6 +18,9 @@ MANIFEST_TOOL_DIR := $(shell mktemp -d)
 export PATH := $(MANIFEST_TOOL_DIR):$(PATH)
 
 MANIFEST_TOOL_VERSION := v0.7.0
+USERNAME ?= oauth2accesstoken
+PASSWORD ?= $(shell gcloud auth print-access-token)
+MANIFEST_TOOL = manifest-tool --username=$(USERNAME) --password=$(PASSWORD)
 
 space :=
 space +=

--- a/images/hostnet-nginx/Makefile
+++ b/images/hostnet-nginx/Makefile
@@ -31,4 +31,4 @@ hostnet-nginx:
 	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
 
 push-manifest: manifest-tool
-	$(foreach image,$(IMAGES_LIST),manifest-tool push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
+	$(foreach image,$(IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)

--- a/images/image-test-win/build.ps1
+++ b/images/image-test-win/build.ps1
@@ -17,7 +17,8 @@ $Tag = "latest"
 $ImagesList = @(
 	"win-test-image-1:$Tag", "win-test-image-2:$Tag", "win-test-image-3:$Tag",
 	"win-test-image-latest:$Tag", "win-test-image-digest:$Tag",
-	"win-test-image-tags:1", "win-test-image-tags:2", "win-test-image-tags:3","win-test-image-tag:test")
+	"win-test-image-tags:1", "win-test-image-tags:2", "win-test-image-tags:3",
+	"win-test-image-tag:test", "win-test-image-tag:all")
 
 Foreach ($image in $ImagesList) {
 	$imageName = $image.Substring(0, $image.IndexOf(":"))

--- a/images/image-test/Makefile
+++ b/images/image-test/Makefile
@@ -15,36 +15,28 @@
 include ../../hack/make-rules/Makefile.manifest
 include ../../hack/make-rules/BASEIMAGES
 
-.PHONY: all-push all-push-images test-image-tags test-image-tag push-manifest
+.PHONY: all-push all-push-images push-manifest
 
 REGISTRY ?= gcr.io/cri-tools
 TAG = latest
 ALL_ARCH = amd64 arm64 ppc64le s390x
 IMAGES_LIST = test-image-1 test-image-2 test-image-3 test-image-latest test-image-digest
+IMAGE_TAGS_LIST = test all
+SAME_IMAGE_TAGS_LIST = 1 2 3
 
-all-push: all-push-images test-image-tags test-image-tag push-manifest
+all-push: all-push-images push-manifest
 
 all-push-images: $(addprefix sub-push-,$(ALL_ARCH))
 
 sub-push-%:
 	$(foreach name,$(IMAGES_LIST),touch $(name) && docker build . -t $(REGISTRY)/$(name)-$*:$(TAG) --build-arg TEST=$(name) --build-arg ARCH=$($*) && rm -f $(name);)
 	$(foreach name,$(IMAGES_LIST),docker push $(REGISTRY)/$(name)-$*:$(TAG);)
-
-test-image-tags:
-	$(foreach arch,$(ALL_ARCH),touch $@ && docker build . -t $(REGISTRY)/$@-$(arch):1 --build-arg TEST=$@ --build-arg ARCH=$($(arch)) && rm -f $@;)
-	$(foreach arch,$(ALL_ARCH),docker tag $(REGISTRY)/$@-$(arch):1 $(REGISTRY)/$@-$(arch):2;)
-	$(foreach arch,$(ALL_ARCH),docker tag $(REGISTRY)/$@-$(arch):1 $(REGISTRY)/$@-$(arch):3;)
-	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch):1;)
-	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch):2;)
-	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch):3;)
-
-test-image-tag:
-	$(foreach arch,$(ALL_ARCH),touch $@ && docker build . -t $(REGISTRY)/$@-$(arch):test --build-arg TEST=$@ --build-arg ARCH=$($(arch)) && rm -f $@;)
-	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch):test;)
+	$(foreach tag,$(IMAGE_TAGS_LIST),touch $(tag) && docker build . -t $(REGISTRY)/test-image-tag-$*:$(tag) --build-arg TEST=$(tag) --build-arg ARCH=$($*) && rm -f $(tag);)
+	$(foreach tag,$(IMAGE_TAGS_LIST),docker push $(REGISTRY)/test-image-tag-$*:$(tag);)
+	$(foreach tag,$(SAME_IMAGE_TAGS_LIST),touch same-image && docker build . -t $(REGISTRY)/test-image-tags-$*:$(tag) --build-arg TEST=same-image --build-arg ARCH=$($*) && rm -f same-image;)
+	$(foreach tag,$(SAME_IMAGE_TAGS_LIST),docker push $(REGISTRY)/test-image-tag-$*:$(tag);)
 
 push-manifest: manifest-tool
-	$(foreach image,$(IMAGES_LIST),manifest-tool push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
-	$(foreach arch,$(ALL_ARCH),manifest-tool push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/test-image-tags-ARCH:1 --target $(REGISTRY)/test-image-tags:1;)
-	$(foreach arch,$(ALL_ARCH),manifest-tool push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/test-image-tags-ARCH:2 --target $(REGISTRY)/test-image-tags:2;)
-	$(foreach arch,$(ALL_ARCH),manifest-tool push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/test-image-tags-ARCH:3 --target $(REGISTRY)/test-image-tags:3;)
-	$(foreach arch,$(ALL_ARCH),manifest-tool push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/test-image-tag-ARCH:test --target $(REGISTRY)/test-image-tag:test;)
+	$(foreach image,$(IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
+	$(foreach tag,$(IMAGE_TAGS_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/test-image-tag-ARCH:$(tag) --target $(REGISTRY)/test-image-tag:$(tag);)
+	$(foreach tag,$(SAME_IMAGE_TAGS_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/test-image-tag-ARCH:$(tag) --target $(REGISTRY)/test-image-tag:$(tag);)

--- a/images/image-user/Makefile
+++ b/images/image-user/Makefile
@@ -42,4 +42,4 @@ test-image-user-username-group:
 	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
 
 push-manifest: manifest-tool
-	$(foreach image,$(IMAGES_LIST),manifest-tool push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
+	$(foreach image,$(IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)

--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -96,14 +96,16 @@ const (
 	imageUserUsernameGroup     = "www-data"
 
 	// Linux defaults
-	testLinuxImageWithoutTag = "gcr.io/cri-tools/test-image-latest"
-	testLinuxImageWithTag    = "gcr.io/cri-tools/test-image-tag:test"
-	testLinuxImageWithDigest = "gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343"
+	testLinuxImageWithoutTag        = "gcr.io/cri-tools/test-image-latest"
+	testLinuxImageWithTag           = "gcr.io/cri-tools/test-image-tag:test"
+	testLinuxImageWithDigest        = "gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343"
+	testLinuxImageWithAllReferences = "gcr.io/cri-tools/test-image-tag:all"
 
 	// Windows defaults
-	testWindowsImageWithoutTag = "gcr.io/cri-tools/win-test-image-latest"
-	testWindowsImageWithTag    = "gcr.io/cri-tools/win-test-image-tag:test"
-	testWindowsImageWithDigest = "gcr.io/cri-tools/win-test-image-digest@sha256:05c5e07eab041551e466d6e33a0a5649a23a929cd236391b2835ec79dc245090"
+	testWindowsImageWithoutTag        = "gcr.io/cri-tools/win-test-image-latest"
+	testWindowsImageWithTag           = "gcr.io/cri-tools/win-test-image-tag:test"
+	testWindowsImageWithDigest        = "gcr.io/cri-tools/win-test-image-digest@sha256:05c5e07eab041551e466d6e33a0a5649a23a929cd236391b2835ec79dc245090"
+	testWindowsImageWithAllReferences = "gcr.io/cri-tools/win-test-image-tag:all"
 )
 
 var (
@@ -115,6 +117,9 @@ var (
 
 	// digested reference for test image
 	testImageWithDigest string
+
+	// image used to test all kinds of references.
+	testImageWithAllReferences string
 
 	// image list where different tags refer to different images
 	testDifferentTagDifferentImageList []string
@@ -155,12 +160,14 @@ var _ = framework.AddBeforeSuiteCallback(func() {
 		testImageWithoutTag = testLinuxImageWithoutTag
 		testImageWithTag = testLinuxImageWithTag
 		testImageWithDigest = testLinuxImageWithDigest
+		testImageWithAllReferences = testLinuxImageWithAllReferences
 		testDifferentTagDifferentImageList = testLinuxDifferentTagDifferentImageList
 		testDifferentTagSameImageList = testLinuxDifferentTagSameImageList
 	} else {
 		testImageWithoutTag = testWindowsImageWithoutTag
 		testImageWithTag = testWindowsImageWithTag
 		testImageWithDigest = testWindowsImageWithDigest
+		testImageWithAllReferences = testWindowsImageWithAllReferences
 		testDifferentTagDifferentImageList = testWindowsDifferentTagDifferentImageList
 		testDifferentTagSameImageList = testWindowsDifferentTagSameImageList
 	}

--- a/pkg/validate/image.go
+++ b/pkg/validate/image.go
@@ -58,7 +58,7 @@ var _ = framework.KubeDescribe("Image Manager", func() {
 	})
 
 	It("image status should support all kinds of references [Conformance]", func() {
-		imageName := testImageWithTag
+		imageName := testImageWithAllReferences
 		// Make sure image does not exist before testing.
 		removeImage(c, imageName)
 
@@ -78,7 +78,6 @@ var _ = framework.KubeDescribe("Image Manager", func() {
 		}
 
 		testRemoveImage(c, imageName)
-
 	})
 
 	if runtime.GOOS != "windows" || framework.TestContext.IsLcow {


### PR DESCRIPTION
Both image tag test and all image reference test are using the same image. It will cause issue when running CRI validation test in parallel.

This PR:
1) Add a new image `test-image-tag:all` and use it in the all reference image test;
2) Simplify the image build code;
3) Add `username` and `password` for manifest-tool;

@feiskyer Do you have a windows environment to build the windows image? Thanks!

Signed-off-by: Lantao Liu <lantaol@google.com>