### PR TITLE
Type cast error messages to `string`

### DIFF
--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -173,7 +173,7 @@ var _ = framework.KubeDescribe("Container", func() {
 			stdout, stderr, err := rc.ExecSync(containerID, checkSleepCmd,
 				time.Duration(defaultExecSyncTimeout)*time.Second)
 			framework.ExpectNoError(err)
-			Expect(stderr).To(BeEmpty())
+			Expect(string(stderr)).To(BeEmpty())
 			Expect(strings.TrimSpace(string(stdout))).To(BeEmpty())
 		})
 
@@ -416,7 +416,7 @@ func execSyncContainer(c internalapi.RuntimeService, containerID string, command
 	By("execSync for containerID: " + containerID)
 	stdout, stderr, err := c.ExecSync(containerID, command, time.Duration(defaultExecSyncTimeout)*time.Second)
 	framework.ExpectNoError(err, "failed to execSync in container %q", containerID)
-	Expect(stderr).To(BeNil(), "The stderr should be nil.")
+	Expect(string(stderr)).To(BeEmpty(), "The stderr should be empty.")
 	framework.Logf("Execsync succeed")
 
 	return string(stdout)

--- a/pkg/validate/networking.go
+++ b/pkg/validate/networking.go
@@ -190,7 +190,7 @@ func checkHostname(c internalapi.RuntimeService, containerID string, hostname st
 	stdout, stderr, err := c.ExecSync(containerID, getHostnameCmd, time.Duration(defaultExecSyncTimeout)*time.Second)
 	framework.ExpectNoError(err, "failed to execSync in container %q", containerID)
 	Expect(strings.EqualFold(strings.TrimSpace(string(stdout)), hostname)).To(BeTrue())
-	Expect(stderr).To(BeNil(), "The stderr should be nil.")
+	Expect(string(stderr)).To(BeEmpty(), "The stderr should be empty.")
 	framework.Logf("check hostname succeed")
 }
 
@@ -202,7 +202,7 @@ func checkDNSConfig(c internalapi.RuntimeService, containerID string, expectedCo
 	for _, content := range expectedContent {
 		Expect(string(stdout)).To(ContainSubstring(content), "The stdout output of execSync should contain %q", content)
 	}
-	Expect(stderr).To(BeNil(), "The stderr should be nil.")
+	Expect(string(stderr)).To(BeEmpty(), "The stderr should be empty.")
 	framework.Logf("check DNS config succeed")
 }
 


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We should force string types for those error messages otherwise they're
not readable by the ginkgo output when running critest.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed critest `ExecSync` output to print strings when `stderr` should be empty.
```
