### PR TITLE
Update the default CRI server

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -57,13 +57,11 @@ var (
 )
 
 func getRuntimeClientConnection(context *cli.Context) (*grpc.ClientConn, error) {
-	if RuntimeEndpoint == "" {
+	if RuntimeEndpointIsSet && RuntimeEndpoint == "" {
 		return nil, fmt.Errorf("--runtime-endpoint is not set")
 	}
 	logrus.Debugf("get runtime connection")
-	// As dockershim is deprecated as a default CRI server, it still needs to
-	// be supported. This allows other default endpoint types to be
-	// checked if cannot connect to dockershim
+	// If no EP set then use the default endpoint types
 	if !RuntimeEndpointIsSet {
 		return getConnection(defaultRuntimeEndpoints)
 	}
@@ -72,16 +70,14 @@ func getRuntimeClientConnection(context *cli.Context) (*grpc.ClientConn, error) 
 
 func getImageClientConnection(context *cli.Context) (*grpc.ClientConn, error) {
 	if ImageEndpoint == "" {
-		if RuntimeEndpoint == "" {
+		if RuntimeEndpointIsSet && RuntimeEndpoint == "" {
 			return nil, fmt.Errorf("--image-endpoint is not set")
 		}
 		ImageEndpoint = RuntimeEndpoint
 		ImageEndpointIsSet = RuntimeEndpointIsSet
 	}
 	logrus.Debugf("get image connection")
-	// As dockershim is deprecated as a default CRI server, it still needs to
-	// be supported. This allows other default endpoint types to be
-	// checked if cannot connect to dockershim
+	// If no EP set then use the default endpoint types
 	if !ImageEndpointIsSet {
 		return getConnection(defaultRuntimeEndpoints)
 	}
@@ -183,7 +179,6 @@ func main() {
 			Name:    "runtime-endpoint",
 			Aliases: []string{"r"},
 			EnvVars: []string{"CONTAINER_RUNTIME_ENDPOINT"},
-			Value:   defaultRuntimeEndpoint,
 			Usage:   "Endpoint of CRI container runtime service",
 		},
 		&cli.StringFlag{

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -57,7 +57,13 @@ func getRuntimeClientConnection(context *cli.Context) (*grpc.ClientConn, error) 
 		return nil, fmt.Errorf("--runtime-endpoint is not set")
 	}
 	logrus.Debugf("get runtime connection")
-	return getConnection(strings.Split(RuntimeEndpoint, " "))
+	// As dockershim is deprecated as a default CRI server, it still needs to
+	// be supported. This allows other default endpoint types to be
+	// checked if cannot connect to dockershim
+	if strings.Contains(RuntimeEndpoint, "dockershim") {
+		return getConnection(defaultRuntimeEndpoints)
+	}
+	return getConnection([]string{RuntimeEndpoint})
 }
 
 func getImageClientConnection(context *cli.Context) (*grpc.ClientConn, error) {
@@ -68,7 +74,13 @@ func getImageClientConnection(context *cli.Context) (*grpc.ClientConn, error) {
 		ImageEndpoint = RuntimeEndpoint
 	}
 	logrus.Debugf("get image connection")
-	return getConnection(strings.Split(ImageEndpoint, " "))
+	// As dockershim is deprecated as a default CRI server, it still needs to
+	// be supported. This allows other default endpoint types to be
+	// checked if cannot connect to dockershim
+	if strings.Contains(ImageEndpoint, "dockershim") {
+		return getConnection(defaultRuntimeEndpoints)
+	}
+	return getConnection([]string{ImageEndpoint})
 }
 
 func getConnection(endPoints []string) (*grpc.ClientConn, error) {

--- a/cmd/crictl/main_unix.go
+++ b/cmd/crictl/main_unix.go
@@ -20,5 +20,7 @@ package main
 
 const (
 	defaultConfigPath      = "/etc/crictl.yaml"
-	defaultRuntimeEndpoint = "unix:///var/run/dockershim.sock unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock"
+	defaultRuntimeEndpoint = "unix:///var/run/dockershim.sock"
 )
+
+var defaultRuntimeEndpoints = []string{"unix:///var/run/dockershim.sock", "unix:///run/containerd/containerd.sock", "unix:///run/crio/crio.sock"}

--- a/cmd/crictl/main_unix.go
+++ b/cmd/crictl/main_unix.go
@@ -20,5 +20,5 @@ package main
 
 const (
 	defaultConfigPath      = "/etc/crictl.yaml"
-	defaultRuntimeEndpoint = "unix:///var/run/dockershim.sock"
+	defaultRuntimeEndpoint = "unix:///var/run/dockershim.sock unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock"
 )

--- a/cmd/crictl/main_unix.go
+++ b/cmd/crictl/main_unix.go
@@ -19,8 +19,7 @@ limitations under the License.
 package main
 
 const (
-	defaultConfigPath      = "/etc/crictl.yaml"
-	defaultRuntimeEndpoint = "unix:///var/run/dockershim.sock"
+	defaultConfigPath = "/etc/crictl.yaml"
 )
 
 var defaultRuntimeEndpoints = []string{"unix:///var/run/dockershim.sock", "unix:///run/containerd/containerd.sock", "unix:///run/crio/crio.sock"}

--- a/cmd/crictl/main_windows.go
+++ b/cmd/crictl/main_windows.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultRuntimeEndpoint = "npipe:////./pipe/dockershim"
+	defaultRuntimeEndpoint = "npipe:////./pipe/dockershim npipe:////./pipe/containerd npipe:////./pipe/crio"
 )
 
 var defaultConfigPath string

--- a/cmd/crictl/main_windows.go
+++ b/cmd/crictl/main_windows.go
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	defaultRuntimeEndpoint = "npipe:////./pipe/dockershim npipe:////./pipe/containerd npipe:////./pipe/crio"
+	defaultRuntimeEndpoint = "npipe:////./pipe/dockershim"
 )
 
+var defaultRuntimeEndpoints = []string{"npipe:////./pipe/dockershim", "npipe:////./pipe/containerd", "npipe:////./pipe/crio"}
 var defaultConfigPath string
 
 func init() {

--- a/cmd/crictl/main_windows.go
+++ b/cmd/crictl/main_windows.go
@@ -23,10 +23,6 @@ import (
 	"path/filepath"
 )
 
-const (
-	defaultRuntimeEndpoint = "npipe:////./pipe/dockershim"
-)
-
 var defaultRuntimeEndpoints = []string{"npipe:////./pipe/dockershim", "npipe:////./pipe/containerd", "npipe:////./pipe/crio"}
 var defaultConfigPath string
 

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -75,6 +75,17 @@ The endpoint can be set in three ways:
 - By setting environment variables `CONTAINER_RUNTIME_ENDPOINT` and `IMAGE_SERVICE_ENDPOINT`
 - By setting the endpoint in the config file `--config=/etc/crictl.yaml`
 
+If the endpoint is not set then it works as follows:
+
+- If the runtime endpoint is not set `crictl` will, by default, try to connect using:
+  - dockershim
+  - containerd
+  - cri-o
+- If the image endpoint is not set `crictl` will, by default, use the runtime endpoint setting
+
+> Note: The default endpoints are now deprecated and the runtime endpoint should always be set instead.
+The performance maybe affected as each default connection attempt takes n-seconds to complete before timing out and going to the next in sequence.
+
 Unix:
 ```sh
 $ cat /etc/crictl.yaml


### PR DESCRIPTION
Currently, the default CRI server is dockershim. This is a deprecated server with cri-tools. Also, does it make sense to even have a default as the user should explicitly define it.

This PR adds `containerd` and `cri-o` to the default list and it checks each in order till one works. It also adds some logging that the defaults are being used. This at least provdes better usability to the user if they don't configure the server.

Closes #597 