### PR TITLE
Add CRI-O GitHub action artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
           make test-cri
         working-directory: ${{ github.workspace }}/src/github.com/containerd/cri
 
-      - name: Upload CRI Test log file
+      - name: Upload containerd logs
         uses: actions/upload-artifact@v1
         with:
-          name: cri-test-${{github.sha}}.log
+          name: containerd-${{github.sha}}.log
           path: /tmp/test-cri/containerd.log
 
   #
@@ -144,3 +144,10 @@ jobs:
             --runtime-endpoint=unix:///var/run/crio/crio.sock \
             --ginkgo.flakeAttempts=3 \
             --parallel=$(nproc)
+          sudo journalctl -u crio > cri-o.log
+
+      - name: Upload CRI-O logs
+        uses: actions/upload-artifact@v1
+        with:
+          name: cri-o-${{github.sha}}.log
+          path: cri-o.log

--- a/pkg/validate/apparmor_linux.go
+++ b/pkg/validate/apparmor_linux.go
@@ -81,7 +81,7 @@ var _ = framework.KubeDescribe("AppArmor", func() {
 				rc.RemovePodSandbox(sandboxID)
 			})
 
-			It("should fail with with an unloaded profile", func() {
+			It("should fail with an unloaded profile", func() {
 				profile := apparmorProfileNamePrefix + "non-existent-profile"
 				containerID := createContainerWithAppArmor(rc, ic, sandboxID, sandboxConfig, profile, false)
 				Expect(containerID).To(BeEmpty())


### PR DESCRIPTION
We now use the CRI-O logs as artifacts and rename the containerd logs
that they are better distinguishable.