### PR TITLE
Print deleted digest when repo tags empty

### DIFF
--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -406,6 +406,14 @@ var removeImageCommand = &cli.Command{
 				}
 				continue
 			}
+			if len(status.Image.RepoTags) == 0 {
+				// RepoTags is nil when pulling image by repoDigest,
+				// so print deleted using that instead.
+				for _, repoDigest := range status.Image.RepoDigests {
+					fmt.Printf("Deleted: %s\n", repoDigest)
+				}
+				continue
+			}
 			for _, repoTag := range status.Image.RepoTags {
 				fmt.Printf("Deleted: %s\n", repoTag)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR updates the `crictl rmi` command to print the repoDigests of deleted images where the image has no repoTags, which can happen when the image digest is used for pulling the image. Currently when this happens the images are deleted with no output whatsoever to indicate this has happened.

#### Which issue(s) this PR fixes:

Fixes #976

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Added output to `crictl rmi` when deleting images that were pulled by digest and therefore have no tags.
```
