### PR TITLE
Move from `gcr.io/cri-tools` to `gcr.io/k8s-staging-cri-tools`

### DIFF
--- a/hack/make-rules/Makefile.manifest
+++ b/hack/make-rules/Makefile.manifest
@@ -22,8 +22,8 @@ USERNAME ?= oauth2accesstoken
 PASSWORD ?= $(shell gcloud auth print-access-token)
 MANIFEST_TOOL = manifest-tool --username=$(USERNAME) --password=$(PASSWORD)
 
-space :=
-space +=
+empty :=
+space := $(empty) $(empty)
 comma := ,
 prefix_linux = $(addprefix linux/,$(strip $1))
 join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))

--- a/images/hostnet-nginx/Makefile
+++ b/images/hostnet-nginx/Makefile
@@ -17,7 +17,7 @@ include ../../hack/make-rules/BASEIMAGES
 
 .PHONY: all push-manifest
 
-REGISTRY = gcr.io/cri-tools
+REGISTRY = gcr.io/k8s-staging-cri-tools
 ALL_ARCH = amd64 arm64 ppc64le s390x mips64le
 TAG = latest
 IMAGES_LIST = hostnet-nginx

--- a/images/image-test-win/build.ps1
+++ b/images/image-test-win/build.ps1
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$Registry = "gcr.io/cri-tools"
+$Registry = "gcr.io/k8s-staging-cri-tools"
 $Tag = "latest"
 $ImagesList = @(
 	"win-test-image-1:$Tag", "win-test-image-2:$Tag", "win-test-image-3:$Tag",

--- a/images/image-test/Makefile
+++ b/images/image-test/Makefile
@@ -17,7 +17,7 @@ include ../../hack/make-rules/BASEIMAGES
 
 .PHONY: all-push all-push-images push-manifest
 
-REGISTRY ?= gcr.io/cri-tools
+REGISTRY ?= gcr.io/k8s-staging-cri-tools
 TAG = latest
 ALL_ARCH = amd64 arm64 ppc64le s390x mips64le
 IMAGES_LIST = test-image-1 test-image-2 test-image-3 test-image-latest test-image-digest

--- a/images/image-user/Makefile
+++ b/images/image-user/Makefile
@@ -24,13 +24,13 @@ USERNAME ?= oauth2accesstoken
 PASSWORD ?= $(shell gcloud auth print-access-token)
 MANIFEST_TOOL = manifest-tool --username=$(USERNAME) --password=$(PASSWORD)
 
-space :=
-space +=
+empty :=
+space := $(empty) $(empty)
 comma := ,
 prefix_linux = $(addprefix linux/,$(strip $1))
 join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
 
-REGISTRY = gcr.io/$(PROJ_ID)
+REGISTRY = gcr.io/k8s-staging-cri-tools
 ALL_ARCH = amd64 arm arm64 ppc64le s390x mips64le
 TAG = latest
 IMAGES_LIST = test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group

--- a/images/image-user/cloudbuild-manifests.yaml
+++ b/images/image-user/cloudbuild-manifests.yaml
@@ -7,5 +7,3 @@ options:
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
     entrypoint: make
-    env:
-    - PROJ_ID=$PROJECT_ID

--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -86,26 +86,28 @@ var _ = framework.AddBeforeSuiteCallback(func() {
 // Image test constants
 
 const (
-	testImageUserUID           = "gcr.io/cri-tools/test-image-user-uid"
+	registry = "gcr.io/k8s-staging-cri-tools/"
+
+	testImageUserUID           = registry + "test-image-user-uid"
 	imageUserUID               = int64(1002)
-	testImageUserUsername      = "gcr.io/cri-tools/test-image-user-username"
+	testImageUserUsername      = registry + "test-image-user-username"
 	imageUserUsername          = "www-data"
-	testImageUserUIDGroup      = "gcr.io/cri-tools/test-image-user-uid-group"
+	testImageUserUIDGroup      = registry + "test-image-user-uid-group"
 	imageUserUIDGroup          = int64(1003)
-	testImageUserUsernameGroup = "gcr.io/cri-tools/test-image-user-username-group"
+	testImageUserUsernameGroup = registry + "test-image-user-username-group"
 	imageUserUsernameGroup     = "www-data"
 
 	// Linux defaults
-	testLinuxImageWithoutTag        = "gcr.io/cri-tools/test-image-latest"
-	testLinuxImageWithTag           = "gcr.io/cri-tools/test-image-tag:test"
-	testLinuxImageWithDigest        = "gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343"
-	testLinuxImageWithAllReferences = "gcr.io/cri-tools/test-image-tag:all"
+	testLinuxImageWithoutTag        = registry + "test-image-latest"
+	testLinuxImageWithTag           = registry + "test-image-tag:test"
+	testLinuxImageWithDigest        = registry + "test-image-digest@sha256:9700f9a2f5bf2c45f2f605a0bd3bce7cf37420ec9d3ed50ac2758413308766bf"
+	testLinuxImageWithAllReferences = registry + "test-image-tag:all"
 
 	// Windows defaults
-	testWindowsImageWithoutTag        = "gcr.io/cri-tools/win-test-image-latest"
-	testWindowsImageWithTag           = "gcr.io/cri-tools/win-test-image-tag:test"
-	testWindowsImageWithDigest        = "gcr.io/cri-tools/win-test-image-digest@sha256:ed127b3a098d6ada53fff1b33ab3ea421dc7ebb06e0c2abded9d3e84bb6842b0"
-	testWindowsImageWithAllReferences = "gcr.io/cri-tools/win-test-image-tag:all"
+	testWindowsImageWithoutTag        = registry + "win-test-image-latest"
+	testWindowsImageWithTag           = registry + "win-test-image-tag:test"
+	testWindowsImageWithDigest        = registry + "win-test-image-digest@sha256:0e8cc62aee4ed03eb85150eb86e5d1fd7bda705511b8951fe6507835cbd34be3"
+	testWindowsImageWithAllReferences = registry + "win-test-image-tag:all"
 )
 
 var (
@@ -132,26 +134,26 @@ var (
 
 	// Linux defaults
 	testLinuxDifferentTagDifferentImageList = []string{
-		"gcr.io/cri-tools/test-image-1:latest",
-		"gcr.io/cri-tools/test-image-2:latest",
-		"gcr.io/cri-tools/test-image-3:latest",
+		registry + "test-image-1:latest",
+		registry + "test-image-2:latest",
+		registry + "test-image-3:latest",
 	}
 	testLinuxDifferentTagSameImageList = []string{
-		"gcr.io/cri-tools/test-image-tags:1",
-		"gcr.io/cri-tools/test-image-tags:2",
-		"gcr.io/cri-tools/test-image-tags:3",
+		registry + "test-image-tags:1",
+		registry + "test-image-tags:2",
+		registry + "test-image-tags:3",
 	}
 
 	// Windows defaults
 	testWindowsDifferentTagDifferentImageList = []string{
-		"gcr.io/cri-tools/win-test-image-1:latest",
-		"gcr.io/cri-tools/win-test-image-2:latest",
-		"gcr.io/cri-tools/win-test-image-3:latest",
+		registry + "win-test-image-1:latest",
+		registry + "win-test-image-2:latest",
+		registry + "win-test-image-3:latest",
 	}
 	testWindowsDifferentTagSameImageList = []string{
-		"gcr.io/cri-tools/win-test-image-tags:1",
-		"gcr.io/cri-tools/win-test-image-tags:2",
-		"gcr.io/cri-tools/win-test-image-tags:3",
+		registry + "win-test-image-tags:1",
+		registry + "win-test-image-tags:2",
+		registry + "win-test-image-tags:3",
 	}
 )
 
@@ -193,7 +195,7 @@ const (
 
 	// Linux defaults
 	webServerLinuxImage        = "nginx"
-	hostNetWebServerLinuxImage = "gcr.io/cri-tools/hostnet-nginx-" + runtime.GOARCH
+	hostNetWebServerLinuxImage = registry + "hostnet-nginx-" + runtime.GOARCH
 
 	// Windows defaults
 	webServerWindowsImage        = "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -35,24 +35,27 @@ var _ = t.Describe("pull", func() {
 		t.StopCrio(testDir, crio)
 	})
 
-	const imageSuccessText = "Image is up to date"
+	const (
+		imageSuccessText = "Image is up to date"
+		registry         = "gcr.io/k8s-staging-cri-tools/"
+	)
 
 	It("should succeed without tag or digest", func() {
 		t.CrictlExpectSuccessWithEndpoint(endpoint,
-			"pull gcr.io/cri-tools/test-image-1",
+			"pull "+registry+"test-image-1",
 			imageSuccessText)
 	})
 
 	It("should succeed with tag", func() {
 		t.CrictlExpectSuccessWithEndpoint(endpoint,
-			"pull gcr.io/cri-tools/test-image-1:latest",
+			"pull "+registry+"test-image-1:latest",
 			imageSuccessText)
 	})
 
 	It("should succeed with digest", func() {
 		t.CrictlExpectSuccessWithEndpoint(endpoint,
-			"pull gcr.io/cri-tools/test-image-digest"+
-				"@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343",
+			"pull "+registry+"test-image-digest"+
+				"@sha256:9700f9a2f5bf2c45f2f605a0bd3bce7cf37420ec9d3ed50ac2758413308766bf",
 			imageSuccessText)
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
This moves the images from `gcr.io/cri-tools` to the community
maintained project `gcr.io/k8s-staging-cri-tools` as fix for many broken
CI systems.

I'm not able to build and push the windows images for now, which leaves
them untouched in this patch.

As a follow-up, we have to put the same automation in place for
`images/hostnet-nginx` and `images/image-test` as we have it for
`images/image-user`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Requires https://github.com/kubernetes-sigs/cri-tools/pull/734
#### Special notes for your reviewer:
I pushed the images manually for now to `k8s-staging-cri-tools`.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Moved all test images to the `gcr.io/k8s-staging-cri-tools` registry
```
