### PR TITLE
Ensure benchmarks are skipped during validation tests.

### DIFF
--- a/cmd/critest/cri_test.go
+++ b/cmd/critest/cri_test.go
@@ -180,8 +180,9 @@ func TestCRISuite(t *testing.T) {
 		flag.Set("ginkgo.succinct", "true")
 	} else {
 		// Skip benchmark measurements for validation tests.
-		flag.Set("ginkgo.skipMeasurements", "true")
+		flag.Set("ginkgo.skip", "benchmark")
 	}
+
 	if *parallel > 1 {
 		runParallelTestSuite(t)
 	} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

This patch ensures that all specs containing "benchmark" will be skipped
unless the `-benchmark` flag is explicitly provided.

#### Which issue(s) this PR fixes:

Following the switch to Ginkgo v2 in #938, running `critest`
without the `-benchmark` flag will erroneously run some benchmark
specs alongside the validation ones too.

Evidence of this most visible in the [containerd CRI-Integration workflows on Windows](https://github.com/containerd/containerd/actions/workflows/windows-periodic-trigger.yml), where the unexpectedly-run benchmarks [have default timeouts which consistently fail on Windows](https://github.com/containerd/containerd/runs/8083135565?check_suite_focus=true#step:21:196).

#### Special notes for your reviewer:

The root cause is [this switch away from `ginkgo.Measure`](https://github.com/kubernetes-sigs/cri-tools/pull/938/files#diff-7a5c1ad8de021d406c2a9f1f8dd114fb94216b5fa9170a09a84a81859e255d99L60), which means that [the `ginkgo.skipMeasurements` flag we set internally](https://github.com/kubernetes-sigs/cri-tools/blob/master/cmd/critest/cri_test.go#L183) is made completely redundant.

I can confirm that this implementation will still allow the direct use of `-ginkgo.skip/focus='...'` with full regexes by users so there should be no hidden regression when it comes to controlling ginkgo by providing extra flags to `critest`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>