### PR TITLE
Updates E2E test images registry

### DIFF
--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -38,7 +38,7 @@ import (
 const (
 	nginxContainerImage string = "nginx:1.18"
 	localhost           string = "localhost/"
-	noNewPrivsImage     string = "gcr.io/kubernetes-e2e-test-images/nonewprivs:1.1"
+	noNewPrivsImage     string = "k8s.gcr.io/e2e-test-images/nonewprivs:1.3"
 )
 
 var _ = framework.KubeDescribe("Security Context", func() {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig testing
/kind cleanup

#### What this PR does / why we need it:

We're moving away from google.com gcp projects. These images are now on community-owned infra.

#### Which issue(s) this PR fixes:

Related: https://github.com/kubernetes/k8s.io/issues/1522

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
