### PR TITLE
Fix Containerd main branch CI for Windows

### DIFF
--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -102,10 +102,11 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/containerd/containerd
 
       - name: Install containerd on Windows
+        shell: bash
         if: startsWith(matrix.os, 'windows')
         run: |
-          make
-          make install
+          mingw32-make.exe 
+          mingw32-make.exe install
         working-directory: ${{ github.workspace }}/src/github.com/containerd/containerd
 
       - name: Install ${{matrix.runc}} runtime engine on Linux
@@ -117,7 +118,9 @@ jobs:
         working-directory: src/github.com/containerd/containerd
 
       - name: Build Windows container shims
-        if: startsWith(matrix.os, 'windows')
+        # After Containerd 1.5 just a 'make' or 'make binaries' invocation will build the windows shim alongside the daemon, ctr, and 
+        # other binaries so this step is only needed on < 1.6 
+        if: startsWith(matrix.os, 'windows') && matrix.version != 'main'
         shell: bash
         run: |
           set -o xtrace


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Due to the containerd makefile using $(PWD)/bin to determine where to place the windows shim, it doesn't seem to like being run with powershell. I'm not sure if it's just not inherited or what the reason is, but instead of having the current dir replaced it simply would be an empty string. The result of this is that the windows shim would get placed in /bin on the machine instead of the bin in the current directory. 'make install' right afterwards would then fail to find the file. To remedy this, use bash.exe
as the shell to run the CI. This shell change should be harmless and is intended to get the CI working again for windows finally, but in Containerd using CURDIR instead of PWD may be the solution to this problem. There shouldn't be a need to revert this if a fix is put in place in Containerd

This change additionally adds a small bit of logic to only build the windows shim ourselves if we're running the CI for containerd < 1.6. In 1.6 (there's only beta versions out so far but) the makefile has support for building the shim itself. A simple 'make' or 'make binaries' invocation will build the shim and place it in the same location as containerd and ctr.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
