### PR TITLE
Trim build paths for binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ critest:
 $(CRITEST):
 	CGO_ENABLED=0 $(GO_TEST) -c -o $@ \
 		-ldflags '$(GO_LDFLAGS)' \
+		-trimpath \
 		-tags '$(BUILDTAGS)' \
 	     $(PROJECT)/cmd/critest
 
@@ -75,6 +76,7 @@ crictl:
 $(CRICTL):
 	CGO_ENABLED=0 $(GO_BUILD) -o $@ \
 		-ldflags '$(GO_LDFLAGS)' \
+		-trimpath \
 		-tags '$(BUILDTAGS)' \
 		$(PROJECT)/cmd/crictl
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This helps to produce a more uniform output, especially for `critest`:

```
[Fail] [k8s.io] Container runtime should support log [BeforeEach] runtime should support reopening container log [Conformance]
github.com/kubernetes-sigs/cri-tools/pkg/framework/util.go:225
```
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Trim file paths from `critest` outputs
```
