### PR TITLE
Add mechanism for building and pushing test user images to staging location

### DIFF
--- a/images/image-user/Makefile
+++ b/images/image-user/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2018 The Kubernetes Authors.
+# Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,34 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include ../../hack/make-rules/Makefile.manifest
-include ../../hack/make-rules/BASEIMAGES
+.PHONY: all manifest-tool push-manifest
 
-.PHONY: all test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group push-manifest
+MANIFEST_TOOL_DIR := $(shell mktemp -d)
+export PATH := $(MANIFEST_TOOL_DIR):$(PATH)
 
-REGISTRY = gcr.io/cri-tools
+MANIFEST_TOOL_VERSION := v0.7.0
+USERNAME ?= oauth2accesstoken
+PASSWORD ?= $(shell gcloud auth print-access-token)
+MANIFEST_TOOL = manifest-tool --username=$(USERNAME) --password=$(PASSWORD)
+
+space :=
+space +=
+comma := ,
+prefix_linux = $(addprefix linux/,$(strip $1))
+join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
+
+REGISTRY = gcr.io/$(PROJ_ID)
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 TAG = latest
 IMAGES_LIST = test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group
 
-all: test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group push-manifest
+all: manifest-tool push-manifest
 
-test-image-user-uid:
-	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=1002;)
-	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
+manifest-tool:
+	curl -sSL https://github.com/estesp/manifest-tool/releases/download/$(MANIFEST_TOOL_VERSION)/manifest-tool-linux-amd64 > $(MANIFEST_TOOL_DIR)/manifest-tool
+	chmod +x $(MANIFEST_TOOL_DIR)/manifest-tool
 
-test-image-user-username:
-	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=www-data;)
-	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
-
-
-test-image-user-uid-group:
-	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=1003:users ;)
-	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
-
-test-image-user-username-group:
-	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=www-data:100 ;)
-	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
-
-push-manifest: manifest-tool
+push-manifest:
 	$(foreach image,$(IMAGES_LIST),$(MANIFEST_TOOL) push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)

--- a/images/image-user/cloudbuild-images.yaml
+++ b/images/image-user/cloudbuild-images.yaml
@@ -1,0 +1,57 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: gcr.io/cloud-builders/docker
+    id : 'build-amd64'
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-amd64
+      - --build-arg=ARCH=amd64
+      - --build-arg=USER=1002;
+      - .
+  - name: gcr.io/cloud-builders/docker
+    id : 'build-arm'
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-arm
+      - --build-arg=ARCH=arm32v6
+      - --build-arg=USER=1002;
+      - .
+  - name: gcr.io/cloud-builders/docker
+    id : 'build-arm64'
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-arm64
+      - --build-arg=ARCH=arm64v8
+      - --build-arg=USER=1002;
+      - .
+  - name: gcr.io/cloud-builders/docker
+    id : 'build-ppc64le'
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-ppc64le
+      - --build-arg=ARCH=ppc64le
+      - --build-arg=USER=1002;
+      - .
+  - name: gcr.io/cloud-builders/docker
+    id : 'build-s390x'
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-s390x
+      - --build-arg=ARCH=s390x
+      - --build-arg=USER=1002;
+      - .
+substitutions:
+  # _IMAGE_TYPE needs to be set to the image that is to be built
+  # Can be one of the following: 'uid', 'username', 'uid-group'
+  # or 'username-group'
+  _IMAGE_TYPE: 'uid'
+images:
+  - 'gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-amd64'
+  - 'gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-arm'
+  - 'gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-arm64'
+  - 'gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-ppc64le'
+  - 'gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-s390x'

--- a/images/image-user/cloudbuild-manifests.yaml
+++ b/images/image-user/cloudbuild-manifests.yaml
@@ -1,0 +1,10 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+    entrypoint: make
+    env:
+    - PROJ_ID=$PROJECT_ID


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind test-infra

#### What this PR does / why we need it:
The test images are pushed to the cri-tools GCR service account for unit tests. Currently we need someone with the authentication to login, pull this PR and run make all-push to refresh the test images. This is all a bit manual and difficult to make changes. This PR adds mechanism to use staging from Kubernetes test-infra to automate the process.

#### Which issue(s) this PR fixes:

Partial #687 

#### Special notes for your reviewer:

This is a first draft at finding a pattern to build and push test images to staging location. At the moment, there is some repetition especially in manifest Makefile as [make GCB process](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md#makefile-build-example) doesn't seem to handle including other makefiles like in [hack](https://github.com/kubernetes-sigs/cri-tools/tree/master/hack/make-rules). It seems to require a make file to be named `Makefile` also.
 
This can be tested locally by connecting to you GCR instance from CLI and then running in order:

1. gcloud builds submit --config cloudbuild-images.yaml --substitutions=_IMAGE_TYPE="uid"
2. gcloud builds submit --config cloudbuild-images.yaml --substitutions=_IMAGE_TYPE="username"
3. gcloud builds submit --config cloudbuild-images.yaml --substitutions=_IMAGE_TYPE="uid-group"
4. gcloud builds submit --config cloudbuild-images.yaml --substitutions=_IMAGE_TYPE="username-group"
5. gcloud builds submit --config cloudbuild-manifests.yaml

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
