### PR TITLE
Fix(ci): CRI Test with Windows containerd runtime

### DIFF
--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -18,7 +18,7 @@ jobs:
         # ║ hcshim           │           │ runhcs  ║
         # ╚══════════════════╧═══════════╧═════════╝
         os: [ubuntu-18.04, windows-2019]
-        version: [master, v1.4.1]
+        version: [master, v1.4.3]
         runtime: [io.containerd.runtime.v1.linux, io.containerd.runc.v1, io.containerd.runc.v2, containerd-shim-runhcs-v1]
         runc: [runc, crun]
         exclude:
@@ -125,7 +125,11 @@ jobs:
           cd src/github.com/containerd/containerd
           mingw32-make.exe binaries
           bindir="$(pwd)"/bin
-          SHIM_COMMIT=$(grep Microsoft/hcsshim vendor.conf | awk '{print $2}')
+          if [ -f "vendor.conf" ]; then
+              SHIM_COMMIT=$(grep 'Microsoft/hcsshim' vendor.conf | awk '{print $2}')
+          else
+              SHIM_COMMIT=$(grep 'Microsoft/hcsshim ' go.mod | awk '{print $2}')
+          fi
           cd ../../Microsoft/hcsshim
           git fetch --tags origin "${SHIM_COMMIT}"
           git checkout "${SHIM_COMMIT}"


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Containerd changed how its `hcsshim` version is stored in its repo (https://github.com/containerd/containerd/pull/4760)  and this broke the CRI test for the containerd (master) runtime on Windows. This PR updates the test to get the version from the go module file instead. 

Also, updated to the latest containerd version `1.4.3`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The containerd change (https://github.com/containerd/containerd/pull/4760) is targeted for 1.5. Therefore, need to still test against `vendor.conf` file for releases prior to its release.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
