### PR TITLE
Enable deadcode, goimports, misspell and prealloc linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,16 +5,19 @@ run:
 linters:
   disable-all: true
   enable:
+    - deadcode
     - depguard
     - gofmt
+    - goimports
     - govet
     - ineffassign
+    - misspell
     - nakedret
+    - prealloc
     - structcheck
     - typecheck
     - varcheck
     # - bodyclose
-    # - deadcode
     # - dupl
     # - errcheck
     # - gochecknoglobals
@@ -22,15 +25,12 @@ linters:
     # - goconst
     # - gocritic
     # - gocyclo
-    # - goimports
     # - golint
     # - gosec
     # - gosimple
     # - interfacer
     # - lll
     # - maligned
-    # - misspell
-    # - prealloc
     # - scopelint
     # - staticcheck
     # - stylecheck

--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -24,7 +24,7 @@ import (
 
 	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/urfave/cli"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime/logs"
 )

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -100,7 +100,7 @@ type portforwardOptions struct {
 }
 
 func getSortedKeys(m map[string]string) []string {
-	var keys []string
+	keys := make([]string, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
@@ -210,7 +210,7 @@ func outputProtobufObjAsYAML(obj proto.Message) error {
 
 func outputStatusInfo(status string, info map[string]string, format string) error {
 	// Sort all keys
-	var keys []string
+	keys := make([]string, len(info))
 	for k := range info {
 		keys = append(keys, k)
 	}

--- a/pkg/benchmark/image.go
+++ b/pkg/benchmark/image.go
@@ -17,10 +17,11 @@ limitations under the License.
 package benchmark
 
 import (
+	"runtime"
+
 	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
-	"runtime"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/apparmor.go
+++ b/pkg/validate/apparmor.go
@@ -82,7 +82,7 @@ var _ = framework.KubeDescribe("AppArmor", func() {
 			})
 
 			It("should fail with with an unloaded profile", func() {
-				profile := apparmorProfileNamePrefix + "non-existant-profile"
+				profile := apparmorProfileNamePrefix + "non-existent-profile"
 				containerID := createContainerWithAppArmor(rc, ic, sandboxID, sandboxConfig, profile, false)
 				checkContainerApparmor(rc, containerID, false)
 			})

--- a/pkg/validate/image.go
+++ b/pkg/validate/image.go
@@ -198,7 +198,7 @@ func testPullPublicImage(c internalapi.ImageManagerService, imageName string, po
 
 // pullImageList pulls the images listed in the imageList.
 func pullImageList(c internalapi.ImageManagerService, imageList []string, podConfig *runtimeapi.PodSandboxConfig) []string {
-	var ids []string
+	ids := []string{}
 	for _, imageName := range imageList {
 		ids = append(ids, framework.PullPublicImage(c, imageName, podConfig))
 	}


### PR DESCRIPTION
This enables the linters and fixes the corresponding reports.