### PR TITLE
Fix e2e tests following docker changes in Kublet

### DIFF
--- a/hack/install-kubelet.ps1
+++ b/hack/install-kubelet.ps1
@@ -25,6 +25,12 @@ cd $k8siopath
 git clone -c core.symlinks=true https://github.com/kubernetes/kubernetes
 
 cd $kubernetespath
+
+# This is a workaround due to build issues caused by Kublet removing
+# Docker support: in kubernetes/kubernetes#87746
+# TODO: This should be removed once issues in kubelet are resolved
+git checkout 6f9c0f9edd835367116971074fb743c39a6b3863
+
 $branch = [System.Environment]::GetEnvironmentVariable("TRAVIS_BRANCH")
 if ( ! "$branch".Equals("master") ) {
   # We can do this because cri-tools have the same branch name with kubernetes.

--- a/hack/install-kubelet.sh
+++ b/hack/install-kubelet.sh
@@ -21,6 +21,12 @@ set -o pipefail
 # Install kubelet
 git clone https://github.com/kubernetes/kubernetes $GOPATH/src/k8s.io/kubernetes
 cd $GOPATH/src/k8s.io/kubernetes
+
+# This is a workaround due to build issues caused by Kublet removing
+# Docker support: in kubernetes/kubernetes#87746
+# TODO: This should be removed once issues in kubelet are resolved
+git checkout 6f9c0f9edd835367116971074fb743c39a6b3863
+
 if [ ${TRAVIS_BRANCH:-"master"} != "master" ]; then
   # We can do this because cri-tools have the same branch name with kubernetes.
   git checkout "${TRAVIS_BRANCH}"

--- a/hack/run-critest.sh
+++ b/hack/run-critest.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # Start dockershim first
-/usr/local/bin/kubelet --v=3 --logtostderr &
+/usr/local/bin/kubelet --v=3 --logtostderr --experimental-dockershim &
 
 # Wait a while for dockershim starting.
 sleep 10

--- a/hack/run-critest.sh
+++ b/hack/run-critest.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # Start dockershim first
-/usr/local/bin/kubelet --v=3 --logtostderr --experimental-dockershim &
+/usr/local/bin/kubelet --v=3 --logtostderr &
 
 # Wait a while for dockershim starting.
 sleep 10


### PR DESCRIPTION
Kubernetes removed the `experimental-dockershim` flag in https://github.com/kubernetes/kubernetes/pull/87746.

This PR is to fix the e2e tests failing as a result.