### PR TITLE
.github/workflows: fix GOROOT under sudo etc

### DIFF
--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -273,11 +273,11 @@ jobs:
             [plugins.cri.containerd.default_runtime]
               runtime_type = \"${{matrix.runtime}}\"
           EOF
-          sudo PATH=$PATH BDIR=$BDIR /usr/local/bin/containerd -a ${BDIR}/c.sock -root ${BDIR}/root -state ${BDIR}/state -log-level debug &> ${BDIR}/containerd-cri.log &
-          sudo BDIR=$BDIR /usr/local/bin/ctr -a ${BDIR}/c.sock version
-          sudo BDIR=$BDIR /usr/local/sbin/runc --version
+          sudo PATH=$PATH /usr/local/bin/containerd -a ${BDIR}/c.sock -root ${BDIR}/root -state ${BDIR}/state -log-level debug &> ${BDIR}/containerd-cri.log &
+          sudo /usr/local/bin/ctr -a ${BDIR}/c.sock version
+          sudo /usr/local/sbin/runc --version
 
-          sudo PATH=$PATH BDIR=$BDIR GOPATH=$GOPATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
+          sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
           TEST_RC=$?
           test $TEST_RC -ne 0 && cat ${BDIR}/containerd-cri.log
           sudo pkill containerd
@@ -298,12 +298,12 @@ jobs:
           REPORT_DIR="${REPORT_DIR:-"c/_artifacts"}"
           mkdir -p "${REPORT_DIR}"
 
-          PATH=$PATH containerd -log-level debug &> "${REPORT_DIR}/containerd-cri.log" &
+          containerd -log-level debug &> "${REPORT_DIR}/containerd-cri.log" &
           pid=$!
-          PATH=$PATH ctr version
+          ctr version
 
           set +o errexit
-          PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=npipe:////./pipe/containerd-containerd --ginkgo.focus="${FOCUS}" --ginkgo.skip="${SKIP}" --report-dir="${REPORT_DIR}" --report-prefix="windows"
+          critest --runtime-endpoint=npipe:////./pipe/containerd-containerd --ginkgo.focus="${FOCUS}" --ginkgo.skip="${SKIP}" --report-dir="${REPORT_DIR}" --report-prefix="windows"
           TEST_RC=$?
           test $TEST_RC -ne 0 && cat ${REPORT_DIR}/containerd.log
           set -o errexit

--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -88,7 +88,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           make
-          sudo PATH=$PATH GOPATH=$GOPATH make install
+          sudo -E PATH=$PATH make install
         working-directory: ${{ github.workspace }}/src/github.com/containerd/containerd
 
       - name: Install containerd on Windows
@@ -103,7 +103,7 @@ jobs:
         env:
           RUNC_FLAVOR: ${{matrix.runc}}
         run: |
-          sudo GOPATH=$GOPATH script/setup/install-runc
+          sudo -E PATH=$PATH script/setup/install-runc
         working-directory: src/github.com/containerd/containerd
 
       - name: Build Windows container shims
@@ -126,7 +126,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           make
-          sudo PATH=$PATH GOPATH=$GOPATH make install
+          sudo -E PATH=$PATH make install
         working-directory: ${{ github.workspace }}/src/github.com/kubernetes-sigs/cri-tools
 
       - name: Build cri-tools on Windows
@@ -277,7 +277,7 @@ jobs:
           sudo /usr/local/bin/ctr -a ${BDIR}/c.sock version
           sudo /usr/local/sbin/runc --version
 
-          sudo PATH=$PATH GOPATH=$GOPATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
+          sudo -E PATH=$PATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
           TEST_RC=$?
           test $TEST_RC -ne 0 && cat ${BDIR}/containerd-cri.log
           sudo pkill containerd

--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -57,7 +57,7 @@ jobs:
           FILENAME=${TARBALL##*/}
           DIR=${FILENAME%%.*}
           pushd "$DIR" || exit
-          sudo PATH=$PATH GOPATH=$GOPATH make install
+          sudo -E PATH=$PATH make install
 
       - name: Install CRI-O latest version
         if: ${{matrix.version == 'v1.19.0'}}
@@ -68,7 +68,7 @@ jobs:
           gsutil cp $RELEASE .
           tar xf $TARBALL
           pushd $DIR || exit
-          sudo PATH=$PATH GOPATH=$GOPATH make install
+          sudo -E PATH=$PATH make install
 
       - name: Configure and start CRI-O
         run: |
@@ -85,12 +85,12 @@ jobs:
       - name: Build cri-tools
         run: |
           make
-          sudo PATH=$PATH GOPATH=$GOPATH make install
+          sudo -E PATH=$PATH make install
         working-directory: ${{ github.workspace }}/src/github.com/kubernetes-sigs/cri-tools
 
       - name: Run critest
         run: |
-          sudo PATH=$PATH GOPATH=$GOPATH critest \
+          sudo -E PATH=$PATH critest \
             --runtime-endpoint=unix:///var/run/crio/crio.sock \
             --ginkgo.flakeAttempts=3 \
             --parallel=$(nproc)

--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -41,7 +41,7 @@ jobs:
           sudo cp $(command -v ginkgo) /usr/local/bin
 
       - name: Setup GCloud
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
 
       - name: Install CRI-O latest master
         if: ${{matrix.version == 'master'}}

--- a/.github/workflows/dockershim.yml
+++ b/.github/workflows/dockershim.yml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install Go 1.13
+      - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: '1.15'

--- a/.github/workflows/dockershim.yml
+++ b/.github/workflows/dockershim.yml
@@ -36,18 +36,18 @@ jobs:
       - name: Build cri-tools
         run: |
           make
-          sudo PATH=$PATH GOPATH=$GOPATH make install
+          sudo -E PATH=$PATH make install
         working-directory: ${{ github.workspace }}/src/github.com/kubernetes-sigs/cri-tools
 
       - name: Build cri-dockerd
         run: |
-          sudo env GOPATH=$GOPATH hack/install-cri-dockerd.sh
+          sudo -E PATH=$PATH hack/install-cri-dockerd.sh
         working-directory: ${{ github.workspace }}/src/github.com/kubernetes-sigs/cri-tools
 
       - name: Run critest
         run: |
-          sudo make install.ginkgo
-          sudo env GOPATH=$GOPATH hack/run-dockershim-critest.sh
+          sudo -E PATH=$PATH make install.ginkgo
+          sudo -E PATH=$PATH hack/run-dockershim-critest.sh
         working-directory: ${{ github.workspace }}/src/github.com/kubernetes-sigs/cri-tools
 
       - name: Dump docker logs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,5 +45,5 @@ jobs:
           sudo chmod +x /usr/bin/runc &&\
           runc --version
 
-          sudo -E env "PATH=$PATH" make all install test-e2e TESTFLAGS=-v
+          sudo -E PATH=$PATH make all install test-e2e TESTFLAGS=-v
         working-directory: src/github.com/kubernetes-sigs/cri-tools


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

##### 1. .github/workflows/containerd.yml: simplify
    
Remove `BDIR=$BDIR` from sudo invocations, as it is not used by commands
run by sudo, and the command line of sudo itself is built before running
sudo. Hope this explanation makes sense.
    
Also remove `PATH=$PATH GOPATH=$GOPATH` assignments. Those could make
sense with sudo, but do not make any sense without.

##### 2. github/workflows: fix GOROOT under sudo

It was found that using sudo (as in e.g. sudo make install) results in
wrong GOROOT setting, which leads to various weird compilation bugs.

Here is how GOROOT is changed:

```diff
-GOROOT="/opt/hostedtoolcache/go/1.15.4/x64"
+GOROOT="/opt/hostedtoolcache/go/1.14.11/x64"
```
Here are some of the errors caused by it:

	# runtime/internal/sys
	compile: version "go1.14.11" does not match go tool version "go1.15.4"
	# sync/atomic
	flag provided but not defined: -p

Let's use `sudo -E PATH=$PATH` for all cases which might call go.
This will make sure that proper go version is used (from $PATH), and
also that all the environment variables that it might need are correctly
set.

##### 3. .github/workflows/dockershim: fix a step name

##### 4. .github/workflows/crio.yml: fix a deprecation notice

Fixes this:
    
> GoogleCloudPlatform/github-actions/setup-gcloud has been deprecated.
> Please use google-github-actions/setup-gcloud

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

* Please see individual commits for details.
* This should fix CI failure observed in https://github.com/kubernetes-sigs/cri-tools/pull/684
* This PR is additionally tested in https://github.com/kubernetes-sigs/cri-tools/pull/690

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
