### PR TITLE
Remove dockershim from crictl

### DIFF
--- a/cmd/crictl/main_unix.go
+++ b/cmd/crictl/main_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 /*
 Copyright 2017 The Kubernetes Authors.
@@ -27,6 +27,6 @@ const (
 	defaultConfigPath = "/etc/crictl.yaml"
 )
 
-var defaultRuntimeEndpoints = []string{"unix:///run/containerd/containerd.sock", "unix:///run/crio/crio.sock", "unix:///var/run/cri-dockerd.sock"}
+var defaultRuntimeEndpoints = []string{"unix:///run/containerd/containerd.sock", "unix:///run/crio/crio.sock", "unix:///var/run/cri-dockerd.sock", "unix:///var/run/dockershim.sock"}
 
 var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/cmd/crictl/main_windows.go
+++ b/cmd/crictl/main_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2017 The Kubernetes Authors.
@@ -24,7 +23,7 @@ import (
 	"path/filepath"
 )
 
-var defaultRuntimeEndpoints = []string{"npipe:////./pipe/containerd", "npipe:////./pipe/crio", "npipe:////./pipe/cri-dockerd"}
+var defaultRuntimeEndpoints = []string{"npipe:////./pipe/containerd", "npipe:////./pipe/crio", "npipe:////./pipe/cri-dockerd", "npipe:////./pipe/dockershim"}
 var defaultConfigPath string
 
 var shutdownSignals = []os.Signal{os.Interrupt}

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -60,13 +60,14 @@ This will
 - Run the benchmark tests using `ginkgo`
 - Output the test results to STDOUT
 
-critest connects to Unix: `unix:///var/run/containerd.sock` or Windows: `tcp://localhost:3735` by default. For other runtimes, the endpoint can be set by flags `--runtime-endpoint` and `--image-endpoint`.
+critest connects to Unix: `unix:///run/containerd/containerd.sock` or Windows: `tcp://localhost:3735` by default. For other runtimes, the endpoint can be set by flags `--runtime-endpoint` and `--image-endpoint`.
 
 ## Additional options
 
 - `-ginkgo.focus`: Only run the tests that match the regular expression.
 - `-image-endpoint`: Set the endpoint of image service. Same with runtime-endpoint if not specified.
-- `-runtime-endpoint`: Set the endpoint of runtime service. Default to Unix: `unix:///var/run/containerd.sock` or Windows: `tcp://localhost:3735`.
+- `-runtime-endpoint`: Set the endpoint of runtime service. If not set, attempt
+  to search a list of known endpoints.
 
    **Note:** The default endpoints are deprecated. Always set the
    `--runtime-endpoint`. Performance might be affected as each default

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -63,51 +63,65 @@ COMMANDS:
 - `completion`:         Output bash shell completion code
 - `help, h`:            Shows a list of commands or help for one command
 
-crictl by default connects on Unix to:
+## Connecting to endpoints
 
-- `unix:///run/containerd/containerd.sock` or
-- `unix:///run/crio/crio.sock` or
+You should specify an endpoint for `crictl` to use. The endpoint is based on your
+container runtime. You can set the endpoint in one of the following ways: 
+
+- Set global option flags `--runtime-endpoint` (`-r`) and `--image-endpoint`
+  (`-i`)
+- Set environment variables `CONTAINER_RUNTIME_ENDPOINT` and
+  `IMAGE_SERVICE_ENDPOINT`
+- Set the endpoint in the config file located at `/etc/crictl.yaml`
+
+If you don't set the endpoint, the following applies:
+
+- If the runtime endpoint is not set, `crictl` tries to connect using:
+  - containerd
+  - cri-o
+  - cri-dockerd
+  - dockershim (unsupported in Kubernetes 1.24)
+- If the image endpoint is not set, `crictl` uses the runtime endpoint setting
+
+`crictl` tries to connect to the following endpoints in order if you don't set one:
+
+**Unix**
+
+- `unix:///run/containerd/containerd.sock`
+- `unix:///run/crio/crio.sock`
 - `unix:///var/run/cri-dockerd.sock`
+- `unix:///var/run/dockershim.sock` (unsupported in Kubernetes 1.24)
 
-or on Windows to:
+**Windows**
 
-- `npipe:////./pipe/containerd` or
-- `npipe:////./pipe/crio` or
+- `npipe:////./pipe/containerd`
+- `npipe:////./pipe/crio`
 - `npipe:////./pipe/cri-dockerd`
+- `npipe:////./pipe/dockershim` (unsupported in Kubernetes 1.24)
 
 For other runtimes, use:
 
 - [frakti](https://github.com/kubernetes/frakti): `unix:///var/run/frakti.sock`
 
-The endpoint can be set in three ways:
+> Note: These backup endpoints are deprecated. You should **always** set a
+> runtime endpoint. If you don't, performance may be affected as each
+> backup connection attempt takes some time to complete before timing out
+> and going to the next in sequence.
 
-- By setting global option flags `--runtime-endpoint` (`-r`) and `--image-endpoint` (`-i`)
-- By setting environment variables `CONTAINER_RUNTIME_ENDPOINT` and `IMAGE_SERVICE_ENDPOINT`
-- By setting the endpoint in the config file `--config=/etc/crictl.yaml`
+You can view the current endpoint configuration in the `crictl` config file.
 
-If the endpoint is not set then it works as follows:
-
-- If the runtime endpoint is not set, `crictl` will by default try to connect using:
-  - containerd
-  - cri-o
-  - cri-dockerd
-- If the image endpoint is not set, `crictl` will by default use the runtime endpoint setting
-
-> Note: The default endpoints are now deprecated and the runtime endpoint should always be set instead.
-The performance maybe affected as each default connection attempt takes n-seconds to complete before timing out and going to the next in sequence.
-
-Unix:
+**Unix**
 
 ```sh
 $ cat /etc/crictl.yaml
-runtime-endpoint: unix:///var/run/containerd.sock
-image-endpoint: unix:///var/run/containerd.sock
+runtime-endpoint: unix:///run/containerd/containerd.sock
+image-endpoint: unix:///run/containerd/containerd.sock
 timeout: 2
 debug: true
 pull-image-on-create: false
 ```
 
-Windows:
+**Windows**
 
 ```cmd
 C:\> type %USERPROFILE%\.crictl\crictl.yaml

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -46,18 +46,18 @@ This will
 - Run the tests using `ginkgo`
 - Output the test results to STDOUT
 
-critest connects to Unix: `unix:///var/run/containerd.sock` or Windows: `tcp://localhost:3735` by default. For other runtimes, the endpoint can be set by flags `--runtime-endpoint` and `--image-endpoint`.
+For specific runtimes, the endpoint can be set by flags
+`--runtime-endpoint` and `--image-endpoint`.
 
 ## Additional options
 
 - `-ginkgo.focus`: Only run the tests that match the regular expression.
 - `-image-endpoint`: Set the endpoint of image service. Same with runtime-endpoint if not specified.
 - `-test-images-file`: Optional path to a YAML file containing references to custom container images to be used in tests.
-- `-runtime-endpoint`: Set the endpoint of runtime service. Default to
-  `unix:///var/run/containerd.sock` or Windows: `tcp://localhost:3735`.
+- `-runtime-endpoint`: Set the endpoint of runtime service. If not set, attempt to search a list of known endpoints.
 
-  **Note:** The default endpoints are deprecated. Always set the
-  `--runtime-endpoint`. Performance might be affected as each default
+  **Note:** The backup endpoints are deprecated. Always set the
+  `--runtime-endpoint`. Performance might be affected as each backup
   connection attempt takes n-seconds to complete before timing out and going
   to the next in sequence.
 

--- a/hack/run-dockershim-critest.sh
+++ b/hack/run-dockershim-critest.sh
@@ -16,9 +16,6 @@
 
 # Run critest with default dockershim.
 
-# Works only with https://github.com/Mirantis/cri-dockerd - other CRI
-# implementations aren't supported.
-
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION

/kind feature
/kind deprecation

#### What this PR does / why we need it:

Removes dockershim from the crictl docs and main_unix / main_windows in preparation for the 1.24 deprecation of dockershim. 

- Remove `dockershim.sock` from default runtime endpoints for unix and windows
- Change `dockershim.sock` to `containerd.sock` in the default description for `--runtime-endpoints`.
- Remove `dockershim` from the crictl docs (including code examples in the docs)

This PR doesn't address `critest` mentions of `dockershim` as I'm not sure how to do that (but I'm happy to learn).

#### Which issue(s) this PR fixes:

Fixes #870

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`dockershim` is no longer one of the runtime endpoints for `crictl`. 
```
