### PR TITLE
Fix server connection timeout

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -102,7 +102,7 @@ func getConnection(endPoints []string) (*grpc.ClientConn, error) {
 	endPointsLen := len(endPoints)
 	var conn *grpc.ClientConn
 	for indx, endPoint := range endPoints {
-		logrus.Debugf("connect using endpoint: %s", endPoint)
+		logrus.Debugf("connect using endpoint '%s' with '%s' timeout", endPoint, Timeout)
 		addr, dialer, err := util.GetAddressAndDialer(endPoint)
 		if err != nil {
 			if indx == endPointsLen-1 {
@@ -203,7 +203,7 @@ func main() {
 			Name:    "timeout",
 			Aliases: []string{"t"},
 			Value:   defaultTimeout,
-			Usage: "Timeout of connecting to the server. " +
+			Usage: "Timeout of connecting to the server in seconds (e.g. 2s, 20s.). " +
 				"0 or less is set to default",
 		},
 		&cli.BoolFlag{

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -203,12 +203,13 @@ func main() {
 			Name:    "timeout",
 			Aliases: []string{"t"},
 			Value:   defaultTimeout,
-			Usage:   "Timeout of connecting to the server (default: 2s)",
+			Usage: "Timeout of connecting to the server. " +
+				"0 or less is set to default",
 		},
 		&cli.BoolFlag{
 			Name:    "debug",
 			Aliases: []string{"D"},
-			Usage:   "Enable debug mode (Default: false)",
+			Usage:   "Enable debug mode",
 		},
 	}
 

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -115,11 +115,11 @@ via sudo (`sudo -E crictl ...`).
 
 ## Additional options
 
-- `--timeout`, `-t`: Timeout of connecting to server (default: 2s)
+- `--timeout`, `-t`: Timeout of connecting to server (default: 2s). 0 or less is interpreted as unset and converted to the default. There is no option for no timeout value set and the smallest supported timeout is `1s`
 - `--debug`, `-D`: Enable debug output
 - `--help`, `-h`: show help
 - `--version`, `-v`: print the version information of crictl
-- `--config`, `-c`: Config file in yaml format. Overrided by flags or environment variables.
+- `--config`, `-c`: Config file in yaml format. Overrided by flags or environment variables
 
 ## Examples
 

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -91,7 +91,7 @@ Unix:
 $ cat /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/dockershim.sock
 image-endpoint: unix:///var/run/dockershim.sock
-timeout: 10
+timeout: 2
 debug: true
 ```
 Windows:
@@ -99,7 +99,7 @@ Windows:
 C:\> type %USERPROFILE%\.crictl\crictl.yaml
 runtime-endpoint: tcp://localhost:3735
 image-endpoint: tcp://localhost:3735
-timeout: 10
+timeout: 2
 debug: true
 ```
 
@@ -115,7 +115,7 @@ via sudo (`sudo -E crictl ...`).
 
 ## Additional options
 
-- `--timeout`, `-t`: Timeout of connecting to server (default: 10s)
+- `--timeout`, `-t`: Timeout of connecting to server (default: 2s)
 - `--debug`, `-D`: Enable debug output
 - `--help`, `-h`: show help
 - `--version`, `-v`: print the version information of crictl

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -115,7 +115,9 @@ via sudo (`sudo -E crictl ...`).
 
 ## Additional options
 
-- `--timeout`, `-t`: Timeout of connecting to server (default: 2s). 0 or less is interpreted as unset and converted to the default. There is no option for no timeout value set and the smallest supported timeout is `1s`
+- `--timeout`, `-t`: Timeout of connecting to server in seconds (default: 2s).
+0 or less is interpreted as unset and converted to the default. There is no
+option for no timeout value set and the smallest supported timeout is `1s`
 - `--debug`, `-D`: Enable debug output
 - `--help`, `-h`: show help
 - `--version`, `-v`: print the version information of crictl

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -62,9 +62,7 @@ func GetServerConfigFromFile(configFileName, currentDir string) (*ServerConfigur
 	// Set the config from file to the server config struct for return
 	serverConfig.RuntimeEndpoint = config.RuntimeEndpoint
 	serverConfig.ImageEndpoint = config.ImageEndpoint
-	if config.Timeout != 0 {
-		serverConfig.Timeout = time.Duration(config.Timeout) * time.Second
-	}
+	serverConfig.Timeout = time.Duration(config.Timeout) * time.Second
 	serverConfig.Debug = config.Debug
 	return &serverConfig, nil
 }


### PR DESCRIPTION
This PR handles the following issues found with the `timeout` setting in the tools:

- The default server connection timeout is stated in documentation as 10s but in code it is set to 2s. This doc is now changed to 2s.
- It allows a negative timeout value  which is probably not a very good setting as the system will give it an indeterminate value. This means an unknown or indefinite timeout. This now uses the default value when set to negative.
- Finally, there seemed to some bugs the way the timeout value is retrieved and handled from config file and CLI. It doesn't seem to be converted to seconds as expected.

Partial #605 

[EDITED]