### PR TITLE
Fix crash when using stats command

### DIFF
--- a/cmd/crictl/stats.go
+++ b/cmd/crictl/stats.go
@@ -92,7 +92,7 @@ var statsCommand = cli.Command{
 		defer closeConnection(context, runtimeConn)
 
 		id := context.String("id")
-		if id == "" && context.Args() != nil {
+		if id == "" && context.NArg() > 0 {
 			id = context.Args()[0]
 		}
 


### PR DESCRIPTION
Previously the stats command checked if the args slice was not nil, and
then tried to access the first element. We should instead be checking if
the slice has length > 0, as an empty slice passes the original check.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>