### PR TITLE
Use CRI-validation-friendly version of nginx image

### DIFF
--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	nginxContainerImage string = "nginx"
+	nginxContainerImage string = "nginx:1.18"
 	localhost           string = "localhost/"
 	noNewPrivsImage     string = "gcr.io/kubernetes-e2e-test-images/nonewprivs:1.1"
 )


### PR DESCRIPTION
Some subtests in CRI validation currently use the latest version of nginx image. Recently, official nginx image (`latest` = `1.19`) [introduced a new (but slower) entrypoint shellscript `/docker-entrypoint.sh`](https://github.com/nginxinc/docker-nginx/blob/2ef3fa66f2a434cd5e44e35a02f4ac502cf50808/mainline/buster/Dockerfile#L104) which wraps nginx binary. In this image, the timing of the creation of some files used in subtests (e.g. [`/var/run/nginx.pid` used in `HostPID` test](https://github.com/kubernetes-sigs/cri-tools/blob/01f00dc813e9110260a71b537ec7f9a1a40271af/pkg/validate/security_context_linux.go#L97-L98)) is slower than the previous version of images. So recently CRI validation became flaky because of an occasional race condition where some of the subtests look up these nginx-related files before the desired contents are written.

This commit mitigates this issue by using CRI-validation-friendly (pervious) version of nginx image (`1.18`) instead of the `latest` tag.
