### PR TITLE
Add darwin to releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,10 @@ jobs:
       script:
         -  make release
     - stage: Build
+      os: osx
+      script:
+        -  make release
+    - stage: Build
       os: linux-ppc64le
       script:
         -  make release

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -32,6 +32,8 @@ CRI_CTL_PLATFORMS=(
     linux/s390x
     windows/amd64
     windows/386
+    darwin/amd64
+    darwin/386
 )
 CRI_TEST_PLATFORMS=(
     linux/amd64
@@ -40,6 +42,8 @@ CRI_TEST_PLATFORMS=(
     linux/arm64
     windows/amd64
     windows/386
+    darwin/amd64
+    darwin/386
 )
 
 # Create releases output directory.


### PR DESCRIPTION
This PR adds precompiled binaries for `darwin` to the release.

I tested the darwin support locally with my Mac:

```bash
$ uname -a
DarwinMacBook-Pro.local 19.4.0 Darwin Kernel Version 19.4.0: Wed Mar  4 22:28:40 PST 2020; root:xnu-6153.101.6~15/RELEASE_X86_64 x86_64 i386 MacBookPro15,2 Darwin
```

and (nearly) everything worked:

```bash
$ make all
CGO_ENABLED=0 GO111MODULE=on go test -mod=vendor -c -o /Users/jscheuermann/go/src/github.com/kubernetes-sigs/cri-tools/_output/critest \
                -ldflags '-X github.com/kubernetes-sigs/cri-tools/pkg/version.Version=1.18.0-6-g719b9ad' \
                -tags 'selinux' \
             github.com/kubernetes-sigs/cri-tools/cmd/critest
CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o /Users/jscheuermann/go/src/github.com/kubernetes-sigs/cri-tools/_output/crictl \
                -ldflags '-X github.com/kubernetes-sigs/cri-tools/pkg/version.Version=1.18.0-6-g719b9ad' \
                -tags 'selinux' \
                github.com/kubernetes-sigs/cri-tools/cmd/crictl
$ make install
install -D -m 755 /Users/jscheuermann/go/src/github.com/kubernetes-sigs/cri-tools/_output/critest /usr/local/bin/critest
install -D -m 755 /Users/jscheuermann/go/src/github.com/kubernetes-sigs/cri-tools/_output/crictl /u
sr/local/bin/crictl
# Setup the unix socket to the remote Linux machines
$ sudo ssh -L /var/run/dockershim.sock:/var/run/dockershim.sock dev-box
$ sudo crictl ps
CONTAINER           IMAGE                                                                                             CREATED             STATE               NAME                      ATTEMPT             POD ID
2d2932ba8b376       5dd8f24429b48                                                                                     About an hour ago   Running             kube-controller-manager   2                   73c30628d302e
a2e4e820fe120       8d2e2e5a92ace                                                                                     About an hour ago   Running             kube-scheduler            2                   8b7430f7450d1
3c0af35ed62ca       628f0e52ae53b                                                                                     About an hour ago   Running             kube-apiserver            0                   4c4d3baeb845e
ed250727561f7       calico/kube-controllers@sha256:0fa9d599e2147a5ee6d951c7f18f59144a6459c2346864a4b31c6ab38668a393   47 hours ago        Running             calico-kube-controllers   0                   2358f406d3e55
929e2a9efa221       70f311871ae12                                                                                     47 hours ago        Running             coredns                   0                   f3fc8e8463397
438b303754b43       70f311871ae12                                                                                     47 hours ago        Running             coredns                   0                   0c5bdc574d8af
e79655b1e7589       calico/node@sha256:9519301b28c79741d3c753b23ae1a71c970789ed77c40ea3fa767693591aea98               47 hours ago        Running             calico-node               0                   e62cf4d069a83
ecd6758c00f66       87a399dffea64                                                                                     47 hours ago        Running             kube-proxy                0                   132ee961678a0
0771860f6ac23       303ce5db0e90d                                                                                     47 hours ago        Running             etcd                      0                   e20a8c3c544ca
```

The only thing that didn't work was `crictl exec` with the following error:

```bash
FATA[0000] execing command in container failed: error sending request: Post "http://127.0.0.1:38865/exec/9K-dNcok": dial tcp 127.0.0.1:38865: connect: connection refused
```

But this error is expected since I didn't add `-L 127.0.0.1:38865:127.0.0.1:38865` to the ssh command.

Fixes: #573 