### PR TITLE
Switch to golang native error wrapping

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	internalapi "k8s.io/cri-api/pkg/apis"
@@ -62,7 +61,7 @@ var runtimeAttachCommand = &cli.Command{
 		}
 		err = Attach(runtimeClient, opts)
 		if err != nil {
-			return errors.Wrap(err, "attaching running container failed")
+			return fmt.Errorf("attaching running container failed: %w", err)
 
 		}
 		return nil

--- a/cmd/crictl/config.go
+++ b/cmd/crictl/config.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 
 	"github.com/kubernetes-sigs/cri-tools/pkg/common"
@@ -64,7 +63,7 @@ CRICTL OPTIONS:
 		// Get config from file.
 		config, err := common.ReadConfig(configFile)
 		if err != nil {
-			return errors.Wrap(err, "load config file")
+			return fmt.Errorf("load config file: %w", err)
 		}
 		if context.IsSet("get") {
 			get := context.String("get")
@@ -82,7 +81,7 @@ CRICTL OPTIONS:
 			case "disable-pull-on-run":
 				fmt.Println(config.DisablePullOnRun)
 			default:
-				return errors.Errorf("no configuration option named %s", get)
+				return fmt.Errorf("no configuration option named %s", get)
 			}
 			return nil
 		} else if context.IsSet("set") {
@@ -92,7 +91,7 @@ CRICTL OPTIONS:
 				for _, option := range options {
 					pair := strings.Split(option, "=")
 					if len(pair) != 2 {
-						return errors.Errorf("incorrectly specified option: %v", setting)
+						return fmt.Errorf("incorrectly specified option: %v", setting)
 					}
 					key := pair[0]
 					value := pair[1]
@@ -125,29 +124,29 @@ func setValue(key, value string, config *common.Config) error {
 	case "timeout":
 		n, err := strconv.Atoi(value)
 		if err != nil {
-			return errors.Wrapf(err, "parse timeout value '%s'", value)
+			return fmt.Errorf("parse timeout value '%s': %w", value, err)
 		}
 		config.Timeout = n
 	case "debug":
 		debug, err := strconv.ParseBool(value)
 		if err != nil {
-			return errors.Wrapf(err, "parse debug value '%s'", value)
+			return fmt.Errorf("parse debug value '%s': %w", value, err)
 		}
 		config.Debug = debug
 	case "pull-image-on-create":
 		pi, err := strconv.ParseBool(value)
 		if err != nil {
-			return errors.Wrapf(err, "parse pull-image-on-create value '%s'", value)
+			return fmt.Errorf("parse pull-image-on-create value '%s': %w", value, err)
 		}
 		config.PullImageOnCreate = pi
 	case "disable-pull-on-run":
 		pi, err := strconv.ParseBool(value)
 		if err != nil {
-			return errors.Wrapf(err, "parse disable-pull-on-run value '%s'", value)
+			return fmt.Errorf("parse disable-pull-on-run value '%s': %w", value, err)
 		}
 		config.DisablePullOnRun = pi
 	default:
-		return errors.Errorf("no configuration option named %s", key)
+		return fmt.Errorf("no configuration option named %s", key)
 	}
 	return nil
 }

--- a/cmd/crictl/container_stats.go
+++ b/cmd/crictl/container_stats.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	internalapi "k8s.io/cri-api/pkg/apis"
@@ -115,7 +114,7 @@ var statsCommand = &cli.Command{
 		}
 
 		if err = ContainerStats(runtimeClient, opts); err != nil {
-			return errors.Wrap(err, "get container stats")
+			return fmt.Errorf("get container stats: %w", err)
 		}
 		return nil
 	},

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	dockerterm "github.com/docker/docker/pkg/term"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	restclient "k8s.io/client-go/rest"
@@ -85,7 +84,7 @@ var runtimeExecCommand = &cli.Command{
 		if context.Bool("sync") {
 			exitCode, err := ExecSync(runtimeClient, opts)
 			if err != nil {
-				return errors.Wrap(err, "execing command in container synchronously")
+				return fmt.Errorf("execing command in container synchronously: %w", err)
 			}
 			if exitCode != 0 {
 				return cli.NewExitError("non-zero exit code", exitCode)
@@ -94,7 +93,7 @@ var runtimeExecCommand = &cli.Command{
 		}
 		err = Exec(runtimeClient, opts)
 		if err != nil {
-			return errors.Wrap(err, "execing command in container")
+			return fmt.Errorf("execing command in container: %w", err)
 		}
 		return nil
 	},

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -17,7 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	internalapi "k8s.io/cri-api/pkg/apis"
@@ -54,7 +55,7 @@ var runtimeStatusCommand = &cli.Command{
 
 		err = Info(context, runtimeClient)
 		if err != nil {
-			return errors.Wrap(err, "getting status of runtime")
+			return fmt.Errorf("getting status of runtime: %w", err)
 		}
 		return nil
 	},

--- a/cmd/crictl/portforward.go
+++ b/cmd/crictl/portforward.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	restclient "k8s.io/client-go/rest"
@@ -53,7 +52,7 @@ var runtimePortForwardCommand = &cli.Command{
 		}
 		err = PortForward(runtimeClient, opts)
 		if err != nil {
-			return errors.Wrap(err, "port forward")
+			return fmt.Errorf("port forward: %w", err)
 
 		}
 		return nil

--- a/cmd/crictl/templates.go
+++ b/cmd/crictl/templates.go
@@ -19,10 +19,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"text/template"
-
-	"github.com/pkg/errors"
 )
 
 func builtinTmplFuncs() template.FuncMap {
@@ -53,19 +52,19 @@ func tmplExecuteRawJSON(tmplStr string, rawJSON string) (string, error) {
 
 	var raw interface{}
 	if err := dec.Decode(&raw); err != nil {
-		return "", errors.Wrapf(err, "failed to decode json")
+		return "", fmt.Errorf("failed to decode json: %w", err)
 	}
 
 	var o = new(bytes.Buffer)
 	tmpl, err := template.New("tmplExecuteRawJSON").Funcs(builtinTmplFuncs()).Parse(tmplStr)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to generate go-template")
+		return "", fmt.Errorf("failed to generate go-template: %w", err)
 	}
 
 	// return error if key doesn't exist
 	tmpl = tmpl.Option("missingkey=error")
 	if err := tmpl.Execute(o, raw); err != nil {
-		return "", errors.Wrapf(err, "failed to template data")
+		return "", fmt.Errorf("failed to template data: %w", err)
 	}
 	return o.String(), nil
 }

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -169,7 +170,7 @@ func loadPodSandboxConfig(path string) (*pb.PodSandboxConfig, error) {
 func openFile(path string) (*os.File, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("config at %s not found", path)
 		}
 		return nil, err

--- a/cmd/crictl/version.go
+++ b/cmd/crictl/version.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	internalapi "k8s.io/cri-api/pkg/apis"
@@ -37,7 +36,7 @@ var runtimeVersionCommand = &cli.Command{
 		}
 		err = Version(runtimeClient, string(remote.CRIVersionV1))
 		if err != nil {
-			return errors.Wrap(err, "getting the runtime version")
+			return fmt.Errorf("getting the runtime version: %w", err)
 		}
 		return nil
 	},

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/opencontainers/runc v1.1.3
 	github.com/opencontainers/selinux v1.10.1
 	github.com/pborman/uuid v1.2.1
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/urfave/cli/v2 v2.11.0
 	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9
@@ -58,6 +57,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -17,11 +17,11 @@ limitations under the License.
 package common
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // ServerConfiguration is the config for connecting to and using a CRI server
@@ -44,22 +44,22 @@ type ServerConfiguration struct {
 func GetServerConfigFromFile(configFileName, currentDir string) (*ServerConfiguration, error) {
 	serverConfig := ServerConfiguration{}
 	if _, err := os.Stat(configFileName); err != nil {
-		if !os.IsNotExist(err) {
-			return nil, errors.Wrap(err, "load config file")
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("load config file: %w", err)
 		}
 		// If the config file was not found, try looking in the program's
 		// directory as a fallback. This is to accommodate where the config file
 		// is placed with the cri tools binary.
 		configFileName = filepath.Join(filepath.Dir(currentDir), "crictl.yaml")
 		if _, err := os.Stat(configFileName); err != nil {
-			return nil, errors.Wrap(err, "load config file")
+			return nil, fmt.Errorf("load config file: %w", err)
 		}
 	}
 
 	// Get config from file.
 	config, err := ReadConfig(configFileName)
 	if err != nil {
-		return nil, errors.Wrap(err, "load config file")
+		return nil, fmt.Errorf("load config file: %w", err)
 	}
 
 	// Set the config from file to the server config struct for return

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -17,12 +17,12 @@ limitations under the License.
 package common
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	gofilepath "path/filepath"
 	"strconv"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -106,25 +106,25 @@ func getConfigOptions(yamlData yaml.Node) (*Config, error) {
 		case "timeout":
 			config.Timeout, err = strconv.Atoi(value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "parsing config option '%s'", name)
+				return nil, fmt.Errorf("parsing config option '%s': %w", name, err)
 			}
 		case "debug":
 			config.Debug, err = strconv.ParseBool(value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "parsing config option '%s'", name)
+				return nil, fmt.Errorf("parsing config option '%s': %w", name, err)
 			}
 		case "pull-image-on-create":
 			config.PullImageOnCreate, err = strconv.ParseBool(value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "parsing config option '%s'", name)
+				return nil, fmt.Errorf("parsing config option '%s': %w", name, err)
 			}
 		case "disable-pull-on-run":
 			config.DisablePullOnRun, err = strconv.ParseBool(value)
 			if err != nil {
-				return nil, errors.Wrapf(err, "parsing config option '%s'", name)
+				return nil, fmt.Errorf("parsing config option '%s': %w", name, err)
 			}
 		default:
-			return nil, errors.Errorf("Config option '%s' is not valid", name)
+			return nil, fmt.Errorf("Config option '%s' is not valid", name)
 		}
 		indx += 2
 	}

--- a/pkg/validate/apparmor_linux.go
+++ b/pkg/validate/apparmor_linux.go
@@ -18,6 +18,7 @@ package validate
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -25,7 +26,6 @@ import (
 
 	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	"github.com/opencontainers/runc/libcontainer/apparmor"
-	"github.com/pkg/errors"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -149,14 +149,14 @@ func checkContainerApparmor(rc internalapi.RuntimeService, containerID string, s
 func loadTestProfiles() error {
 	f, err := ioutil.TempFile("/tmp", "apparmor")
 	if err != nil {
-		return errors.Wrap(err, "open temp file")
+		return fmt.Errorf("open temp file: %w", err)
 	}
 	defer os.Remove(f.Name())
 	defer f.Close()
 
 	// write test profiles to a temp file.
 	if _, err = f.WriteString(testProfiles); err != nil {
-		return errors.Wrap(err, "write profiles to file")
+		return fmt.Errorf("write profiles to file: %w", err)
 	}
 
 	// load apparmor profiles into kernel.
@@ -173,7 +173,7 @@ func loadTestProfiles() error {
 			glog.Infof("apparmor_parser: %s", out)
 		}
 
-		return errors.Wrap(err, "load profiles")
+		return fmt.Errorf("load profiles: %w", err)
 	}
 
 	glog.V(2).Infof("Loaded profiles: %v", out)

--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -563,7 +563,7 @@ func pathExists(path string) bool {
 	if err == nil {
 		return true
 	}
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return false
 	}
 	framework.ExpectNoError(err, "failed to check whether %q Exists: %v", path, err)

--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
-	"github.com/pkg/errors"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -1117,7 +1116,7 @@ func createAndCheckHostNetwork(rc internalapi.RuntimeService, ic internalapi.Ima
 func createSeccompProfileDir() (string, error) {
 	hostPath, err := ioutil.TempDir("", "seccomp-tests")
 	if err != nil {
-		return "", errors.Wrapf(err, "create tempdir %q", hostPath)
+		return "", fmt.Errorf("create tempdir %q: %w", hostPath, err)
 	}
 	return hostPath, nil
 }
@@ -1127,7 +1126,7 @@ func createSeccompProfile(profileContents string, profileName string, hostPath s
 	profilePath := filepath.Join(hostPath, profileName)
 	err := ioutil.WriteFile(profilePath, []byte(profileContents), 0644)
 	if err != nil {
-		return "", errors.Wrapf(err, "create %s", profilePath)
+		return "", fmt.Errorf("create %s: %w", profilePath, err)
 	}
 	return profilePath, nil
 }

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -137,7 +138,7 @@ func SetupCrio() string {
 	)
 	tmpDir := filepath.Join(os.TempDir(), "crio-tmp")
 
-	if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
+	if _, err := os.Stat(tmpDir); errors.Is(err, os.ErrNotExist) {
 		logrus.Info("cloning and building CRI-O")
 
 		Expect(checkoutAndBuild(tmpDir, crioURL, crioVersion)).To(BeNil())


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We now use the golang native error wrapping instead of the deprecated `github.com/pkg/errors` library.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

```release-note
None
```