### PR TITLE
Simplify Makefile.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,14 +52,15 @@ jobs:
       os: linux
       script:
         - make
+        - sudo make install
         - travis_wait hack/install-docker.sh
         - travis_wait hack/install-kubelet.sh
-        - cp build/bin/ginkgo $GOPATH/bin
-        - sudo env PATH=$PATH GOPATH=$GOPATH hack/run-critest.sh
+        - sudo cp build/bin/ginkgo /usr/local/bin
+        - sudo env PATH=$PATH hack/run-critest.sh
     - stage: Test
       os: windows
       script:
-        - make windows
+        - make
         - powershell -c "Set-ExecutionPolicy Bypass -Scope CURRENTUSER -Force"
         - travis_wait powershell hack/install-kubelet.ps1
         # Skip hack/run-critest.sh temporarily.


### PR DESCRIPTION
The old way of building binaries into `$GOPATH/bin` is really confusing.
1) You can not `make clean` the binary you built;
2) You don't know where to find the built binaries if you don't know it builds to $GOPATH;
3) The behavior on windows is different from linux, because on windows it builds to `_output`;
4) The building to GOPATH logic doesn't work on windows, because the Makefile tries to get the first GOPATH split by `:`, while for windows path `C:\` `C` becomes a GOPATH;
5) ......

Let's just simplify this and always build the binaries into `_output`. Now we can easily build and cleanup binaries:
```console
$ make

$ ls _output/
crictl critest

$ GOOS=windows make

$ ls _output/
crictl crictl.exe critest critest.exe

$ make clean

$ ls _output/
```
Signed-off-by: Lantao Liu <lantaol@google.com>