### PR TITLE
Treat first `crictl stats` argument as filter ID

### DIFF
--- a/cmd/crictl/stats.go
+++ b/cmd/crictl/stats.go
@@ -50,6 +50,7 @@ var statsCommand = cli.Command{
 	Usage:                  "List container(s) resource usage statistics",
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
+	ArgsUsage:              "[ID]",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "all, a",
@@ -90,9 +91,14 @@ var statsCommand = cli.Command{
 		}
 		defer closeConnection(context, runtimeConn)
 
+		id := context.String("id")
+		if id == "" && context.Args() != nil {
+			id = context.Args()[0]
+		}
+
 		opts := statsOptions{
 			all:    context.Bool("all"),
-			id:     context.String("id"),
+			id:     id,
 			podID:  context.String("pod"),
 			sample: time.Duration(context.Int("seconds")) * time.Second,
 			output: context.String("output"),


### PR DESCRIPTION
The first argument supplied to `crictl stats` can be taken as the filter
ID of the container, whereas `--id` gets precedence.
