### PR TITLE
Enable crictl completion autoloading with compinit

### DIFF
--- a/cmd/crictl/completion.go
+++ b/cmd/crictl/completion.go
@@ -23,7 +23,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var bashCompletionTemplate = `_cli_bash_autocomplete() {
+var bashCompletionTemplate = `_crictl() {
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
@@ -32,7 +32,7 @@ var bashCompletionTemplate = `_cli_bash_autocomplete() {
     return 0
 }
 
-complete -F _cli_bash_autocomplete crictl`
+complete -F _crictl crictl`
 
 func bashCompletion(c *cli.Context) error {
 	subcommands := []string{}
@@ -55,8 +55,8 @@ func bashCompletion(c *cli.Context) error {
 }
 
 var zshCompletionTemplate = `#compdef crictl
-_cli_zsh_autocomplete() {
 
+_crictl() {
   local -a cmds
   cmds=('%s')
   _describe 'commands' cmds
@@ -68,7 +68,7 @@ _cli_zsh_autocomplete() {
   return
 }
 
-compdef _cli_zsh_autocomplete crictl`
+compdef _crictl crictl`
 
 func zshCompletion(c *cli.Context) error {
 	subcommands := []string{}

--- a/cmd/crictl/completion.go
+++ b/cmd/crictl/completion.go
@@ -54,7 +54,8 @@ func bashCompletion(c *cli.Context) error {
 	return nil
 }
 
-var zshCompletionTemplate = `_cli_zsh_autocomplete() {
+var zshCompletionTemplate = `#compdef crictl
+_cli_zsh_autocomplete() {
 
   local -a cmds
   cmds=('%s')

--- a/cmd/crictl/completion.go
+++ b/cmd/crictl/completion.go
@@ -92,6 +92,15 @@ func zshCompletion(c *cli.Context) error {
 
 }
 
+func fishCompletion(c *cli.Context) error {
+	completion, err := c.App.ToFishCompletion()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(c.App.Writer, completion)
+	return nil
+}
+
 var completionCommand = &cli.Command{
 	Name:      "completion",
 	Usage:     "Output shell completion code",
@@ -130,13 +139,4 @@ Examples:
 			return fmt.Errorf("only bash, zsh or fish are supported")
 		}
 	},
-}
-
-func fishCompletion(c *cli.Context) error {
-	completion, err := c.App.ToFishCompletion()
-	if err != nil {
-		return err
-	}
-	fmt.Fprintln(c.App.Writer, completion)
-	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

The first commit adds the `#compdef` tag in the first line of `crictl completion zsh`. This is required to autoload the completion with `compinit`[^1]. Note that in this case, the completion does not need to be sourced manually, but instead it is stored in an `FPATH`[^2] directory such as `/usr/local/share/zsh/site-functions`.

The second and third commits are mostly clean-ups to stick to current conventions.

Before the patch

```bash
$ cat /usr/local/share/zsh/site-functions/_crictl | grep "#compdef"
$ type _cli_zsh_autocomplete
_cli_zsh_autocomplete not found
$ source /usr/local/share/zsh/site-functions/_crictl
$ type _cli_zsh_autocomplete
_cli_zsh_autocomplete is a shell function from /usr/local/share/zsh/site-functions/_crictl
$ which _cli_zsh_autocomplete
_cli_zsh_autocomplete () {
	local -a cmds
	cmds=('attach:Attach to a running container' 'create:Create a new container' 'exec:Run a command in a running container' 'version:Display runtime version information' 'images:List images' 'image:List images' 'img:List images' 'inspect:Display the status of one or more containers' 'inspecti:Return the status of one or more images' 'imagefsinfo:Return image filesystem info' 'inspectp:Display the status of one or more pods' 'logs:Fetch the logs of a container' 'port-forward:Forward local port to a pod' 'ps:List containers' 'pull:Pull an image from a registry' 'run:Run a new container inside a sandbox' 'runp:Run a new pod' 'rm:Remove one or more containers' 'rmi:Remove one or more images' 'rmp:Remove one or more pods' 'pods:List pods' 'start:Start one or more created containers' 'info:Display information of the container runtime' 'stop:Stop one or more running containers' 'stopp:Stop one or more running pods' 'update:Update one or more running containers' 'config:Get and set crictl client configuration options' 'stats:List container(s) resource usage statistics' 'completion:Output shell completion code' 'help:Shows a list of commands or help for one command' 'h:Shows a list of commands or help for one command')
	_describe 'commands' cmds
	local -a opts
	opts=('--config' '--debug' '--image-endpoint' '--runtime-endpoint' '--timeout' '--help' '--version')
	_describe 'global options' opts
	return
}
```

After the patch

```bash
$ cat /usr/local/share/zsh/site-functions/_crictl | grep "#compdef"
#compdef crictl
$ type _crictl
_crictl is an autoload shell function
$ which _crictl
_crictl () {
	# undefined
	builtin autoload -XUz
}
```

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Enabled crictl completion autoloading with compinit.
```

[^1]: Details in [zsh.sourceforge.io/Doc/Release/Completion-System.html#Initialization](https://web.archive.org/web/20211108122828/https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Initialization)
[^2]: Better explanation in <https://unix.stackexchange.com/questions/33255/how-to-define-and-load-your-own-shell-function-in-zsh>
