### PR TITLE
pkg/validate/apparmor: fix path

### DIFF
--- a/pkg/validate/apparmor_linux.go
+++ b/pkg/validate/apparmor_linux.go
@@ -108,7 +108,7 @@ func createContainerWithAppArmor(rc internalapi.RuntimeService, ic internalapi.I
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
 		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
-		Command:  []string{"touch", "foo"},
+		Command:  []string{"touch", "/tmp/foo"},
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
 				ApparmorProfile: profile,


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

A change introduced by [1] makes it impossible to create a directory
entry right under container's root directory, so the test case
"should enforce a permissive profile" fails.

For the purpose of this test it does not matter where we create the
file, so let's do it under /tmp.

[1] https://github.com/containers/storage/pull/743

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

n/a 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
