### PR TITLE
Fix cri-dockerd CI runs

### DIFF
--- a/.github/workflows/dockershim.yml
+++ b/.github/workflows/dockershim.yml
@@ -71,7 +71,7 @@ jobs:
           set -o pipefail
 
           git clone https://github.com/Mirantis/cri-dockerd $GOPATH/src/github.com/Mirantis/cri-dockerd
-          cd $GOPATH/src/github.com/Mirantis/cri-dockerd
+          cd $GOPATH/src/github.com/Mirantis/cri-dockerd/src
           go mod tidy
 
           # Need the flag for errors building on Windows
@@ -107,7 +107,8 @@ jobs:
           SKIP="runtime should support execSync|runtime should support portforward|runtime should support starting container with log|runtime should support execSync with timeout|runtime should support removing running container|runtime should support port mapping with only container port|runtime should support creating container|runtime should support starting container with volume|runtime should support exec with tty=true and stdin=true|runtime should support set hostname|runtime should support removing stopped container|runtime should support removing created container|runtime should support running PodSandbox|runtime should support port mapping with host port and container port|runtime should support exec with tty=false and stdin=false|runtime should support DNS config|runtime should support attach|runtime should support listing container stats|runtime should support reopening container log|runtime should support stopping container|runtime should support starting container with volume when host path is a symlink|runtime should support removing PodSandbox|runtime should support stopping PodSandbox|runtime should support starting container"
 
           # Start dockershim first
-          /usr/local/bin/cri-dockerd --v=10 --network-plugin="" --logtostderr &> "${REPORT_DIR}/dockerd-cri.log" &
+          ep=npipe:////./pipe/dockershim
+          /usr/local/bin/cri-dockerd --network-plugin="" --container-runtime-endpoint=${ep} &> "${REPORT_DIR}/dockerd-cri.log" &
           pid=$!
 
           # Wait a while for dockershim starting.
@@ -115,6 +116,7 @@ jobs:
 
           # Run cri test cases
           /usr/local/bin/critest --ginkgo.focus="${FOCUS}" --ginkgo.skip="${SKIP}" --report-dir="${REPORT_DIR}" --report-prefix="windows"
+
           ls ${REPORT_DIR}
           TEST_RC1=$?
           test $TEST_RC1 -ne 0 && cat ${REPORT_DIR}/dockerd-cri.log

--- a/hack/install-cri-dockerd.sh
+++ b/hack/install-cri-dockerd.sh
@@ -21,7 +21,7 @@ set -o pipefail
 # Build cri-dockerd
 
 git clone https://github.com/Mirantis/cri-dockerd $GOPATH/src/github.com/Mirantis/cri-dockerd
-cd $GOPATH/src/github.com/Mirantis/cri-dockerd
+cd $GOPATH/src/github.com/Mirantis/cri-dockerd/src
 
 go install .
 sudo mv $GOPATH/bin/cri-dockerd /usr/local/bin

--- a/hack/run-dockershim-critest.sh
+++ b/hack/run-dockershim-critest.sh
@@ -38,7 +38,8 @@ fi
 # Start dockershim first
 logs_dir="$GOPATH/logs"
 mkdir -p $logs_dir
-sudo /usr/local/bin/cri-dockerd --v=10 --network-plugin="" --logtostderr >$logs_dir/cri-dockerd.log 2>&1 &
+ep="unix:///var/run/dockershim.sock"
+sudo /usr/local/bin/cri-dockerd --network-plugin="" --container-runtime-endpoint=${ep} >$logs_dir/cri-dockerd.log 2>&1 &
 
 # Wait a while for dockershim starting.
 sleep 10
@@ -48,8 +49,7 @@ sleep 10
 # Skip runtime should support execSync with timeout because docker doesn't
 # support it.
 # Skip apparmor test as we don't enable apparmor yet in this CI job.
-sudo critest -ginkgo.skip=${SKIP} -parallel 1
-
+sudo critest -ginkgo.skip=${SKIP} -parallel 1 
 
 # Run benchmark test cases
 sudo critest -benchmark


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
github.com/Mirantis/cri-dockerd has changed a couple things that were affecting the CI. The code has moved to a src/ subdirectory so running 'go install .' at the root of the repo fails on finding anything. The default addresses have also changed from /var/run/dockershim.sock (and //./pipe/dockershim) to /var/run/cri-dockerd.sock. A couple of flags also don't seem to exist anymore, namely --logtostderr and --v. All in all this change cds to the src subdirectory before trying to build/install anything, makes cri-dockerd launch with the old dockershim address, and gets rid of the now nonexistent flags.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
