### PR TITLE
Add global signal handler for Interrupt signal

### DIFF
--- a/cmd/crictl/main_unix.go
+++ b/cmd/crictl/main_unix.go
@@ -18,8 +18,15 @@ limitations under the License.
 
 package main
 
+import (
+	"os"
+	"syscall"
+)
+
 const (
 	defaultConfigPath = "/etc/crictl.yaml"
 )
 
 var defaultRuntimeEndpoints = []string{"unix:///var/run/dockershim.sock", "unix:///run/containerd/containerd.sock", "unix:///run/crio/crio.sock"}
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/cmd/crictl/main_windows.go
+++ b/cmd/crictl/main_windows.go
@@ -26,6 +26,8 @@ import (
 var defaultRuntimeEndpoints = []string{"npipe:////./pipe/dockershim", "npipe:////./pipe/containerd", "npipe:////./pipe/crio"}
 var defaultConfigPath string
 
+var shutdownSignals = []os.Signal{os.Interrupt}
+
 func init() {
 	defaultConfigPath = filepath.Join(os.Getenv("USERPROFILE"), ".crictl", "crictl.yaml")
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig node

#### What this PR does / why we need it:

Fix Ctrl+C not working with "crictl logs -f" command.
Switch to the global signal handler in following commands:
  * crictl port-forward
  * crictl stats -w

#### Which issue(s) this PR fixes:
Fixes #673

#### Special notes for your reviewer:
This PR also introduces a global Interrupt signal handling mechanism for long-running commands.
When programmer calls `SetupInterruptSignalHandler()`, a global read-only `stopCh` is returned.
Behind the scene:
  * It setups a global signal handler monitoring Interrupt signals.
  * The `stopCh` will be closed when Interrupt signal received.
  * The current program exits immediately on receiving the Interrupt signal twice.
  * No behavior change if `SetupInterruptSignalHandler()` is not called.

#### Does this PR introduce a user-facing change?

```release-note
"crictl logs -f" command now can be stopped with Ctrl+C
```