### PR TITLE
OWNERS: move euank to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,6 @@
 approvers:
   - Random-Liu
   - dchen1107
-  - euank
   - feiskyer
   - heartlock
   - mrunalp
@@ -14,3 +13,5 @@ approvers:
   - yujuhong
   - runcom
 
+emeritus_approvers:
+  - euank


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit moves euank to the
emeritus_approvers section.

cc @euank @mrbobbytables 

/kind cleanup
/assign @saschagrunert 


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
