### PR TITLE
Added dropping/adding `ALL` capabilities case to critest

### DIFF
--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -8,7 +8,7 @@ jobs:
   linux-build-and-critest-cri-o:
     strategy:
       matrix:
-        version: [master, v1.20.0]
+        version: [master]
     name: ${{matrix.version}} / linux amd64
     runs-on: ubuntu-18.04
     steps:
@@ -57,17 +57,6 @@ jobs:
         if: ${{matrix.version == 'master'}}
         run: |
           curl https://raw.githubusercontent.com/cri-o/cri-o/master/scripts/get | sudo bash
-
-      - name: Install CRI-O latest version
-        if: ${{matrix.version == 'v1.20.0'}}
-        run: |
-          DIR=crio-${{matrix.version}}
-          TARBALL=$DIR.tar.gz
-          RELEASE=gs://k8s-conform-cri-o/artifacts/$TARBALL
-          gsutil cp $RELEASE .
-          tar xf $TARBALL
-          pushd $DIR || exit
-          sudo -E PATH=$PATH make install
 
       - name: Configure and start CRI-O
         run: |


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
We now test additionally adding and dropping `ALL` capabilities. Beside
that, another dropping `NET_RAW` test has been added.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Closes https://github.com/kubernetes-sigs/cri-tools/issues/773
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- Added dropping/adding `ALL` capabilities test. This also adds a test case for dropping a single `NET_RAW` capability.
```
