### PR TITLE
update containerd socket in windows

### DIFF
--- a/cmd/crictl/main_windows.go
+++ b/cmd/crictl/main_windows.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 )
 
-var defaultRuntimeEndpoints = []string{"npipe:////./pipe/dockershim", "npipe:////./pipe/containerd", "npipe:////./pipe/crio", "npipe:////./pipe/cri-dockerd"}
+var defaultRuntimeEndpoints = []string{"npipe:////./pipe/dockershim", "npipe:////./pipe/containerd-containerd", "npipe:////./pipe/cri-dockerd"}
 var defaultConfigPath string
 
 var shutdownSignals = []os.Signal{os.Interrupt}

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -73,8 +73,7 @@ crictl by default connects on Unix to:
 or on Windows to:
 
 - `npipe:////./pipe/dockershim` or
-- `npipe:////./pipe/containerd` or
-- `npipe:////./pipe/crio` or
+- `npipe:////./pipe/containerd-containerd` or
 - `npipe:////./pipe/cri-dockerd`
 
 For other runtimes, use:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The containerd socket in windows is wrong.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
change default contained socket from `npipe:////./pipe/containerd` to `npipe:////./pipe/containerd-containerd`
```
