### PR TITLE
Add SHA512 sum for release files

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -94,16 +94,22 @@ for platform in "${CRI_TEST_PLATFORMS[@]}"; do
 done
 
 printf "\n## Downloads\n\n"
-printf "| file | sha256 |\n"
-printf "| ---- | ------ |\n"
+printf "| file | sha256 | sha512\n"
+printf "| ---- | ------ | ------\n"
 
-# Show sha256 for release files
+# Show sha256/512 for release files
 if [[ "${OSTYPE}" == "darwin"* ]]; then
-    for file in $(ls "$OUTPUTDIR"); do
-        echo "| $file | $(shasum -a 256 "$OUTPUTDIR/$file" | sed -e "s,$OUTPUTDIR,," | tee "$OUTPUTDIR/$file.sha256" | awk '{print $1}') |"
+    for file in "$OUTPUTDIR"/*.tar.gz; do
+        SHA256=$(shasum -a 256 "$file" | sed -e "s,$file,," | awk '{print $1}' | tee "$file.sha256")
+        SHA512=$(shasum -a 512 "$file" | sed -e "s,$file,," | awk '{print $1}' | tee "$file.sha512")
+        BASE=$(basename "$file")
+        echo "| $BASE | $SHA256 | $SHA512 |"
     done
 else
-    for file in $(ls "$OUTPUTDIR"); do
-        echo "| $file | $(sha256sum -b "$OUTPUTDIR/$file" | sed -e "s,$OUTPUTDIR,," | tee "$OUTPUTDIR/$file.sha256" | awk '{print $1}') |"
+    for file in "$OUTPUTDIR"/*.tar.gz; do
+        SHA256=$(sha256sum -b "$file" | sed -e "s,$file,," | awk '{print $1}' | tee "$file.sha256")
+        SHA512=$(sha512sum -b "$file" | sed -e "s,$file,," | awk '{print $1}' | tee "$file.sha512")
+        BASE=$(basename "$file")
+        echo "| $BASE | $SHA256 | $SHA512 |"
     done
 fi


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
We now add the SHA512 files as well as values to the table output when
running `make release`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
New table output as example:

```markdown
## Downloads

| file | sha256 | sha512
| ---- | ------ | ------
| crictl-v1.22.0-darwin-amd64.tar.gz | 126ccd96074a254e70b2a345ad4e8fd3bc2f58dc1e6cfabbb982ed751358c58a | f1dc9946f4fdf69a3c833195831d6856e53401e2fdfaadc11fc210e4d14c8df2f1a9760c774f5e1005e9614d5bc418809e6298c35cd9ff624918e0d08c1c5fc5 |
| crictl-v1.22.0-linux-386.tar.gz | 6e2bcff528df5470313bdb983496fa2ee76876e705b729755fc7cbf794b57d2e | 16a01186cdae18ffd9f478f69cec993c8c6130478fe544f58ecf369450422bab101f5565b184b138b9f07ca650fc063610d5bc57e39a5b262427b5025da54927 |
| crictl-v1.22.0-linux-amd64.tar.gz | 535f152c4262348f102ef89482e4085318a8cc8f537db80434926e22d6fd5b2f | 552a82acd00d2195ee3b66ef891711a172662fb5af8cf849c045662a3062996be1ab868917aef62a12668faff1592ad992b5fecbc6b7aa69a399f6365d3f0cee |
| crictl-v1.22.0-linux-arm64.tar.gz | 19612789e247a35b18d0e669e59d3c0136f03593a77accad37c7019279c619ea | 32abb8abe8971ebb797cc951261977a76e5efdfe0272b3c6a42f8eca42dc65577dba3b57131b1efcc35e042d41ebc086b1fbc9b96f227de8508d4f16a60f8891 |
| crictl-v1.22.0-linux-arm.tar.gz | ef8af7d0a85ec6e8c75a4081a2d4eff070eaf02d985e8148fc610d46ae2329da | 0ee70d77e0003aa5a610bcde2e5fa9785f0028440c2c5efb28e3a38cb89656cdeeaa0122ad6e170bf02f6a2f46bfb3ce5e15aa625fb4cfc28b3d965a2af42bfb |
| crictl-v1.22.0-linux-mips64le.tar.gz | 3360d721880cbd6e7fcf75b45dd94daac540aacf8e13b4693f690a6edd14d997 | bff25a6225ad3e6ca69e47a67b89ddfbc6db2c4bb0e6b882534a8594ca1f91cde517457b0330ff98a998ca18975dee9d0fa4f5e0060ae1a6bb531711284d6004 |
| crictl-v1.22.0-linux-ppc64le.tar.gz | d46722523d7b977bcea5b004af6d595acdc71d7aafc38ab448bb751d3be7a0bb | 8964cefe48eabe18d9859f1bebfec9677f1050167ab4336d5bbf55a497804e9358a2d0e912a9b5d90427e7fc1353a3be2d1637bcf5000d49ef1fa3d486c7d3eb |
| crictl-v1.22.0-linux-s390x.tar.gz | ef680f1e83475bebde4401585ac66be69b7542a109c95ba5b7c6c3ccb7165fad | 839119f03008b93ee93be32074c8d0766c40b37550effedfdbe319299db92114571e15489e1fedf41a1d6a3485fef178396a4ad95d1411d500d2bdbccac6cf10 |
| crictl-v1.22.0-windows-386.tar.gz | f32527e3b88fdc1379646b40fe1c093b247fa4409dbc00ad120a9cc03b17555f | 555acbb29b5010988ecbfde4b13042a638d3d9648c0023168408779d6890167f323c41154d3e47d513e1e00ab87871ecc98b2dd17b45a3e0944f72852d2d275f |
| crictl-v1.22.0-windows-amd64.tar.gz | ae53c9508425849fc95b7f812d52305a3700a00aac6b6ce1e918fe63a2186a2d | 137e67cb8204e4c5f023cb70e278c6c28706b10fe388263400ba23de6b5f60c5c6e4133adb7ef5daa3030d14bc8963bfd1074134c9f33ccd1ff9702bcec41b88 |
| critest-v1.22.0-darwin-amd64.tar.gz | 70af9dafc53a65b9aeb1e49da1bf752761b43509409eaadaa568dc6270f46131 | bf863de829688ad5449ae7f9637e308f33180cde7dc4eb4fcb6987b809cc6a9c26101b99363084f1168ed8873d1f4579ddefce1aa7238c5b734536c0552b00e7 |
| critest-v1.22.0-linux-386.tar.gz | 7c39cb0ea87a3e691a40afc2b7d176408cc02dc516c65d337f2a6de5714b80fc | 409b3933bebb8f6095123cba4852f69907e8d06a48006056a82765cfe53bfb7ea94c1c9c42bb0c1097a53fc893f024995d913032d292bda27370c426d7a233a0 |
| critest-v1.22.0-linux-amd64.tar.gz | a12ec6f06b3ef538af17958287a43929179f88eab56aa5ddbeec6a49a73ebaa7 | 6e6770f8ccb3367b2a9d3d2063b2b2b331837d6f81a904641432aef56b25887faada4fe8eae3c0ae93786d64f08750d14fd315a4a102d18a75f5c19da4720df7 |
| critest-v1.22.0-linux-arm64.tar.gz | 79ccd3d4970f825f05540330531de0a1ad013ced44928473b8640b493d872704 | 7933076f32682d6042fa4f3d346c01b84bc7077861c1dcb4d2ef538619febc9f916cbdebfaff3fc3df0113678fe12f7fc011ea81c76b21c5bd3ec90da0ef7c02 |
| critest-v1.22.0-linux-arm.tar.gz | 444414f058cc2c277548e6e9bd2944d9410a9b084689754cbb84b85088046be6 | b421db82862882c44680e9839c6a9485b6f379b50cb07f11f2338efb6e8fe1db9d94deab3ac2b84325e38bb1528d1aa302ce9cffdc9b03eeeae15b2272e37f52 |
| critest-v1.22.0-windows-386.tar.gz | 6afab9dadf1e97e8f8874797c7a47f0a928cf381ed037557ac80dae3df94ffcf | efa2a63cc4b957dd8bde75c63503e423634e02aac879b1b3394f2ebeb4b6e609c55e2cee2729964d74050715ba946d8e4f9bc3274c015f1230a8021cacf69b26 |
| critest-v1.22.0-windows-amd64.tar.gz | 51db2d29a7d7dd43c68f4a70bbe166fe229a54e4f23685b01781252b1d3bc7ce | c69917f9b3288e538d2e196c2826a51e67e25bd8f58a9f140945dced3173e5ccebc003a39c5d95f1d04c41ed5adb37059721b22a1fa0dcd0ae121bdf67e78cbd |
```

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
