### PR TITLE
Fix timeout for exec sync

### DIFF
--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -110,7 +110,8 @@ func ExecSync(client internalapi.RuntimeService, opts execOptions) (int, error) 
 		Timeout:     opts.timeout,
 	}
 	logrus.Debugf("ExecSyncRequest: %v", request)
-	stdout, stderr, err := client.ExecSync(opts.id, opts.cmd, time.Duration(opts.timeout))
+	timeoutDuration := time.Duration(opts.timeout) * time.Second
+	stdout, stderr, err := client.ExecSync(opts.id, opts.cmd, timeoutDuration)
 	if err != nil {
 		return 1, err
 	}


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Correctly convert the `int64` timeout in seconds to a `time.Duration` type.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Requires a new release since this regression seems critical.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `crictl exec --timeout` value to correctly represent seconds.
```
