### PR TITLE
support mips64le architecture.

### DIFF
--- a/hack/make-rules/BASEIMAGES
+++ b/hack/make-rules/BASEIMAGES
@@ -3,3 +3,4 @@ arm=arm32v6
 arm64=arm64v8
 ppc64le=ppc64le
 s390x=s390x
+mips64le=mips64le

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -30,6 +30,7 @@ CRI_CTL_PLATFORMS=(
     linux/arm64
     linux/ppc64le
     linux/s390x
+    linux/mips64le
     windows/amd64
     windows/386
     darwin/amd64

--- a/images/hostnet-nginx/Makefile
+++ b/images/hostnet-nginx/Makefile
@@ -18,7 +18,7 @@ include ../../hack/make-rules/BASEIMAGES
 .PHONY: all push-manifest
 
 REGISTRY = gcr.io/cri-tools
-ALL_ARCH = amd64 arm64 ppc64le s390x
+ALL_ARCH = amd64 arm64 ppc64le s390x mips64le
 TAG = latest
 IMAGES_LIST = hostnet-nginx
 PORT=12003

--- a/images/image-test/Makefile
+++ b/images/image-test/Makefile
@@ -19,7 +19,7 @@ include ../../hack/make-rules/BASEIMAGES
 
 REGISTRY ?= gcr.io/cri-tools
 TAG = latest
-ALL_ARCH = amd64 arm64 ppc64le s390x
+ALL_ARCH = amd64 arm64 ppc64le s390x mips64le
 IMAGES_LIST = test-image-1 test-image-2 test-image-3 test-image-latest test-image-digest
 IMAGE_TAGS_LIST = test all
 SAME_IMAGE_TAGS_LIST = 1 2 3

--- a/images/image-user/Makefile
+++ b/images/image-user/Makefile
@@ -31,7 +31,7 @@ prefix_linux = $(addprefix linux/,$(strip $1))
 join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
 
 REGISTRY = gcr.io/$(PROJ_ID)
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
+ALL_ARCH = amd64 arm arm64 ppc64le s390x mips64le
 TAG = latest
 IMAGES_LIST = test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group
 

--- a/images/image-user/cloudbuild-images.yaml
+++ b/images/image-user/cloudbuild-images.yaml
@@ -45,6 +45,14 @@ steps:
       - --build-arg=ARCH=s390x
       - --build-arg=USER=1002;
       - .
+  - name: gcr.io/cloud-builders/docker
+    id : 'build-mips64le'
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-mips64le
+      - --build-arg=ARCH=mips64le
+      - --build-arg=USER=1002;
+      - .
 substitutions:
   # _IMAGE_TYPE needs to be set to the image that is to be built
   # Can be one of the following: 'uid', 'username', 'uid-group'
@@ -56,3 +64,4 @@ images:
   - 'gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-arm64'
   - 'gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-ppc64le'
   - 'gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-s390x'
+  - 'gcr.io/$PROJECT_ID/test-image-user-$_IMAGE_TYPE-mips64le'


### PR DESCRIPTION
#### What type of PR is this?
cri-tools add mips64le architecture.
#### What this PR does / why we need it:
support more cpu architecture, convenient for more users to use.
#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Add support for mips64le architecture as release-artifact
```
@mrunalp @runcom


