### PR TITLE
Makefile: use deferred assignment for BINDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifeq ($(GOOS),windows)
 endif
 
 PROJECT := github.com/kubernetes-sigs/cri-tools
-BINDIR := /usr/local/bin
+BINDIR ?= /usr/local/bin
 
 VERSION := $(shell git describe --tags --dirty --always)
 VERSION := $(VERSION:v%=%)


### PR DESCRIPTION
Use deferred assignment for BINDIR.

The practical effect is that Makefile can honor an environment
variable BINDIR during build, instead of hard-coded value
/usr/local/bin.  For example:

```
    $ export BINDIR=/tmp/cri-tools
    $ make
    [...]
    $ make install
    install -D -m 755 /home/muriloo/sources/cri-o/cri-tools/_output/critest /tmp/cri-tools/critest
    install -D -m 755 /home/muriloo/sources/cri-o/cri-tools/_output/crictl /tmp/cri-tools/crictl
```

Fixes: https://github.com/kubernetes-sigs/cri-tools/issues/654
Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

> Uncomment only one `/kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake
> /kind regression

#### What this PR does / why we need it:

Allowing cri-tools to be installed on other directories, e.g.: `/opt/bin`, adds flexibility to the installation process without changing previous behavior. The default installation directory can still be `/usr/local/bin` if `BINDIR` is not defined by user.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #654 

#### Special notes for your reviewer:
This pull request doesn't change the default `/usr/local/bin` path set for `BINDIR` in `Makefile`.

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
