### PR TITLE
The check should not have 1s timeout.

### DIFF
--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -141,7 +141,8 @@ var _ = framework.KubeDescribe("Container", func() {
 			Expect(err).Should(HaveOccurred(), "execSync should timeout")
 
 			By("timeout exec process should be gone")
-			stdout, stderr, err := rc.ExecSync(containerID, checkSleepCmd, time.Second)
+			stdout, stderr, err := rc.ExecSync(containerID, checkSleepCmd,
+				time.Duration(defaultExecSyncTimeout)*time.Second)
 			framework.ExpectNoError(err)
 			Expect(stderr).To(BeEmpty())
 			Expect(strings.TrimSpace(string(stdout))).To(BeEmpty())


### PR DESCRIPTION
We should not set the 1 second timeout on the check exec, it may timeout.

This is especially important on windows, because the exec is slower. :)

/cc @yujuhong @feiskyer 
Signed-off-by: Lantao Liu <lantaol@google.com>