### PR TITLE
Add support for specifying custom test container images.

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -52,6 +52,7 @@ critest connects to Unix: `unix:///var/run/dockershim.sock` or Windows: `tcp://l
 
 - `-ginkgo.focus`: Only run the tests that match the regular expression.
 - `-image-endpoint`: Set the endpoint of image service. Same with runtime-endpoint if not specified.
+- `-test-images-file`: Optional path to a YAML file containing references to custom container images to be used in tests.
 - `-runtime-endpoint`: Set the endpoint of runtime service. Default to `unix:///var/run/dockershim.sock` or Windows: `tcp://localhost:3735`.
 - `-ginkgo.skip`: Skip the tests that match the regular expression.
 - `-parallel`: The number of parallel test nodes to run (default 1). [ginkgo](https://github.com/onsi/ginkgo) must be installed to run parallel tests.

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -46,9 +46,6 @@ var (
 	// DefaultPodLabels are labels used by default in pods
 	DefaultPodLabels map[string]string
 
-	// DefaultContainerImage is the default image used for containers
-	DefaultContainerImage string
-
 	// DefaultContainerCommand is the default command used for containers
 	DefaultContainerCommand []string
 
@@ -103,18 +100,24 @@ const (
 var _ = BeforeSuite(func() {
 	if runtime.GOOS != "windows" || TestContext.IsLcow {
 		DefaultPodLabels = DefaultLinuxPodLabels
-		DefaultContainerImage = DefaultLinuxContainerImage
 		DefaultContainerCommand = DefaultLinuxContainerCommand
 		DefaultPauseCommand = DefaultLinuxPauseCommand
+		TestContext.TestImageList.DefaultTestContainerImage = DefaultLinuxContainerImage
 
 		if TestContext.IsLcow {
 			DefaultPodLabels = DefaultLcowPodLabels
 		}
 	} else {
 		DefaultPodLabels = DefaultWindowsPodLabels
-		DefaultContainerImage = DefaultWindowsContainerImage
 		DefaultContainerCommand = DefaultWindowsContainerCommand
 		DefaultPauseCommand = DefaultWindowsPauseCommand
+		TestContext.TestImageList.DefaultTestContainerImage = DefaultWindowsContainerImage
+	}
+
+	// Load any custom image definitions:
+	err := TestContext.LoadCustomImagesFileIntoTestingContext()
+	if err != nil {
+		panic(err)
 	}
 
 	for _, callback := range beforeSuiteCallbacks {
@@ -254,7 +257,7 @@ func CreateDefaultContainer(rc internalapi.RuntimeService, ic internalapi.ImageM
 	containerName := prefix + NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: BuildContainerMetadata(containerName, DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  DefaultContainerCommand,
 		Linux:    &runtimeapi.LinuxContainerConfig{},
 	}
@@ -267,7 +270,7 @@ func CreatePauseContainer(rc internalapi.RuntimeService, ic internalapi.ImageMan
 	containerName := prefix + NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: BuildContainerMetadata(containerName, DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  DefaultPauseCommand,
 		Linux:    &runtimeapi.LinuxContainerConfig{},
 	}

--- a/pkg/validate/apparmor_linux.go
+++ b/pkg/validate/apparmor_linux.go
@@ -107,7 +107,7 @@ func createContainerWithAppArmor(rc internalapi.RuntimeService, ic internalapi.I
 	containerName := "apparmor-test-" + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  []string{"touch", "/tmp/foo"},
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{

--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -243,6 +243,11 @@ var _ = framework.AddBeforeSuiteCallback(func() {
 		getDNSConfigContent = getDNSConfigWindowsContent
 		getHostnameCmd = getHostnameWindowsCmd
 	}
+
+	// Override the web server test image if an explicit one is provided:
+	if framework.TestContext.TestImageList.WebServerTestImage != "" {
+		webServerImage = framework.TestContext.TestImageList.WebServerTestImage
+	}
 })
 
 // Streaming test constants

--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -337,7 +337,7 @@ func createShellContainer(rc internalapi.RuntimeService, ic internalapi.ImageMan
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata:  framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:     &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:     &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:   shellCmd,
 		Linux:     &runtimeapi.LinuxContainerConfig{},
 		Stdin:     true,
@@ -455,7 +455,7 @@ func createVolumeContainer(rc internalapi.RuntimeService, ic internalapi.ImageMa
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  pauseCmd,
 		// mount host path to the same directory in container, and will check if hostPath isn't empty
 		Mounts: []*runtimeapi.Mount{
@@ -477,7 +477,7 @@ func createLogContainer(rc internalapi.RuntimeService, ic internalapi.ImageManag
 	path := fmt.Sprintf("%s.log", containerName)
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  logDefaultCmd,
 		LogPath:  path,
 	}
@@ -491,7 +491,7 @@ func createKeepLoggingContainer(rc internalapi.RuntimeService, ic internalapi.Im
 	path := fmt.Sprintf("%s.log", containerName)
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  loopLogDefaultCmd,
 		LogPath:  path,
 	}

--- a/pkg/validate/container_linux.go
+++ b/pkg/validate/container_linux.go
@@ -218,7 +218,7 @@ func createMountPropagationContainer(rc internalapi.RuntimeService, ic internala
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  pauseCmd,
 		// Set Privileged in order to executing mount command in container
 		Linux: &runtimeapi.LinuxContainerConfig{

--- a/pkg/validate/multi_container_linux.go
+++ b/pkg/validate/multi_container_linux.go
@@ -145,7 +145,7 @@ func createMultiContainerTestBusyboxContainer(rc internalapi.RuntimeService, ic 
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  []string{"sh", "-c", "echo " + defaultLog + "; sleep 1000"},
 		LogPath:  fmt.Sprintf("%s.log", containerName),
 	}

--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -103,7 +103,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			command = []string{"sh", "-c", "sleep 1000"}
 			prefix = "container-with-HostPID-test-"
 			containerName = prefix + framework.NewUUID()
-			containerID, _, _ = createNamespaceContainer(rc, ic, podID, podConfig, containerName, framework.DefaultContainerImage, namespaceOption, command, "")
+			containerID, _, _ = createNamespaceContainer(rc, ic, podID, podConfig, containerName, framework.TestContext.TestImageList.DefaultTestContainerImage, namespaceOption, command, "")
 
 			By("start container")
 			startContainer(rc, containerID)
@@ -145,7 +145,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			By("create a default container with namespace")
 			prefix := "namespace-container-"
 			containerName := prefix + framework.NewUUID()
-			containerID, _, _ := createNamespaceContainer(rc, ic, podID, podConfig, containerName, framework.DefaultContainerImage, namespaceOption, pauseCmd, "")
+			containerID, _, _ := createNamespaceContainer(rc, ic, podID, podConfig, containerName, framework.TestContext.TestImageList.DefaultTestContainerImage, namespaceOption, pauseCmd, "")
 
 			By("start container")
 			startContainer(rc, containerID)
@@ -177,7 +177,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			By("create a default container with namespace")
 			prefix := "namespace-container-"
 			containerName := prefix + framework.NewUUID()
-			containerID, _, _ := createNamespaceContainer(rc, ic, podID, podConfig, containerName, framework.DefaultContainerImage, namespaceOption, pauseCmd, "")
+			containerID, _, _ := createNamespaceContainer(rc, ic, podID, podConfig, containerName, framework.TestContext.TestImageList.DefaultTestContainerImage, namespaceOption, pauseCmd, "")
 
 			By("start container")
 			startContainer(rc, containerID)
@@ -294,7 +294,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			containerName := "container-with-SupplementalGroups-test-" + framework.NewUUID()
 			containerConfig := &runtimeapi.ContainerConfig{
 				Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-				Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+				Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 				Command:  pauseCmd,
 				Linux: &runtimeapi.LinuxContainerConfig{
 					SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -549,7 +549,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			containerName := "container-with-maskedpaths" + framework.NewUUID()
 			containerConfig := &runtimeapi.ContainerConfig{
 				Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-				Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+				Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 				Command:  pauseCmd,
 				Linux: &runtimeapi.LinuxContainerConfig{
 					SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -578,7 +578,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			containerName := "container-with-readonlypaths" + framework.NewUUID()
 			containerConfig := &runtimeapi.ContainerConfig{
 				Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-				Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+				Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 				Command:  pauseCmd,
 				Linux: &runtimeapi.LinuxContainerConfig{
 					SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -846,7 +846,7 @@ func createRunAsUserContainer(rc internalapi.RuntimeService, ic internalapi.Imag
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  pauseCmd,
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -868,7 +868,7 @@ func createRunAsUserNameContainer(rc internalapi.RuntimeService, ic internalapi.
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  pauseCmd,
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -890,7 +890,7 @@ func createRunAsGroupContainer(rc internalapi.RuntimeService, ic internalapi.Ima
 	By("create a container with RunAsUser and RunAsGroup")
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  []string{"sh", "-c", "echo $(id -u):$(id -g)"},
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -913,7 +913,7 @@ func createInvalidRunAsGroupContainer(rc internalapi.RuntimeService, ic internal
 	By("create a container with RunAsGroup without RunAsUser")
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  []string{"sh", "-c", "echo $(id -u):$(id -g)"},
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -970,7 +970,7 @@ func createReadOnlyRootfsContainer(rc internalapi.RuntimeService, ic internalapi
 	path := fmt.Sprintf("%s.log", containerName)
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  []string{"sh", "-c", "touch test.go && [ -f test.go ] && echo 'Found'"},
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -1021,7 +1021,7 @@ func createPrivilegedContainer(rc internalapi.RuntimeService, ic internalapi.Ima
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  pauseCmd,
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -1053,7 +1053,7 @@ func createCapabilityContainer(rc internalapi.RuntimeService, ic internalapi.Ima
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  pauseCmd,
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -1086,7 +1086,7 @@ func createAndCheckHostNetwork(rc internalapi.RuntimeService, ic internalapi.Ima
 	command := []string{"sh", "-c", "netstat -ln"}
 	containerName := "container-with-HostNetwork-test-" + framework.NewUUID()
 	path := fmt.Sprintf("%s.log", containerName)
-	containerID, _, logPath := createNamespaceContainer(rc, ic, podID, podConfig, containerName, framework.DefaultContainerImage, namespaceOptions, command, path)
+	containerID, _, logPath := createNamespaceContainer(rc, ic, podID, podConfig, containerName, framework.TestContext.TestImageList.DefaultTestContainerImage, namespaceOptions, command, path)
 
 	By("start container")
 	startContainer(rc, containerID)
@@ -1154,7 +1154,7 @@ func seccompTestContainer(rc internalapi.RuntimeService, ic internalapi.ImageMan
 	containerName := containerNamePrefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  pauseCmd,
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
@@ -1200,7 +1200,7 @@ func createSeccompContainer(rc internalapi.RuntimeService,
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  []string{"sleep", "60"},
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{

--- a/pkg/validate/selinux_linux.go
+++ b/pkg/validate/selinux_linux.go
@@ -161,7 +161,7 @@ func createContainerWithSelinux(rc internalapi.RuntimeService, ic internalapi.Im
 	containerName := "selinux-test-" + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: framework.DefaultContainerImage},
+		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  pauseCmd,
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This patch adds an optional `--test-images-file` argument for specifying the path to a YAML file containing custom container image references to be used in tests.

This will allow for user selection of more recent or even custom test images, as well as prevent the need to update/re-ship `cri-tools` in case of issues related to the currently-hardcoded default images. (e.g. updating their manifests for new Window releases, see #853 )

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
Added optional `--test-images-file` CLI flag for providing the path to a YAML file defining custom container image references to be used in tests, with the current user-overridable image keys being `defaultTestContainerImage` (the image used in the majority of tests), and `webServerTestImage`. (which is used in Networking-related tests) 
```
