### PR TITLE
Fix CRI test on windows.

### DIFF
--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -50,7 +50,7 @@ var (
 	// Windows defaults
 	echoHelloWindowsCmd      = []string{"powershell", "-c", "echo hello"}
 	sleepWindowsCmd          = []string{"powershell", "-c", "sleep", "4321"}
-	checkSleepWindowsCmd     = []string{"powershell", "-c", "tasklist powershell | findstr sleep"}
+	checkSleepWindowsCmd     = []string{"powershell", "-c", "tasklist | findstr sleep; exit 0"}
 	shellWindowsCmd          = []string{"cmd", "/Q"}
 	pauseWindowsCmd          = []string{"powershell", "-c", "ping -t localhost"}
 	logDefaultWindowsCmd     = []string{"powershell", "-c", "echo '" + defaultLog + "'"}


### PR DESCRIPTION
This PR:
1) Use `ioutil.TempDir` instead of `/tmp`;
2) Fix sleep command on windows, and add `exit 0` to avoid `findstr` returning non-zero exit code.

Signed-off-by: Lantao Liu <lantaol@google.com>