### PR TITLE
CI: bring back port forward test

### DIFF
--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -23,6 +23,17 @@ jobs:
           echo "::set-env name=GOPATH::${{ github.workspace }}"
           echo "::add-path::${{ github.workspace }}/bin"
 
+      - name: Setup system
+        run: |
+          # enable necessary kernel modules
+          sudo ip6tables --list >/dev/null
+
+          # enable necessary sysctls
+          sudo sysctl -w net.ipv4.conf.all.route_localnet=1
+          sudo sysctl -w net.bridge.bridge-nf-call-iptables=1
+          sudo sysctl -w net.ipv4.ip_forward=1
+          sudo iptables -t nat -I POSTROUTING -s 127.0.0.0/8 ! -d 127.0.0.0/8 -j MASQUERADE
+
       - name: Install ginkgo
         run: |
           go get -u github.com/onsi/ginkgo/ginkgo
@@ -79,14 +90,9 @@ jobs:
 
       - name: Run critest
         run: |
-          # Skipping the test because of possible conflicts with MASQUERADE:
-          # https://unix.stackexchange.com/questions/466105/iptables-masquerade-breaks-dns-lookups
-          # https://unix.stackexchange.com/questions/304050/how-to-avoid-conflicts-between-dnsmasq-and-systemd-resolved
-          SKIP="runtime should support port mapping with host port and container port"
           sudo PATH=$PATH GOPATH=$GOPATH critest \
             --runtime-endpoint=unix:///var/run/crio/crio.sock \
             --ginkgo.flakeAttempts=3 \
-            --ginkgo.skip="$SKIP" \
             --parallel=$(nproc)
           sudo journalctl -u crio > cri-o.log
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

(is adding back a CI test a feature? IDK)

#### What this PR does / why we need it:

This reverts commit 2688ed34bf00a7bc2fe718c748b0fbaf9ab6cb79 (PR #626),
and adds the following change on top:

```diff
-          sudo iptables -t nat -I POSTROUTING -s 127.0.0.1 ! -d 127.0.0.1 -j MASQUERADE
+          sudo iptables -t nat -I POSTROUTING -s 127.0.0.0/8 ! -d 127.0.0.0/8 -j MASQUERADE
```

The original DNS problem was caused by the fact that
systemd-resolved is listening at the IP address 127.0.0.53
and thus it was affected by the above rule.

Change the address to the address block (yes, the whole /8 block
is reserved for localhost addresses!) to fix this.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```
