### PR TITLE
fix test case chmod syscall for arm64

### DIFF
--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -619,7 +619,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
      "defaultAction": "SCMP_ACT_ALLOW",
      "syscalls": [
          {
-             "names": ["chmod"],
+             "names": ["chmod", "fchmodat"],
              "action": "SCMP_ACT_ERRNO"
          }
      ]


### PR DESCRIPTION
Signed-off-by: sayaoailun <guojianwei007@126.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When run critest in arm64, test case `chmod syscall` failed

#### Which issue(s) this PR fixes:

None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

docker info
```bash
Client:
 Context:    default
 Debug Mode: false
 Plugins:
  app: Docker App (Docker Inc., v0.9.1-beta3)
  buildx: Build with BuildKit (Docker Inc., v0.5.1-docker)

Server:
 Containers: 0
  Running: 0
  Paused: 0
  Stopped: 0
 Images: 9
 Server Version: 20.10.5
 Storage Driver: overlay2
  Backing Filesystem: xfs
  Supports d_type: true
  Native Overlay Diff: true
 Logging Driver: json-file
 Cgroup Driver: cgroupfs
 Cgroup Version: 1
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 io.containerd.runtime.v1.linux runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: d71fcd7d8303cbf684402823e425e9dd2e99285d
 runc version: fabf83fd21f205c801571df4074024179eb03b44
 init version: de40ad0
 Security Options:
  seccomp
   Profile: default
 Kernel Version: 4.19.90-23.8.v2101.ky10.aarch64
 Operating System: Kylin Linux Advanced Server V10 (Tercel)
 OSType: linux
 Architecture: aarch64
 CPUs: 4
 Total Memory: 2.901GiB
 Name: localhost.localdomain
 ID: 44NW:OFNO:M4XN:OSIS:QESN:5YGE:T4O6:M2IP:E5N4:2AJZ:DVHY:SEVX
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Labels:
 Experimental: false
 Live Restore Enabled: false
```

#### Does this PR introduce a user-facing change?

NONE

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
