### PR TITLE
Pass pod config when pulling image during create

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -574,7 +574,7 @@ func CreateContainer(
 
 		// Try to pull the image before container creation
 		image := config.GetImage().GetImage()
-		if _, err := PullImage(iClient, image, auth); err != nil {
+		if _, err := PullImageWithSandbox(iClient, image, auth, podConfig); err != nil {
 			return "", err
 		}
 	}

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -478,12 +478,6 @@ func normalizeRepoDigest(repoDigests []string) (string, string) {
 	return repoDigestPair[0], repoDigestPair[1]
 }
 
-// PullImage sends a PullImageRequest to the server, and parses
-// the returned PullImageResponse.
-func PullImage(client pb.ImageServiceClient, image string, auth *pb.AuthConfig) (resp *pb.PullImageResponse, err error) {
-	return PullImageWithSandbox(client, image, auth, nil)
-}
-
 // PullImageWithSandbox sends a PullImageRequest to the server, and parses
 // the returned PullImageResponse.
 func PullImageWithSandbox(client pb.ImageServiceClient, image string, auth *pb.AuthConfig, sandbox *pb.PodSandboxConfig) (resp *pb.PullImageResponse, err error) {


### PR DESCRIPTION
Signed-off-by: Kevin Parsons <kevpar@microsoft.com>

The change to pull image as part of container create broke LCOW (Linux Containers on Windows), as it depends on knowing the pod config at pull time to select the correct snapshotter. We already have the pull config available in this function, so this change just passes it through to the pull operation.