### PR TITLE
Timeout fixes

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -124,10 +124,10 @@ var createContainerCommand = &cli.Command{
 	Usage:     "Create a new container",
 	ArgsUsage: "POD container-config.[json|yaml] pod-config.[json|yaml]",
 	Flags:     append(createPullFlags, &cli.DurationFlag{
-		Name:    "timeout",
-		Aliases: []string{"t"},
+		Name:    "cancel-timeout",
+		Aliases: []string{"T"},
 		Value:   0,
-		Usage:   "Seconds to wait for a container create request before cancelling the request",
+		Usage:   "Seconds to wait for a container create request to complete before cancelling the request",
 	}),
 
 	Action: func(context *cli.Context) error {
@@ -167,7 +167,7 @@ var createContainerCommand = &cli.Command{
 					creds:    context.String("creds"),
 					auth:     context.String("auth"),
 				},
-				timeout: context.Duration("timeout"),
+				timeout: context.Duration("cancel-timeout"),
 			},
 		}
 

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -53,10 +53,10 @@ var runPodCommand = &cli.Command{
 			Usage:   "Runtime handler to use. Available options are defined by the container runtime.",
 		},
 		&cli.DurationFlag{
-			Name:    "timeout",
-			Aliases: []string{"t"},
+			Name:    "cancel-timeout",
+			Aliases: []string{"T"},
 			Value:   0,
-			Usage:   "Seconds to wait for a run pod sandox request to complete before cancelling the request",
+			Usage:   "Seconds to wait for a run pod sandbox request to complete before cancelling the request",
 		},
 	},
 
@@ -78,7 +78,7 @@ var runPodCommand = &cli.Command{
 		}
 
 		// Test RuntimeServiceClient.RunPodSandbox
-		podID, err := RunPodSandbox(runtimeClient, podSandboxConfig, context.String("runtime"), context.Duration("timeout"))
+		podID, err := RunPodSandbox(runtimeClient, podSandboxConfig, context.String("runtime"), context.Duration("cancel-timeout"))
 		if err != nil {
 			return errors.Wrap(err, "run pod sandbox")
 		}

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -349,7 +349,7 @@ func ctxWithTimeout(timeout time.Duration) context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	if timeout > 0 {
 		go func() {
-			time.Sleep(timeout * time.Second)
+			time.Sleep(timeout)
 			cancel()
 		}()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug


Optionally add one or more of the following kinds if applicable:

-->
/kind bug
/kind api-change

#### What this PR does / why we need it:
Adds two fixes to the runp/create `--timeout` feature
1: correctly use the timeout passed in by not multiplying it by time.Seconds (a relic from when it was originally specified as an int, oops)
2: change the option to `--cancel-timeout` and `-T` to not overload `--timeout` and `-t` (Which has a different meaning in the top level flags, and could confuse users)

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update the `timeout` option in create, run, runp requests to be `cancel-timeout`
```
