### PR TITLE
Add test oci images

### DIFF
--- a/hack/install-buildah.sh
+++ b/hack/install-buildah.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Install buildah
+. /etc/os-release
+sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${ID^}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${ID^}_${VERSION_ID}/Release.key -O Release.key
+sudo apt-key add - < Release.key
+rm -f Release.key
+sudo apt-get update -qq
+sudo apt-get -qq -y install buildah

--- a/images/hostnet-nginx/Makefile
+++ b/images/hostnet-nginx/Makefile
@@ -15,20 +15,38 @@
 include ../../hack/make-rules/Makefile.manifest
 include ../../hack/make-rules/BASEIMAGES
 
-.PHONY: all push-manifest
+.PHONY: all docker-all oci-all hostnet-nginx push-docker-manifest oci-hostnet-nginx push-oci-manifest
 
 REGISTRY = gcr.io/cri-tools
 ALL_ARCH = amd64 arm64 ppc64le s390x
 TAG = latest
-IMAGES_LIST = hostnet-nginx
+DOCKER_IMAGES_LIST = hostnet-nginx
+OCI_IMAGES_LIST = oci-hostnet-nginx
 PORT=12003
 
-all: hostnet-nginx push-manifest
+all: docker-all oci-all
+docker-all: hostnet-nginx push-docker-manifest
+
+# TODO: Add push-oci-manifest target when 
+# https://github.com/estesp/manifest-tool v2 is released
+# because it will provide OCI support
+oci-all: oci-hostnet-nginx
 
 hostnet-nginx:
 	sed -i "s/listen\s*80;/listen ${PORT};/g" default.conf
 	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch));)
 	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
 
-push-manifest: manifest-tool
-	$(foreach image,$(IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
+oci-hostnet-nginx:
+	../../hack/install-buildah.sh
+	sed -i "s/listen\s*80;/listen ${PORT};/g" default.conf
+	$(foreach arch,$(ALL_ARCH),buildah build-using-dockerfile -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch));)
+	$(foreach arch,$(ALL_ARCH),buildah push $(REGISTRY)/$@-$(arch);)
+
+push-docker-manifest: manifest-tool
+	$(foreach image,$(DOCKER_IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
+
+# TODO: Dependant on OCI support which will be available
+# when https://github.com/estesp/manifest-tool v2 is released
+push-oci-manifest: manifest-tool
+	$(foreach image,$(OCI_IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)

--- a/images/image-test-win/build.ps1
+++ b/images/image-test-win/build.ps1
@@ -14,16 +14,30 @@
 
 $Registry = "gcr.io/cri-tools"
 $Tag = "latest"
-$ImagesList = @(
+$DockerImagesList = @(
 	"win-test-image-1:$Tag", "win-test-image-2:$Tag", "win-test-image-3:$Tag",
 	"win-test-image-latest:$Tag", "win-test-image-digest:$Tag",
 	"win-test-image-tags:1", "win-test-image-tags:2", "win-test-image-tags:3",
 	"win-test-image-tag:test", "win-test-image-tag:all")
 
-Foreach ($image in $ImagesList) {
+$OCIImagesList = @(
+	"win-test-oci-image-1:$Tag", "win-test-oci-image-2:$Tag", "win-test-image-3:$Tag",
+	"win-test-oci-image-latest:$Tag", "win-test-oci-image-digest:$Tag",
+	"win-test-oci-image-tags:1", "win-test-oci-image-tags:2", "win-test-image-tags:3",
+	"win-test-ociimage-tag:test", "win-test-oci-image-tag:all")
+
+Foreach ($image in $DockerImagesList) {
 	$imageName = $image.Substring(0, $image.IndexOf(":"))
 	New-Item -ItemType File -Path . -Name $imageName
 	docker build . -t "$Registry/${image}" --build-arg TEST=$imageName
 	docker push "$Registry/${image}"
+	Remove-Item -Force $imageName
+}
+
+Foreach ($image in $OCIImagesList) {
+	$imageName = $image.Substring(0, $image.IndexOf(":"))
+	New-Item -ItemType File -Path . -Name $imageName
+	buildah build-using-dockerfile -t "$Registry/${image}" --build-arg TEST=$imageName
+	buildah push "$Registry/${image}"
 	Remove-Item -Force $imageName
 }

--- a/images/image-test/Makefile
+++ b/images/image-test/Makefile
@@ -15,28 +15,52 @@
 include ../../hack/make-rules/Makefile.manifest
 include ../../hack/make-rules/BASEIMAGES
 
-.PHONY: all-push all-push-images push-manifest
+.PHONY: all-push all-push-docker all-push-oci all-push-docker-images push-docker-manifest all-push-oci-images push-oci-manifest
 
 REGISTRY ?= gcr.io/cri-tools
 TAG = latest
 ALL_ARCH = amd64 arm64 ppc64le s390x
-IMAGES_LIST = test-image-1 test-image-2 test-image-3 test-image-latest test-image-digest
+DOCKER_IMAGES_LIST = test-image-1 test-image-2 test-image-3 test-image-latest test-image-digest
+OCI_IMAGES_LIST = test-oci-image-1 test-oci-image-2 test-oci-image-3 test-oci-image-latest test-oci-image-digest
 IMAGE_TAGS_LIST = test all
 SAME_IMAGE_TAGS_LIST = 1 2 3
 
-all-push: all-push-images push-manifest
+all-push: all-push-docker all-push-oci
+all-push-docker: all-push-docker-images push-docker-manifest
 
-all-push-images: $(addprefix sub-push-,$(ALL_ARCH))
+# TODO: Add push-oci-manifest target when 
+# https://github.com/estesp/manifest-tool v2 is released
+# because it will provide OCI support
+all-push-oci: all-push-oci-images
 
-sub-push-%:
-	$(foreach name,$(IMAGES_LIST),touch $(name) && docker build . -t $(REGISTRY)/$(name)-$*:$(TAG) --build-arg TEST=$(name) --build-arg ARCH=$($*) && rm -f $(name);)
-	$(foreach name,$(IMAGES_LIST),docker push $(REGISTRY)/$(name)-$*:$(TAG);)
+all-push-docker-images: $(addprefix sub-push-docker-,$(ALL_ARCH))
+all-push-oci-images: $(addprefix sub-push-oci-,$(ALL_ARCH))
+
+sub-push-docker-%:
+	$(foreach name,$(DOCKER_IMAGES_LIST),touch $(name) && docker build . -t $(REGISTRY)/$(name)-$*:$(TAG) --build-arg TEST=$(name) --build-arg ARCH=$($*) && rm -f $(name);)
+	$(foreach name,$(DOCKER_IMAGES_LIST),docker push $(REGISTRY)/$(name)-$*:$(TAG);)
 	$(foreach tag,$(IMAGE_TAGS_LIST),touch $(tag) && docker build . -t $(REGISTRY)/test-image-tag-$*:$(tag) --build-arg TEST=$(tag) --build-arg ARCH=$($*) && rm -f $(tag);)
 	$(foreach tag,$(IMAGE_TAGS_LIST),docker push $(REGISTRY)/test-image-tag-$*:$(tag);)
 	$(foreach tag,$(SAME_IMAGE_TAGS_LIST),touch same-image && docker build . -t $(REGISTRY)/test-image-tags-$*:$(tag) --build-arg TEST=same-image --build-arg ARCH=$($*) && rm -f same-image;)
 	$(foreach tag,$(SAME_IMAGE_TAGS_LIST),docker push $(REGISTRY)/test-image-tags-$*:$(tag);)
 
-push-manifest: manifest-tool
-	$(foreach image,$(IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
+sub-push-oci-%:
+	../../hack/install-buildah.sh
+	$(foreach name,$(OCI_IMAGES_LIST),touch $(name) && buildah build-using-dockerfile -t $(REGISTRY)/$(name)-$*:$(TAG) --build-arg TEST=$(name) --build-arg ARCH=$($*) && rm -f $(name);)
+	$(foreach name,$(OCI_IMAGES_LIST),buildah push $(REGISTRY)/$(name)-$*:$(TAG);)
+	$(foreach tag,$(IMAGE_TAGS_LIST),touch $(tag) && buildah build-using-dockerfile -t $(REGISTRY)/test-image-tag-$*:$(tag) --build-arg TEST=$(tag) --build-arg ARCH=$($*) && rm -f $(tag);)
+	$(foreach tag,$(IMAGE_TAGS_LIST),buildah push $(REGISTRY)/test-image-tag-$*:$(tag);)
+	$(foreach tag,$(SAME_IMAGE_TAGS_LIST),touch same-image && buildah build-using-dockerfile -t $(REGISTRY)/test-image-tags-$*:$(tag) --build-arg TEST=same-image --build-arg ARCH=$($*) && rm -f same-image;)
+	$(foreach tag,$(SAME_IMAGE_TAGS_LIST),buildah push $(REGISTRY)/test-image-tags-$*:$(tag);)
+
+push-docker-manifest: manifest-tool
+	$(foreach image,$(DOCKER_IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
+	$(foreach tag,$(IMAGE_TAGS_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/test-image-tag-ARCH:$(tag) --target $(REGISTRY)/test-image-tag:$(tag);)
+	$(foreach tag,$(SAME_IMAGE_TAGS_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/test-image-tags-ARCH:$(tag) --target $(REGISTRY)/test-image-tags:$(tag);)
+
+# TODO: Dependant on OCI support which will be available
+# when https://github.com/estesp/manifest-tool v2 is released
+push-oci-manifest: manifest-tool
+	$(foreach image,$(OCI_IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
 	$(foreach tag,$(IMAGE_TAGS_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/test-image-tag-ARCH:$(tag) --target $(REGISTRY)/test-image-tag:$(tag);)
 	$(foreach tag,$(SAME_IMAGE_TAGS_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/test-image-tags-ARCH:$(tag) --target $(REGISTRY)/test-image-tags:$(tag);)

--- a/images/image-user/Makefile
+++ b/images/image-user/Makefile
@@ -15,14 +15,21 @@
 include ../../hack/make-rules/Makefile.manifest
 include ../../hack/make-rules/BASEIMAGES
 
-.PHONY: all test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group push-manifest
+.PHONY: all all-docker all-oci test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group push-docker-manifest test-oci-image-user-uid test-oci-image-user-username test-oci-image-user-uid-group test-oci-image-user-username-group push-oci-manifest
 
 REGISTRY = gcr.io/cri-tools
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 TAG = latest
-IMAGES_LIST = test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group
+DOCKER_IMAGES_LIST = test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group
+OCI_IMAGES_LIST = test-oci-image-user-uid test-oci-image-user-username test-oci-image-user-uid-group test-oci-image-user-username-group
 
-all: test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group push-manifest
+all: all-docker all-oci
+all-docker: test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group push-docker-manifest
+
+# TODO: Add push-oci-manifest target when 
+# https://github.com/estesp/manifest-tool v2 is released
+# because it will provide OCI support
+all-oci: test-oci-image-user-uid test-oci-image-user-username test-oci-image-user-uid-group test-oci-image-user-username-group
 
 test-image-user-uid:
 	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=1002;)
@@ -32,7 +39,6 @@ test-image-user-username:
 	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=www-data;)
 	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
 
-
 test-image-user-uid-group:
 	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=1003:users ;)
 	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
@@ -41,5 +47,30 @@ test-image-user-username-group:
 	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=www-data:100 ;)
 	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
 
-push-manifest: manifest-tool
-	$(foreach image,$(IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
+test-oci-image-user-uid:
+	../../hack/install-buildah.sh
+	$(foreach arch,$(ALL_ARCH),buildah build-using-dockerfile -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=1002;)
+	$(foreach arch,$(ALL_ARCH),buildah push $(REGISTRY)/$@-$(arch);)
+
+test-oci-image-user-username:
+	../../hack/install-buildah.sh
+	$(foreach arch,$(ALL_ARCH),buildah build-using-dockerfile -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=www-data;)
+	$(foreach arch,$(ALL_ARCH),buildah push $(REGISTRY)/$@-$(arch);)
+
+test-oci-image-user-uid-group:
+	../../hack/install-buildah.sh
+	$(foreach arch,$(ALL_ARCH),buildah build-using-dockerfile -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=1003:users ;)
+	$(foreach arch,$(ALL_ARCH),buildah push $(REGISTRY)/$@-$(arch);)
+
+test-oci-image-user-username-group:
+	../../hack/install-buildah.sh
+	$(foreach arch,$(ALL_ARCH),buildah build-using-dockerfile -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=www-data:100 ;)
+	$(foreach arch,$(ALL_ARCH),buildah push $(REGISTRY)/$@-$(arch);)
+
+push-docker-manifest: manifest-tool
+	$(foreach image,$(DOCKER_IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)
+
+# TODO: Dependant on OCI support which will be available
+# when https://github.com/estesp/manifest-tool v2 is released
+push-oci-manifest: manifest-tool
+	$(foreach image,$(OCI_IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds OCI images which can be used to expand ihe test buckets to test more than one container image. it is currently testing just a docker image.

#### Which issue(s) this PR fixes:

Partial #661 

#### Special notes for your reviewer:

Tested against a local docker registry, Docker Hub and GCR. 
TODO: It will need to be run against the `gcr.io/cri-tools` project to load the OCI images for use by the test buckets. I don't have access to this project.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
