### PR TITLE
Update golangci-lint to v1.40.1 and fix lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,18 +7,28 @@ linters:
   enable:
     - deadcode
     - depguard
+    - durationcheck
+    - forcetypeassert
     - gofmt
     - goimports
     - govet
+    - importas
     - ineffassign
+    - makezero
     - misspell
     - nakedret
+    - nilerr
     - prealloc
+    - predeclared
+    - promlinter
     - structcheck
+    - tagliatelle
     - typecheck
     - varcheck
+    - wastedassign
     # - asciicheck
     # - bodyclose
+    # - cyclop
     # - dogsled
     # - dupl
     # - errcheck
@@ -26,6 +36,7 @@ linters:
     # - exhaustive
     # - exhaustivestruct
     # - exportloopref
+    # - forbidigo
     # - funlen
     # - gci
     # - gochecknoglobals
@@ -41,23 +52,26 @@ linters:
     # - goheader
     # - golint
     # - gomnd
+    # - gomoddirectives
     # - gomodguard
     # - goprintffuncname
-    # - gosec (gas)
-    # - gosimple (megacheck)
-    # - interfacer
+    # - gosec
+    # - gosimple
+    # - ifshort
     # - lll
-    # - maligned
     # - nestif
     # - nlreturn
     # - noctx
     # - nolintlint
+    # - paralleltest
+    # - revive
     # - rowserrcheck
     # - scopelint
     # - sqlclosecheck
     # - staticcheck
     # - stylecheck
     # - testpackage
+    # - thelper
     # - tparallel
     # - unconvert
     # - unparam

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ install.lint: $(GOLANGCI_LINT)
 
 $(GOLANGCI_LINT):
 	export \
-		VERSION=v1.32.2 \
+		VERSION=v1.40.1 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=${BUILD_BIN_PATH} && \
 	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION

--- a/cmd/crictl/stats.go
+++ b/cmd/crictl/stats.go
@@ -154,7 +154,7 @@ func ContainerStats(client pb.RuntimeServiceClient, opts statsOptions) error {
 			return err
 		}
 	} else {
-		s := make(chan os.Signal)
+		s := make(chan os.Signal, 1)
 		signal.Notify(s, os.Interrupt)
 		go func() {
 			<-s


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
This updates golangci-lint to the latest release and fixes new lints. It
also enables linters which do not report any issue.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
