### PR TITLE
Disable ppc64le test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,14 +57,6 @@ jobs:
         - cp build/bin/ginkgo $GOPATH/bin
         - sudo env PATH=$PATH GOPATH=$GOPATH hack/run-critest.sh
     - stage: Test
-      os: linux-ppc64le
-      script:
-        - make
-        - travis_wait hack/install-docker.sh
-        - travis_wait hack/install-kubelet.sh
-        - cp build/bin/ginkgo $GOPATH/bin
-        - sudo env PATH=$PATH GOPATH=$GOPATH hack/run-critest.sh
-    - stage: Test
       os: windows
       script:
         - make windows


### PR DESCRIPTION
For https://github.com/kubernetes-sigs/cri-tools/issues/514.

Let's disable the test for now. @nitkon Can you fix the test? So that we can enable the test again.

Signed-off-by: Lantao Liu <lantaol@google.com>