### PR TITLE
Add `crictl info` e2e tests

### DIFF
--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega/gexec"
+)
+
+// The actual test suite
+var _ = t.Describe("info", func() {
+
+	var (
+		endpoint, testDir string
+		crio              *Session
+	)
+	BeforeEach(func() {
+		endpoint, testDir, crio = t.StartCrio()
+	})
+
+	AfterEach(func() {
+		t.StopCrio(testDir, crio)
+	})
+
+	It("should succeed", func() {
+		t.CrictlExpectSuccessWithEndpoint(endpoint, "info", "NetworkReady")
+	})
+
+	It("should fail with additional argument", func() {
+		t.CrictlExpectFailure("--invalid", "", "flag provided but not defined")
+	})
+})

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -147,14 +147,15 @@ func (t *TestFramework) StartCrio() (string, string, *Session) {
 	lcmd("cp %s %s", filepath.Join(t.crioDir, "test", "policy.json"),
 		tmpDir).Wait()
 
-	lcmd("cp %s %s", filepath.Join(t.crioDir, "contrib", "cni",
-		"10-crio-bridge.conf"), tmpDir).Wait()
-
 	for _, d := range []string{
 		"cni-config", "root", "runroot", "log", "exits", "attach",
 	} {
 		Expect(os.MkdirAll(filepath.Join(tmpDir, d), 0755)).To(BeNil())
 	}
+
+	lcmd("cp %s %s", filepath.Join(t.crioDir, "contrib", "cni",
+		"10-crio-bridge.conf"),
+		filepath.Join(tmpDir, "cni-config")).Wait()
 
 	endpoint := filepath.Join(tmpDir, "crio.sock")
 

--- a/vendor/github.com/onsi/gomega/gbytes/say_matcher.go
+++ b/vendor/github.com/onsi/gomega/gbytes/say_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 1
+
 package gbytes
 
 import (
@@ -19,7 +21,7 @@ Say is a Gomega matcher that operates on gbytes.Buffers:
 
 will succeed if the unread portion of the buffer matches the regular expression "something".
 
-When Say succeeds, it fast forwards the gbytes.Buffer's read cursor to just after the succesful match.
+When Say succeeds, it fast forwards the gbytes.Buffer's read cursor to just after the successful match.
 Thus, subsequent calls to Say will only match against the unread portion of the buffer
 
 Say pairs very well with Eventually.  To assert that a buffer eventually receives data matching "[123]-star" within 3 seconds you can:

--- a/vendor/github.com/onsi/gomega/gexec/build.go
+++ b/vendor/github.com/onsi/gomega/gexec/build.go
@@ -1,3 +1,5 @@
+// untested sections: 5
+
 package gexec
 
 import (
@@ -66,7 +68,7 @@ func doBuild(gopath, packagePath string, env []string, args ...string) (compiled
 
 	executable := filepath.Join(tmpDir, path.Base(packagePath))
 	if runtime.GOOS == "windows" {
-		executable = executable + ".exe"
+		executable += ".exe"
 	}
 
 	cmdArgs := append([]string{"build"}, args...)

--- a/vendor/github.com/onsi/gomega/gexec/exit_matcher.go
+++ b/vendor/github.com/onsi/gomega/gexec/exit_matcher.go
@@ -1,3 +1,5 @@
+// untested sections: 2
+
 package gexec
 
 import (

--- a/vendor/github.com/onsi/gomega/gexec/prefixed_writer.go
+++ b/vendor/github.com/onsi/gomega/gexec/prefixed_writer.go
@@ -1,3 +1,5 @@
+// untested sections: 1
+
 package gexec
 
 import (
@@ -6,7 +8,7 @@ import (
 )
 
 /*
-PrefixedWriter wraps an io.Writer, emiting the passed in prefix at the beginning of each new line.
+PrefixedWriter wraps an io.Writer, emitting the passed in prefix at the beginning of each new line.
 This can be useful when running multiple gexec.Sessions concurrently - you can prefix the log output of each
 session by passing in a PrefixedWriter:
 

--- a/vendor/github.com/onsi/gomega/gexec/session.go
+++ b/vendor/github.com/onsi/gomega/gexec/session.go
@@ -1,6 +1,9 @@
 /*
 Package gexec provides support for testing external processes.
 */
+
+// untested sections: 1
+
 package gexec
 
 import (


### PR DESCRIPTION
I also fixed the cni-config directory to make the network actually work. The `info` tests now validates this.