### PR TITLE
Fix e2e tests by cloning conmon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,6 @@ jobs:
       name: crictl e2e
       os: linux
       script:
-        # TODO: Re-enable the test when it is fixed.
-        - exit 0
         - |
           sudo apt-get update &&\
           sudo apt-get install -y libseccomp-dev


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/cri-tools/issues/539 by adding an additional conmon clone step.