### PR TITLE
Allow -s for --state when listing containers

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -407,9 +407,10 @@ var listContainersCommand = &cli.Command{
 			Usage: "Filter by container image",
 		},
 		&cli.StringFlag{
-			Name:  "state",
-			Value: "",
-			Usage: "Filter by container state",
+			Name:    "state",
+			Aliases: []string{"s"},
+			Value:   "",
+			Usage:   "Filter by container state",
 		},
 		&cli.StringSliceFlag{
 			Name:  "label",


### PR DESCRIPTION
The same is already possible for pods, so we now add the alias to
containers as well to streamline the CLI behavior.