### PR TITLE
Update Windows images for ltsc2022

### DIFF
--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -96,7 +96,7 @@ const (
 	DefaultLinuxContainerImage string = "busybox:1.28"
 
 	// DefaultWindowsContainerImage default container image for Windows
-	DefaultWindowsContainerImage string = "k8s.gcr.io/e2e-test-images/busybox:1.29-1"
+	DefaultWindowsContainerImage string = "k8s.gcr.io/e2e-test-images/busybox:1.29-2"
 )
 
 // Set the constants based on operating system and flags

--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -198,8 +198,8 @@ const (
 	hostNetWebServerLinuxImage = registry + "hostnet-nginx-" + runtime.GOARCH
 
 	// Windows defaults
-	webServerWindowsImage        = "k8s.gcr.io/e2e-test-images/nginx:1.14-1"
-	hostNetWebServerWindowsImage = "k8s.gcr.io/e2e-test-images/nginx:1.14-1"
+	webServerWindowsImage        = "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
+	hostNetWebServerWindowsImage = "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Makes it so critest can run on Windows ltsc2022

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```