### PR TITLE
update containerd to 1.5.9

### DIFF
--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -18,7 +18,7 @@ jobs:
         # ║ hcshim           │           │ runhcs  ║
         # ╚══════════════════╧═══════════╧═════════╝
         os: [ubuntu-18.04, windows-2019]
-        version: [main, v1.5.2]
+        version: [main, v1.5.9]
         runtime: [io.containerd.runtime.v1.linux, io.containerd.runc.v1, io.containerd.runc.v2, containerd-shim-runhcs-v1]
         runc: [runc, crun]
         exclude:


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
updates containerd version to 1.5.9. this is needed to make 
https://github.com/kubernetes-sigs/cri-tools/pull/857
pass


