### PR TITLE
Enable critest to use CRI server configuration file

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ServerConfiguration is the config for connecting to a CRI server
+type ServerConfiguration struct {
+	// RuntimeEndpoint is CRI server runtime endpoint
+	RuntimeEndpoint string
+	// ImageEndpoint is CRI server image endpoint
+	ImageEndpoint string
+	// Timeout  of connecting to server
+	Timeout time.Duration
+	// Debug enable debug output
+	Debug bool
+}
+
+// GetServerConfigFromFile returns the CRI server configuration from file
+func GetServerConfigFromFile(configFileName, currentDir string) (*ServerConfiguration, error) {
+	serverConfig := ServerConfiguration{}
+	if _, err := os.Stat(configFileName); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, errors.Wrap(err, "load config file")
+		} else {
+			// If the config file was not found, try looking in the program's
+			// directory as a fallback. This is to accommodate where the config file
+			// is placed with the cri tools binary.
+			configFileName = filepath.Join(filepath.Dir(currentDir), "crictl.yaml")
+			if _, err := os.Stat(configFileName); err != nil {
+				return nil, errors.Wrap(err, "load config file")
+			}
+		}
+	}
+
+	// Get config from file.
+	config, err := ReadConfig(configFileName)
+	if err != nil {
+		return nil, errors.Wrap(err, "load config file")
+	}
+
+	// Set the config from file to the server config struct for return
+	serverConfig.RuntimeEndpoint = config.RuntimeEndpoint
+	serverConfig.ImageEndpoint = config.ImageEndpoint
+	if config.Timeout != 0 {
+		serverConfig.Timeout = time.Duration(config.Timeout) * time.Second
+	}
+	serverConfig.Debug = config.Debug
+	return &serverConfig, nil
+}

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"io/ioutil"
+	"os"
+	gofilepath "path/filepath"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Config is the internal representation of the yaml that defines
+// server configuration
+type Config struct {
+	RuntimeEndpoint string `yaml:"runtime-endpoint"`
+	ImageEndpoint   string `yaml:"image-endpoint"`
+	Timeout         int    `yaml:"timeout"`
+	Debug           bool   `yaml:"debug"`
+}
+
+// ReadConfig reads from a file with the given name and returns a config or
+// an error if the file was unable to be parsed.
+func ReadConfig(filepath string) (*Config, error) {
+	data, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		return nil, err
+	}
+	config := Config{}
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		return nil, err
+	}
+	return &config, err
+}
+
+// WriteConfig writes config to file
+// an error if the file was unable to be written to.
+func WriteConfig(c *Config, filepath string) error {
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(gofilepath.Dir(filepath), 0o755); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath, data, 0o644)
+}

--- a/pkg/framework/test_context.go
+++ b/pkg/framework/test_context.go
@@ -18,6 +18,8 @@ package framework
 
 import (
 	"flag"
+	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -31,6 +33,7 @@ type TestContextType struct {
 	ReportPrefix string
 
 	// CRI client configurations.
+	ConfigPath            string
 	ImageServiceAddr      string
 	ImageServiceTimeout   time.Duration
 	RuntimeServiceAddr    string
@@ -69,10 +72,13 @@ func RegisterFlags() {
 	flag.DurationVar(&TestContext.ImageServiceTimeout, "image-service-timeout", 300*time.Second, "Timeout when trying to connect to image service.")
 
 	svcaddr := "unix:///var/run/dockershim.sock"
+	defaultConfigPath := "/etc/crictl.yaml"
 	if runtime.GOOS == "windows" {
 		svcaddr = "npipe:////./pipe/dockershim"
+		defaultConfigPath = filepath.Join(os.Getenv("USERPROFILE"), ".crictl", "crictl.yaml")
 	}
-	flag.StringVar(&TestContext.RuntimeServiceAddr, "runtime-endpoint", svcaddr, "Runtime service socket for client to connect..")
+	flag.StringVar(&TestContext.ConfigPath, "config", defaultConfigPath, "Location of the client config file. If not specified and the default does not exist, the program's directory is searched as well")
+	flag.StringVar(&TestContext.RuntimeServiceAddr, "runtime-endpoint", svcaddr, "Runtime service socket for client to connect.")
 	flag.DurationVar(&TestContext.RuntimeServiceTimeout, "runtime-service-timeout", 300*time.Second, "Timeout when trying to connect to a runtime service.")
 	flag.StringVar(&TestContext.RuntimeHandler, "runtime-handler", "", "Runtime handler to use in the test.")
 	flag.IntVar(&TestContext.Number, "number", 5, "Number of PodSandbox/container in listing benchmark test.")


### PR DESCRIPTION
This commit refactors `crictl` config logic so that `critest` can also use config file for CRI server configuration.

Closes #592 