### PR TITLE
add index.docker.io/ prefix to image: in docs/example

### DIFF
--- a/docs/examples/container-config.json
+++ b/docs/examples/container-config.json
@@ -3,7 +3,7 @@
     "name": "busybox"
   },
   "image":{
-    "image": "busybox"
+    "image": "docker.io/busybox"
   },
   "command": [
     "top"

--- a/docs/examples/container-config.yaml
+++ b/docs/examples/container-config.yaml
@@ -1,7 +1,7 @@
 metadata:
   name: busybox
 image:
-  image: busybox:latest
+  image: docker.io/busybox:latest
 command:
 - top
 log_path: busybox.0.log


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it: 

https://wiki.archlinux.org/index.php/CRI-O#Testing Docker Hub is not hard-coded, registry prefix best explicit.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Hope this makes sense.

#### Does this PR introduce a user-facing change? 

NONE