### PR TITLE
Update the default CRI server defaults

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/net/context"
@@ -62,7 +63,7 @@ var runtimeAttachCommand = &cli.Command{
 		}
 		err = Attach(runtimeClient, opts)
 		if err != nil {
-			return fmt.Errorf("attaching running container failed: %v", err)
+			return errors.Wrap(err, "attaching running container failed")
 
 		}
 		return nil

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	dockerterm "github.com/docker/docker/pkg/term"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/net/context"
@@ -84,7 +85,7 @@ var runtimeExecCommand = &cli.Command{
 		if context.Bool("sync") {
 			exitCode, err := ExecSync(runtimeClient, opts)
 			if err != nil {
-				return fmt.Errorf("execing command in container synchronously failed: %v", err)
+				return errors.Wrap(err, "execing command in container synchronously")
 			}
 			if exitCode != 0 {
 				return cli.NewExitError("non-zero exit code", exitCode)
@@ -93,7 +94,7 @@ var runtimeExecCommand = &cli.Command{
 		}
 		err = Exec(runtimeClient, opts)
 		if err != nil {
-			return fmt.Errorf("execing command in container failed: %v", err)
+			return errors.Wrap(err, "execing command in container")
 		}
 		return nil
 	},

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -17,12 +17,12 @@ limitations under the License.
 package main
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/docker/go-units"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/net/context"
@@ -86,13 +86,13 @@ var pullImageCommand = &cli.Command{
 		if context.IsSet("pod-config") {
 			sandbox, err = loadPodSandboxConfig(context.String("pod-config"))
 			if err != nil {
-				return fmt.Errorf("load podSandboxConfig failed: %v", err)
+				return errors.Wrap(err, "load podSandboxConfig")
 			}
 		}
 
 		r, err := PullImageWithSandbox(imageClient, imageName, auth, sandbox)
 		if err != nil {
-			return fmt.Errorf("pulling image failed: %v", err)
+			return errors.Wrap(err, "pulling image")
 		}
 		fmt.Printf("Image is up to date for %s\n", r.ImageRef)
 		return nil
@@ -139,7 +139,7 @@ var listImageCommand = &cli.Command{
 
 		r, err := ListImages(imageClient, context.Args().First())
 		if err != nil {
-			return fmt.Errorf("listing images failed: %v", err)
+			return errors.Wrap(err, "listing images")
 		}
 		sort.Sort(imageByRef(r.Images))
 
@@ -251,7 +251,7 @@ var imageStatusCommand = &cli.Command{
 
 			r, err := ImageStatus(imageClient, id, verbose)
 			if err != nil {
-				return fmt.Errorf("image status for %q request failed: %v", id, err)
+				return errors.Wrapf(err, "image status for %q request", id)
 			}
 			image := r.Image
 			if image == nil {
@@ -260,12 +260,12 @@ var imageStatusCommand = &cli.Command{
 
 			status, err := protobufObjectToJSON(r.Image)
 			if err != nil {
-				return fmt.Errorf("failed to marshal status to json for %q: %v", id, err)
+				return errors.Wrapf(err, "marshal status to json for %q", id)
 			}
 			switch output {
 			case "json", "yaml", "go-template":
 				if err := outputStatusInfo(status, r.Info, output, tmplStr); err != nil {
-					return fmt.Errorf("failed to output status for %q: %v", id, err)
+					return errors.Wrapf(err, "output status for %q", id)
 				}
 				continue
 			case "table": // table output is after this switch block
@@ -444,18 +444,18 @@ var imageFsInfoCommand = &cli.Command{
 
 		r, err := ImageFsInfo(imageClient)
 		if err != nil {
-			return fmt.Errorf("image filesystem info request failed: %v", err)
+			return errors.Wrap(err, "image filesystem info request")
 		}
 		for _, info := range r.ImageFilesystems {
 			status, err := protobufObjectToJSON(info)
 			if err != nil {
-				return fmt.Errorf("failed to marshal image filesystem info to json: %v", err)
+				return errors.Wrap(err, "marshal image filesystem info to json")
 			}
 
 			switch output {
 			case "json", "yaml", "go-template":
 				if err := outputStatusInfo(status, nil, output, tmplStr); err != nil {
-					return fmt.Errorf("failed to output image filesystem info %v", err)
+					return errors.Wrap(err, "output image filesystem info")
 				}
 				continue
 			case "table": // table output is after this switch block

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -17,8 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/net/context"
@@ -56,7 +55,7 @@ var runtimeStatusCommand = &cli.Command{
 
 		err = Info(context, runtimeClient)
 		if err != nil {
-			return fmt.Errorf("getting status of runtime failed: %v", err)
+			return errors.Wrap(err, "getting status of runtime")
 		}
 		return nil
 	},

--- a/cmd/crictl/main_unix.go
+++ b/cmd/crictl/main_unix.go
@@ -20,5 +20,5 @@ package main
 
 const (
 	defaultConfigPath      = "/etc/crictl.yaml"
-	defaultRuntimeEndpoint = "unix:///var/run/dockershim.sock"
+	defaultRuntimeEndpoint = "unix:///var/run/dockershim.sock unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock"
 )

--- a/cmd/crictl/main_windows.go
+++ b/cmd/crictl/main_windows.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultRuntimeEndpoint = "npipe:////./pipe/dockershim"
+	defaultRuntimeEndpoint = "npipe:////./pipe/dockershim npipe:////./pipe/containerd npipe:////./pipe/crio"
 )
 
 var defaultConfigPath string

--- a/cmd/crictl/portforward.go
+++ b/cmd/crictl/portforward.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/net/context"
@@ -54,7 +55,7 @@ var runtimePortForwardCommand = &cli.Command{
 		}
 		err = PortForward(runtimeClient, opts)
 		if err != nil {
-			return fmt.Errorf("port forward failed: %v", err)
+			return errors.Wrap(err, "port forward")
 
 		}
 		return nil

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -68,13 +68,13 @@ var runPodCommand = &cli.Command{
 
 		podSandboxConfig, err := loadPodSandboxConfig(sandboxSpec)
 		if err != nil {
-			return fmt.Errorf("load podSandboxConfig failed: %v", err)
+			return errors.Wrap(err, "load podSandboxConfig")
 		}
 
 		// Test RuntimeServiceClient.RunPodSandbox
 		podID, err := RunPodSandbox(runtimeClient, podSandboxConfig, context.String("runtime"))
 		if err != nil {
-			return fmt.Errorf("run pod sandbox failed: %v", err)
+			return errors.Wrap(err, "run pod sandbox")
 		}
 		fmt.Println(podID)
 		return nil
@@ -98,7 +98,7 @@ var stopPodCommand = &cli.Command{
 			id := context.Args().Get(i)
 			err := StopPodSandbox(runtimeClient, id)
 			if err != nil {
-				return fmt.Errorf("stopping the pod sandbox %q failed: %v", id, err)
+				return errors.Wrapf(err, "stopping the pod sandbox %q", id)
 			}
 		}
 		return nil
@@ -213,7 +213,7 @@ var podStatusCommand = &cli.Command{
 
 			err := PodSandboxStatus(runtimeClient, id, context.String("output"), context.Bool("quiet"), context.String("template"))
 			if err != nil {
-				return fmt.Errorf("getting the pod sandbox status for %q failed: %v", id, err)
+				return errors.Wrapf(err, "getting the pod sandbox status for %q", id)
 			}
 		}
 		return nil
@@ -306,7 +306,7 @@ var listPodCommand = &cli.Command{
 			return err
 		}
 		if err = ListPodSandboxes(runtimeClient, opts); err != nil {
-			return fmt.Errorf("listing pod sandboxes failed: %v", err)
+			return errors.Wrap(err, "listing pod sandboxes")
 		}
 		return nil
 	},

--- a/cmd/crictl/stats.go
+++ b/cmd/crictl/stats.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/net/context"
@@ -114,7 +115,7 @@ var statsCommand = &cli.Command{
 		}
 
 		if err = ContainerStats(runtimeClient, opts); err != nil {
-			return fmt.Errorf("get container stats failed: %v", err)
+			return errors.Wrap(err, "get container stats")
 		}
 		return nil
 	},

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 	"google.golang.org/grpc"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -152,7 +153,7 @@ func getRuntimeClient(context *cli.Context) (pb.RuntimeServiceClient, *grpc.Clie
 	// Set up a connection to the server.
 	conn, err := getRuntimeClientConnection(context)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to connect: %v", err)
+		return nil, nil, errors.Wrap(err, "connect")
 	}
 	runtimeClient := pb.NewRuntimeServiceClient(conn)
 	return runtimeClient, conn, nil
@@ -162,7 +163,7 @@ func getImageClient(context *cli.Context) (pb.ImageServiceClient, *grpc.ClientCo
 	// Set up a connection to the server.
 	conn, err := getImageClientConnection(context)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to connect: %v", err)
+		return nil, nil, errors.Wrap(err, "connect")
 	}
 	imageClient := pb.NewImageServiceClient(conn)
 	return imageClient, conn, nil

--- a/cmd/crictl/version.go
+++ b/cmd/crictl/version.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/net/context"
@@ -40,7 +41,7 @@ var runtimeVersionCommand = &cli.Command{
 		defer closeConnection(context, runtimeConn)
 		err = Version(runtimeClient, criClientVersion)
 		if err != nil {
-			return fmt.Errorf("getting the runtime version failed: %v", err)
+			return errors.Wrap(err, "getting the runtime version")
 		}
 		return nil
 	},

--- a/pkg/validate/apparmor_linux.go
+++ b/pkg/validate/apparmor_linux.go
@@ -18,13 +18,13 @@ package validate
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"time"
 
 	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
+	"github.com/pkg/errors"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/security/apparmor"
@@ -149,14 +149,14 @@ func checkContainerApparmor(rc internalapi.RuntimeService, containerID string, s
 func loadTestProfiles() error {
 	f, err := ioutil.TempFile("/tmp", "apparmor")
 	if err != nil {
-		return fmt.Errorf("failed to open temp file: %v", err)
+		return errors.Wrap(err, "open temp file")
 	}
 	defer os.Remove(f.Name())
 	defer f.Close()
 
 	// write test profiles to a temp file.
 	if _, err = f.WriteString(testProfiles); err != nil {
-		return fmt.Errorf("failed to write profiles to file: %v", err)
+		return errors.Wrap(err, "write profiles to file")
 	}
 
 	// load apparmor profiles into kernel.
@@ -173,7 +173,7 @@ func loadTestProfiles() error {
 			glog.Infof("apparmor_parser: %s", out)
 		}
 
-		return fmt.Errorf("failed to load profiles: %v", err)
+		return errors.Wrap(err, "load profiles")
 	}
 
 	glog.V(2).Infof("Loaded profiles: %v", out)

--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
+	"github.com/pkg/errors"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
@@ -1052,7 +1053,7 @@ func createAndCheckHostNetwork(rc internalapi.RuntimeService, ic internalapi.Ima
 func createSeccompProfileDir() (string, error) {
 	hostPath, err := ioutil.TempDir("", "seccomp-tests")
 	if err != nil {
-		return "", fmt.Errorf("failed to create tempdir %q: %v", hostPath, err)
+		return "", errors.Wrapf(err, "create tempdir %q", hostPath)
 	}
 	return hostPath, nil
 }
@@ -1062,7 +1063,7 @@ func createSeccompProfile(profileContents string, profileName string, hostPath s
 	profilePath := filepath.Join(hostPath, profileName)
 	err := ioutil.WriteFile(profilePath, []byte(profileContents), 0644)
 	if err != nil {
-		return "", fmt.Errorf("failed to create %s: %v", profilePath, err)
+		return "", errors.Wrapf(err, "create %s", profilePath)
 	}
 	return profilePath, nil
 }

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -62,6 +62,6 @@ var _ = t.Describe("pull", func() {
 
 	It("should fail on not existing image", func() {
 		t.CrictlExpectFailureWithEndpoint(endpoint, "pull localhost/wrong",
-			"", "pulling image failed")
+			"", "pulling image")
 	})
 })


### PR DESCRIPTION
Currently, the default CRI server is dockershim. This is a deprecated server with cri-tools. Also, does it make sense to even have a default as the user should explicitly define it.

This PR adds `containerd` and `cri-o` to the default list and it checks each in order till one works. It also adds some looging that the defaults are being used. This at least provdes better usability to the user if they don't configure the server.

Closes #597 