### PR TITLE
ps: document --pod <id> must be a full ID

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -869,7 +869,18 @@ func ListContainers(runtimeClient pb.RuntimeServiceClient, imageClient pb.ImageS
 		filter.Id = opts.id
 	}
 	if opts.podID != "" {
-		filter.PodSandboxId = opts.podID
+		// translate to full pod ID
+		request := &pb.PodSandboxStatusRequest{
+			PodSandboxId: opts.podID,
+		}
+		logrus.Debugf("PodSandboxStatusRequest to find full pod ID: %v", request)
+		r, err := runtimeClient.PodSandboxStatus(context.Background(), request)
+		logrus.Debugf("PodSandboxStatusReponse to find full pod ID: %v", r)
+		if err != nil {
+			return errors.Wrapf(err, "failed to translate pod ID %s to full pod ID", opts.podID)
+		}
+
+		filter.PodSandboxId = r.Status.Id
 	}
 	st := &pb.ContainerStateValue{}
 	if !opts.all && opts.state == "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
 /kind documentation


#### What this PR does / why we need it:
Since ps is simply passing a filter, and filters don't check for substring matches, but rather exact matches,
the ID must be full.

Before we pass the id as a filter, translate truncated id to full id with a PodSandboxStatus request

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
