### PR TITLE
Validate container status in volume mount tests

### DIFF
--- a/pkg/framework/test_context.go
+++ b/pkg/framework/test_context.go
@@ -120,6 +120,9 @@ var TestContext TestContextType
 // DefaultRegistryPrefix specifies the default prefix used for images
 const DefaultRegistryPrefix = "docker.io/library"
 
+const DockerShimSockPathUnix = "unix:///var/run/dockershim.sock"
+const DockerShimSockPathWindows = "npipe:////./pipe/dockershim"
+
 // RegisterFlags registers flags to e2e test suites.
 func RegisterFlags() {
 	suite, reporter := ginkgo.GinkgoConfiguration()
@@ -139,10 +142,10 @@ func RegisterFlags() {
 	flag.StringVar(&testImagesFilePath, "test-images-file", "", "Optional path to a YAML file containing references to custom container images to be used in tests.")
 	flag.DurationVar(&TestContext.ImageServiceTimeout, "image-service-timeout", 300*time.Second, "Timeout when trying to connect to image service.")
 
-	svcaddr := "unix:///var/run/dockershim.sock"
+	svcaddr := DockerShimSockPathUnix
 	defaultConfigPath := "/etc/crictl.yaml"
 	if runtime.GOOS == "windows" {
-		svcaddr = "npipe:////./pipe/dockershim"
+		svcaddr = DockerShimSockPathWindows
 		defaultConfigPath = filepath.Join(os.Getenv("USERPROFILE"), ".crictl", "crictl.yaml")
 	}
 	flag.StringVar(&TestContext.ConfigPath, "config", defaultConfigPath, "Location of the client config file. If not specified and the default does not exist, the program's directory is searched as well")


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We fixed an issue in CRI-O returning an invalid container status on different mount propagations: https://github.com/cri-o/cri-o/pull/5981

To avoid such failures everywhere, we now also validate the container status in critest.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/cri-o/cri-o/pull/5981
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Verify container status on all three "Container Mount Propagation" critest cases.
```
