### PR TITLE
Add release publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: release
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  publish:
+    name: release
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+      - name: Set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-release-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-release-
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: src/github.com/kubernetes-sigs/cri-tools
+      - run: |
+          make release-notes
+          make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        working-directory: src/github.com/kubernetes-sigs/cri-tools
+      - uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: src/github.com/kubernetes-sigs/cri-tools/_output/releases/*
+          bodyFile: src/github.com/kubernetes-sigs/cri-tools/release-notes.md
+          token: ${{ secrets.GH_TOKEN }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: release-notes
+          path: src/github.com/kubernetes-sigs/cri-tools/release-notes.md
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-artifacts
+          path: src/github.com/kubernetes-sigs/cri-tools/_output

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Session.vim
 .netrwhist
 
 /build
+release-notes.md

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,9 @@ $(GINKGO):
 release:
 	hack/release.sh
 
+release-notes:
+	hack/release-notes.sh
+
 # needs to run as root to work
 test-e2e: $(GINKGO)
 	$(GINKGO) $(TESTFLAGS) \
@@ -142,5 +145,6 @@ vendor:
 	install.ginkgo \
 	install.lint \
 	release \
+	release-notes \
 	test-e2e \
 	vendor

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,7 @@
 # Release Process
 
-The Kubernetes cri-tools Project is released on an as-needed basis. The process is as follows:
+The Kubernetes cri-tools Project is released for every Kubernetes release. The
+process is as follows:
 
-1. An issue is proposing a new release with a changelog since the last release
-1. All [OWNERS](OWNERS) must LGTM this release
-1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
-1. The release issue is closed
+1. An OWNER runs `git tag -m $VERSION -s $VERSION` and pushes the tag with `git push $VERSION`, where `$VERSION` follows the Kubernetes minor version.
 1. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] cri-tools $VERSION is released`

--- a/hack/release-notes.sh
+++ b/hack/release-notes.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+go install k8s.io/release/cmd/release-notes@latest
+
+release-notes \
+    --discover minor-to-minor \
+    --org kubernetes-sigs \
+    --repo cri-tools \
+    --required-author "" \
+    --output release-notes.md

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -93,9 +93,9 @@ for platform in "${CRI_TEST_PLATFORMS[@]}"; do
         ${CRITEST_BIN}
 done
 
-printf "\n## Downloads\n\n"
-printf "| file | sha256 | sha512\n"
-printf "| ---- | ------ | ------\n"
+printf "\n## Downloads\n\n" | tee -a release-notes.md
+echo "| file | sha256 | sha512" | tee -a release-notes.md
+echo "| ---- | ------ | ------" | tee -a release-notes.md
 
 # Show sha256/512 for release files
 if [[ "${OSTYPE}" == "darwin"* ]]; then
@@ -103,13 +103,13 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
         SHA256=$(shasum -a 256 "$file" | sed -e "s,$file,," | awk '{print $1}' | tee "$file.sha256")
         SHA512=$(shasum -a 512 "$file" | sed -e "s,$file,," | awk '{print $1}' | tee "$file.sha512")
         BASE=$(basename "$file")
-        echo "| $BASE | $SHA256 | $SHA512 |"
+        echo "| $BASE | $SHA256 | $SHA512 |" | tee -a release-notes.md
     done
 else
     for file in "$OUTPUTDIR"/*.tar.gz; do
         SHA256=$(sha256sum -b "$file" | sed -e "s,$file,," | awk '{print $1}' | tee "$file.sha256")
         SHA512=$(sha512sum -b "$file" | sed -e "s,$file,," | awk '{print $1}' | tee "$file.sha512")
         BASE=$(basename "$file")
-        echo "| $BASE | $SHA256 | $SHA512 |"
+        echo "| $BASE | $SHA256 | $SHA512 |" | tee -a release-notes.md
     done
 fi


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adding a GitHub action workflow to automatically create releases when pushing a new tag on `master`.

Demo run in my own org: https://github.com/saschagrunert/cri-tools/actions/runs/1320451685
The resulting release:https://github.com/saschagrunert/cri-tools/releases/tag/v1.20.0

#### Which issue(s) this PR fixes:

Fixes #836 

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
