### PR TITLE
context timeout: use provided WithTimeout function

### DIFF
--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -346,12 +346,9 @@ func matchesImage(imageClient pb.ImageServiceClient, image string, containerImag
 }
 
 func ctxWithTimeout(timeout time.Duration) context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	if timeout > 0 {
-		go func() {
-			time.Sleep(timeout)
-			cancel()
-		}()
+	if timeout == 0 {
+		return context.Background()
 	}
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
 	return ctx
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
as it cleans the code up a bit and doesn't reinvent the wheel

Signed-off-by: Peter Hunt <pehunt@redhat.com>

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
none
```
