### PR TITLE
Add CRICTL_AUTH/CRICTL_CREDS env var option to crictl pull

### DIFF
--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -49,14 +49,16 @@ var pullImageCommand = &cli.Command{
 	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "creds",
-			Value: "",
-			Usage: "Use `USERNAME[:PASSWORD]` for accessing the registry",
+			Name:    "creds",
+			Value:   "",
+			Usage:   "Use `USERNAME[:PASSWORD]` for accessing the registry",
+			EnvVars: []string{"CRICTL_CREDS"},
 		},
 		&cli.StringFlag{
-			Name:  "auth",
-			Value: "",
-			Usage: "Use `AUTH_STRING` for accessing the registry. AUTH_STRING is a base64 encoded 'USERNAME[:PASSWORD]'",
+			Name:    "auth",
+			Value:   "",
+			Usage:   "Use `AUTH_STRING` for accessing the registry. AUTH_STRING is a base64 encoded 'USERNAME[:PASSWORD]'",
+			EnvVars: []string{"CRICTL_AUTH"},
 		},
 		&cli.StringFlag{
 			Name:      "pod-config",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds the ability to input the AUTH_STRING for crictl pull using an environment variable. This provides the ability to supply credentials when crictl is being called by another process programmatically.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #903

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add the ability to provide the registry authentication string using the CRICTL_AUTH or the credentials using the CRICTL_CREDS environment variables.
```
