### PR TITLE
Migrate to native ginkgo v2

### DIFF
--- a/cmd/critest/cri_test.go
+++ b/cmd/critest/cri_test.go
@@ -23,14 +23,12 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/reporters"
 	ginkgotypes "github.com/onsi/ginkgo/v2/types"
 	"github.com/onsi/gomega"
 
@@ -93,17 +91,7 @@ func isFlagSet(name string) bool {
 // runTestSuite runs cri validation tests and benchmark tests.
 func runTestSuite(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	reporter := []ginkgo.Reporter{}
-	if framework.TestContext.ReportDir != "" {
-		if err := os.MkdirAll(framework.TestContext.ReportDir, 0755); err != nil {
-			t.Errorf("Failed creating report directory: %v", err)
-		}
-
-		reporter = append(reporter, reporters.NewJUnitReporter(path.Join(framework.TestContext.ReportDir, fmt.Sprintf("junit_%v.xml", framework.TestContext.ReportPrefix))))
-	}
-
-	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "CRI validation", reporter)
+	ginkgo.RunSpecs(t, "CRI validation")
 }
 
 func generateTempTestName() (string, error) {

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -17,24 +17,12 @@ limitations under the License.
 package benchmark
 
 import (
-	"fmt"
 	"math/rand"
-	"os"
-	"path"
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/reporters"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-)
-
-const (
-	defaultOperationTimes int = 20
 )
 
 // TestPerformance checks configuration parameters (specified through flags) and then runs
@@ -44,19 +32,5 @@ const (
 func TestPerformance(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
 	RegisterFailHandler(Fail)
-	r := []Reporter{}
-	reportDir := framework.TestContext.ReportDir
-	if reportDir != "" {
-		// Create the directory if it doesn't already exists
-		if err := os.MkdirAll(reportDir, 0755); err != nil {
-			glog.Errorf("Failed creating report directory: %v", err)
-		} else {
-			suite, _ := ginkgo.GinkgoConfiguration()
-			// Configure a junit reporter to write to the directory
-			junitFile := fmt.Sprintf("junit_%s%02d.xml", framework.TestContext.ReportPrefix, suite.ParallelProcess)
-			junitPath := path.Join(reportDir, junitFile)
-			r = append(r, reporters.NewJUnitReporter(junitPath))
-		}
-	}
-	RunSpecsWithDefaultAndCustomReporters(t, "Benchmark Test Suite", r)
+	RunSpecs(t, "Benchmark Test Suite")
 }

--- a/pkg/validate/e2e.go
+++ b/pkg/validate/e2e.go
@@ -17,17 +17,9 @@ limitations under the License.
 package validate
 
 import (
-	"fmt"
 	"math/rand"
-	"os"
-	"path"
 	"testing"
 	"time"
-
-	"github.com/golang/glog"
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/reporters"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -41,19 +33,5 @@ import (
 func TestE2ECRI(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
 	RegisterFailHandler(Fail)
-	r := []Reporter{}
-	reportDir := framework.TestContext.ReportDir
-	if reportDir != "" {
-		// Create the directory if it doesn't already exists
-		if err := os.MkdirAll(reportDir, 0755); err != nil {
-			glog.Errorf("Failed creating report directory: %v", err)
-		} else {
-			suite, _ := ginkgo.GinkgoConfiguration()
-			// Configure a junit reporter to write to the directory
-			junitFile := fmt.Sprintf("junit_%s%02d.xml", framework.TestContext.ReportPrefix, suite.ParallelProcess)
-			junitPath := path.Join(reportDir, junitFile)
-			r = append(r, reporters.NewJUnitReporter(junitPath))
-		}
-	}
-	RunSpecsWithDefaultAndCustomReporters(t, "E2ECRI Suite", r)
+	RunSpecs(t, "E2ECRI Suite")
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Two migrations needs to be done to avoid the following warnings:

```
You're using deprecated Ginkgo functionality:
=============================================
  Support for custom reporters has been removed in V2.  Please read the documentation linked to below for Ginkgo's new behavior and for a migration path:
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#removed-custom-reporters
  Measure is deprecated and will be removed in Ginkgo V2.  Please migrate to gomega/gmeasure.
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#removed-measure
    github.com/kubernetes-sigs/cri-tools/pkg/benchmark/pod_container.go:60
```
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed warnings when running with ginkgo v2.
```
