### PR TITLE
Fix CRI-O tests

### DIFF
--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           sudo mkdir -p /etc/crio/crio.conf.d
           printf '[crio.runtime]\nlog_level = "debug"\n' | sudo tee /etc/crio/crio.conf.d/01-log-level.conf
+          printf '[crio.runtime]\nseccomp_use_default_when_empty = false\n' | sudo tee /etc/crio/crio.conf.d/02-seccomp.conf
           sudo systemctl daemon-reload
           sudo systemctl start crio
 


### PR DESCRIPTION
#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
We switched the option `seccomp_use_default_when_empty` to `true` in upstream which break critest. To avoid such a failure in CI we now set it manually to `false`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Refers to https://github.com/cri-o/cri-o/pull/5587
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
