### PR TITLE
Add backwards compatiblity to `Version` and `ListContainerStats` RPCs

### DIFF
--- a/cmd/crictl/version.go
+++ b/cmd/crictl/version.go
@@ -22,23 +22,20 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/net/context"
+	internalapi "k8s.io/cri-api/pkg/apis"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
-const (
-	criClientVersion = "v1"
-)
+const criClientVersion = "v1"
 
 var runtimeVersionCommand = &cli.Command{
 	Name:  "version",
 	Usage: "Display runtime version information",
 	Action: func(context *cli.Context) error {
-		runtimeClient, runtimeConn, err := getRuntimeClient(context)
+		runtimeClient, err := getRuntimeService(context)
 		if err != nil {
 			return err
 		}
-		defer closeConnection(context, runtimeConn)
 		err = Version(runtimeClient, criClientVersion)
 		if err != nil {
 			return errors.Wrap(err, "getting the runtime version")
@@ -48,10 +45,10 @@ var runtimeVersionCommand = &cli.Command{
 }
 
 // Version sends a VersionRequest to the server, and parses the returned VersionResponse.
-func Version(client pb.RuntimeServiceClient, version string) error {
+func Version(client internalapi.RuntimeService, version string) error {
 	request := &pb.VersionRequest{Version: version}
 	logrus.Debugf("VersionRequest: %v", request)
-	r, err := client.Version(context.Background(), request)
+	r, err := client.Version(version)
 	logrus.Debugf("VersionResponse: %v", r)
 	if err != nil {
 		return err


### PR DESCRIPTION

#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows backwards compatiblity with previous runtimes not supporting
CRI v1.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/cri-tools/issues/883
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
