### PR TITLE
Update crictl ps to show pod name and repo image

### DIFF
--- a/cmd/crictl/display.go
+++ b/cmd/crictl/display.go
@@ -41,6 +41,7 @@ const (
 	columnInodes     = "INODES"
 	columnDisk       = "DISK"
 	columnCPU        = "CPU %"
+	columnPodname    = "POD"
 )
 
 // display use to output something on screen with table format.

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -100,6 +100,8 @@ type listOptions struct {
 	noTrunc bool
 	// image used by the container
 	image string
+	// resolve image path
+	resolveImagePath bool
 }
 
 type execOptions struct {
@@ -378,4 +380,15 @@ func ctxWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc)
 		return context.Background(), func() {}
 	}
 	return context.WithTimeout(context.Background(), timeout)
+}
+
+func getRepoImage(imageClient pb.ImageServiceClient, image string) (string, error) {
+	r, err := ImageStatus(imageClient, image, false)
+	if err != nil {
+		return "", err
+	}
+	if len(r.Image.RepoTags) > 0 {
+		return r.Image.RepoTags[0], nil
+	}
+	return image, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design
Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- This PR introduces 2 changes to `crictl ps` command

1. Include pod name in the container listing (add a new column `POD`). It's easier to find containers under a K8s pod.
2. Include a new boolean flag `-r` / `--resolve-image-path` (default value: `false`). When specified, `crictl ps` will try to resolve the image path (e.g. `quay.io/kubevirt/virt-handler:v0.46.1`) instead of showing the image ID.

- Sample output

```bash
 ./build/bin/crictl ps
CONTAINER           IMAGE               CREATED             STATE               NAME                      ATTEMPT             POD ID              POD
0ad4683fc9548       269223fff922b       2 weeks ago         Running             virt-operator             2                   676ebb03e169c       virt-operator-66dd67d78f-v5r59
3b23cf549905f       8deacd130927c       2 weeks ago         Running             virt-controller           1                   7cf86a6e98285       virt-controller-6d7f9f9cf8-9kzbh
85a2b70d91c3a       269223fff922b       2 weeks ago         Running             virt-operator             1                   4f3bff1980882       virt-operator-66dd67d78f-jhjg7
```

```bash
crictl ps -r
CONTAINER           IMAGE                                                                                        CREATED             STATE               NAME                      ATTEMPT             POD ID              POD
426f9e7b85c27       quay.io/kubevirt/virt-handler:v0.46.1                                                        3 months ago        Running             virt-handler              0                   e902e1f57ea09       virt-handler-w44df
e282451824393       k8s.gcr.io/node-problem-detector:v0.8.1                                                      3 months ago        Running             node-problem-detector     56                  2f9a775a4ef9f       node-problem-detector-9s7hp
```


#### Which issue(s) this PR fixes:
- No issues linked

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

- Nil

#### Does this PR introduce a user-facing change?

- Yes

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- `crictl ps` will include a new column `POD`, the value show the pod name to which the container belong.
- Include a new boolean flag  for `crictl ps`, `-r` / `--resolve-image-path` (default value: `false`). When specified, `crictl ps` will try to resolve the image path (e.g. `quay.io/kubevirt/virt-handler:v0.46.1`) instead of showing the image ID.
```