### PR TITLE
Update critest Windows tests.

### DIFF
--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -96,7 +96,7 @@ const (
 	DefaultLinuxContainerImage string = "busybox:1.28"
 
 	// DefaultWindowsContainerImage default container image for Windows
-	DefaultWindowsContainerImage string = "mcr.microsoft.com/windows/servercore:ltsc2019"
+	DefaultWindowsContainerImage string = "k8s.gcr.io/e2e-test-images/busybox:1.29-1"
 )
 
 // Set the constants based on operating system and flags

--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -49,8 +49,8 @@ var (
 
 	// Windows defaults
 	echoHelloWindowsCmd      = []string{"powershell", "-c", "echo hello"}
-	sleepWindowsCmd          = []string{"powershell", "-c", "sleep", "4321"}
-	checkSleepWindowsCmd     = []string{"powershell", "-c", "tasklist | findstr sleep; exit 0"}
+	sleepWindowsCmd          = []string{"powershell", "-c", "start-sleep 4321"}
+	checkSleepWindowsCmd     = []string{"powershell", "-c", "get-process | findstr sleep; exit 0"}
 	shellWindowsCmd          = []string{"cmd", "/Q"}
 	pauseWindowsCmd          = []string{"powershell", "-c", "ping -t localhost"}
 	logDefaultWindowsCmd     = []string{"powershell", "-c", "echo '" + defaultLog + "'"}
@@ -198,8 +198,8 @@ const (
 	hostNetWebServerLinuxImage = registry + "hostnet-nginx-" + runtime.GOARCH
 
 	// Windows defaults
-	webServerWindowsImage        = "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"
-	hostNetWebServerWindowsImage = "mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019"
+	webServerWindowsImage        = "k8s.gcr.io/e2e-test-images/nginx:1.14-1"
+	hostNetWebServerWindowsImage = "k8s.gcr.io/e2e-test-images/nginx:1.14-1"
 )
 
 var (


### PR DESCRIPTION
Update images used. Given the size of the Windows container images,
pull times make these tests unresonable for CI work. There has been
a lot of work done around the test images for K8s E2E tests on Windows,
including creating small images based on Nanoserver and also creating
a image promoting process for automated build & publish of images.

This commit also changes a small command for a test that was not
correct for Windows.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
