### PR TITLE
move up to 1.4 release of containerd

### DIFF
--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -18,7 +18,7 @@ jobs:
         # ║ hcshim           │           │ runhcs  ║
         # ╚══════════════════╧═══════════╧═════════╝
         os: [ubuntu-18.04, windows-2019]
-        version: [master, v1.4.0-beta.2]
+        version: [master, v1.4.0]
         runtime: [io.containerd.runtime.v1.linux, io.containerd.runc.v1, io.containerd.runc.v2, containerd-shim-runhcs-v1]
         runc: [runc, crun]
         exclude:


### PR DESCRIPTION
Updating the more stable test branch of containerd from the 1.4 beta 2 branch to the released 1.4 branch. 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>

