### PR TITLE
fix StartedAt and FinishedAt of the container status 

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -794,9 +794,22 @@ func marshalContainerStatus(cs *pb.ContainerStatus) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	jsonMap["createdAt"] = time.Unix(0, cs.CreatedAt).Format(time.RFC3339Nano)
-	jsonMap["startedAt"] = time.Unix(0, cs.StartedAt).Format(time.RFC3339Nano)
-	jsonMap["finishedAt"] = time.Unix(0, cs.FinishedAt).Format(time.RFC3339Nano)
+	var startedAt, finishedAt time.Time
+	if cs.State != pb.ContainerState_CONTAINER_CREATED {
+		// If container is not in the created state, we have tried and
+		// started the container. Set the startedAt.
+		startedAt = time.Unix(0, cs.StartedAt)
+	}
+	if cs.State == pb.ContainerState_CONTAINER_EXITED ||
+		(cs.State == pb.ContainerState_CONTAINER_UNKNOWN && cs.FinishedAt > 0) {
+		// If container is in the exit state, set the finishedAt.
+		// Or if container is in the unknown state and FinishedAt > 0, set the finishedAt
+		finishedAt = time.Unix(0, cs.FinishedAt)
+	}
+	jsonMap["startedAt"] = startedAt.Format(time.RFC3339Nano)
+	jsonMap["finishedAt"] = finishedAt.Format(time.RFC3339Nano)
 	return marshalMapInOrder(jsonMap, *cs)
 }
 


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Finished time is always `1754-08-31T06:49:24.128654848+08:05` in the run and create states, because `FinishedAt` is `-6795364578871345152`
```sh
[root@iceber-3 ~]# crictl inspect 587444fc34ec9
{
  "status": {
    "id": "587444fc34ec9846c163d0c74bbf985ac73662817a89e16b7328b955a03ef902",
    "metadata": {
      "attempt": 6,
      "name": "dx-arch-stolon-sentinel"
    },
    "state": "CONTAINER_RUNNING",
    "createdAt": "2021-03-01T16:45:23.390180141+08:00",
    "startedAt": "2021-03-01T16:45:23.544299436+08:00",
    "finishedAt": "1754-08-31T06:49:24.128654848+08:05",
    "exitCode": 0,
```
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
Fixed output in the running state:
```sh
[root@iceber-3 ~]# ./crictl inspect 587444fc34ec9
{
  "status": {
    "id": "587444fc34ec9846c163d0c74bbf985ac73662817a89e16b7328b955a03ef902",
    "metadata": {
      "attempt": 6,
      "name": "dx-arch-stolon-sentinel"
    },
    "state": "CONTAINER_RUNNING",
    "createdAt": "2021-03-01T16:45:23.390180141+08:00",
    "startedAt": "2021-03-01T16:45:23.544299436+08:00",
    "finishedAt": "0001-01-01T00:00:00Z",
    "exitCode": 0,
```

#### Does this PR introduce a user-facing change?
