### PR TITLE
Bump gcb-docker-gcloud image to v20210331-c732583

### DIFF
--- a/images/image-user/cloudbuild-manifests.yaml
+++ b/images/image-user/cloudbuild-manifests.yaml
@@ -5,7 +5,7 @@ timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
     entrypoint: make
     env:
     - PROJ_ID=$PROJECT_ID


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
This will re-trigger the `image-user` builds and tries to mitigate the
current `403` issues when pulling container images from
gcr.io/cri-tools.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
