### PR TITLE
critest: use os.Executable instead of exec.LookPath

### DIFF
--- a/cmd/critest/cri_test.go
+++ b/cmd/critest/cri_test.go
@@ -89,10 +89,11 @@ func generateTempTestName() (string, error) {
 }
 
 func runParallelTestSuite(t *testing.T) {
-	criPath, err := exec.LookPath("critest")
+	criPath, err := os.Executable()
 	if err != nil {
 		t.Fatalf("Failed to lookup path of critest: %v", err)
 	}
+	t.Logf("critest path: %s", criPath)
 
 	tempFileName, err := generateTempTestName()
 	if err != nil {


### PR DESCRIPTION
exec.LookPath depends on caller's PATH settings. Sometimes, there are
several versions in PATH and it is hard to debug. It is good to use
current critest binary path by os.Executable to make sure that
ginkgo uses the same binary.

Signed-off-by: Wei Fu <fuweid89@gmail.com>