### PR TITLE
Create directory for config file.

### DIFF
--- a/cmd/crictl/config.go
+++ b/cmd/crictl/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	gofilepath "path/filepath"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -54,6 +55,9 @@ func ReadConfig(filepath string) (*Config, error) {
 func writeConfig(c *Config, filepath string) error {
 	data, err := yaml.Marshal(c)
 	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(gofilepath.Dir(filepath), 0755); err != nil {
 		return err
 	}
 	return ioutil.WriteFile(filepath, data, 0644)


### PR DESCRIPTION
Create config directory if it does not exists.

This is useful especially on windows, where default config is in `C:\\Users\\lantaol\\.crictl\\crictl.yaml`
Signed-off-by: Lantao Liu <lantaol@google.com>