### PR TITLE
Fix e2e tests by pinning CRI-O and conmon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,6 @@ jobs:
       name: crictl e2e
       os: linux
       script:
-        # TODO: Re-enable the test when it is fixed.
-        - exit 0
         - |
           sudo apt-get update &&\
           sudo apt-get install -y libseccomp-dev


### PR DESCRIPTION
Closes #539 by adding an additional conmon clone step.

We have to use a newer version of CRI-O than 1.15.2, because the gRPC changes between crictl (master) and CRI-O (1.15.x) make them incompatible right now.

I'd suggest to pin CRI-O to the latest commit of the `release-1.16` branch for now and change it to `1.16.0` once it's released.

Supersedes: https://github.com/kubernetes-sigs/cri-tools/pull/540