### PR TITLE
fix containerd running critest on wrong commit and make default critest show version

### DIFF
--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{matrix.version}}
           fetch-depth: 150
 
-      - name: Set containerd ${{matrix.version}} cri repo version 
+      - name: Set containerd ${{matrix.version}} cri repo version
         shell: bash
         if: ${{matrix.version != 'master'}}
         run: |
@@ -105,6 +105,8 @@ jobs:
       - name: Run critest on Linux
         if: startsWith(matrix.os, 'ubuntu')
         run: |
+          # have to copy here because cri-tools install and containerd/cri test-cri presume different paths
+          mkdir -p "${GOPATH}/bin" && cp /usr/local/bin/critest $_
           GOPATH=$GOPATH make test-cri
         working-directory: ${{ github.workspace }}/src/github.com/containerd/cri
 

--- a/cmd/critest/cri_test.go
+++ b/cmd/critest/cri_test.go
@@ -163,8 +163,10 @@ func runParallelTestSuite(t *testing.T) {
 }
 
 func TestCRISuite(t *testing.T) {
+	fmt.Printf("critest version: %s\n", versionconst.Version)
+
 	if *version {
-		fmt.Printf("critest version: %s\n", versionconst.Version)
+		// print version only and exit
 		return
 	}
 


### PR DESCRIPTION
first commit shows version information by default for critest runs

second commit will fix containerd git hub actions

Signed-off-by: Mike Brown <brownwm@us.ibm.com>