### PR TITLE
Add support for cri-dockerd

### DIFF
--- a/cmd/crictl/main_unix.go
+++ b/cmd/crictl/main_unix.go
@@ -27,6 +27,6 @@ const (
 	defaultConfigPath = "/etc/crictl.yaml"
 )
 
-var defaultRuntimeEndpoints = []string{"unix:///var/run/dockershim.sock", "unix:///run/containerd/containerd.sock", "unix:///run/crio/crio.sock"}
+var defaultRuntimeEndpoints = []string{"unix:///var/run/dockershim.sock", "unix:///run/containerd/containerd.sock", "unix:///run/crio/crio.sock", "unix:///var/run/cri-dockerd.sock"}
 
 var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/cmd/crictl/main_windows.go
+++ b/cmd/crictl/main_windows.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 )
 
-var defaultRuntimeEndpoints = []string{"npipe:////./pipe/dockershim", "npipe:////./pipe/containerd", "npipe:////./pipe/crio"}
+var defaultRuntimeEndpoints = []string{"npipe:////./pipe/dockershim", "npipe:////./pipe/containerd", "npipe:////./pipe/crio", "npipe:////./pipe/cri-dockerd"}
 var defaultConfigPath string
 
 var shutdownSignals = []os.Signal{os.Interrupt}

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -67,13 +67,15 @@ crictl by default connects on Unix to:
 
 - `unix:///var/run/dockershim.sock` or
 - `unix:///run/containerd/containerd.sock` or
-- `unix:///run/crio/crio.sock`
+- `unix:///run/crio/crio.sock` or
+- `unix:///var/run/cri-dockerd.sock`
 
 or on Windows to:
 
 - `npipe:////./pipe/dockershim` or
 - `npipe:////./pipe/containerd` or
-- `npipe:////./pipe/crio`
+- `npipe:////./pipe/crio` or
+- `npipe:////./pipe/cri-dockerd`
 
 For other runtimes, use:
 
@@ -91,6 +93,7 @@ If the endpoint is not set then it works as follows:
   - dockershim
   - containerd
   - cri-o
+  - cri-dockerd
 - If the image endpoint is not set, `crictl` will by default use the runtime endpoint setting
 
 > Note: The default endpoints are now deprecated and the runtime endpoint should always be set instead.


### PR DESCRIPTION
Since Kubernetes 1.24, dockershim.sock has been replaced
with cri-dockerd.sock (and similar npipe, for Windows)

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

detect the "docker" runtime, after moving from dockershim to external endpoint

https://github.com/Mirantis/cri-dockerd

https://kubernetes.io/docs/setup/production-environment/container-runtimes/

#### Which issue(s) this PR fixes:

Fixes #868 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
detect cri-dockerd socket, after dockershim removal
```
