### PR TITLE
WIP: Add test to stop/exit container via attach

### DIFF
--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -392,16 +392,23 @@ func getContainerStatus(c internalapi.RuntimeService, containerID string) *runti
 }
 
 // createShellContainer creates a container to run /bin/sh.
-func createShellContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, prefix string) string {
+func createShellContainer(
+	rc internalapi.RuntimeService,
+	ic internalapi.ImageManagerService,
+	podID string,
+	podConfig *runtimeapi.PodSandboxConfig,
+	prefix string,
+	stdin, stdinOnce, tty bool,
+) string {
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata:  framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
 		Image:     &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
 		Command:   shellCmd,
 		Linux:     &runtimeapi.LinuxContainerConfig{},
-		Stdin:     true,
-		StdinOnce: true,
-		Tty:       false,
+		Stdin:     stdin,
+		StdinOnce: stdinOnce,
+		Tty:       tty,
 	}
 
 	return framework.CreateContainer(rc, ic, containerConfig, podID, podConfig)
@@ -572,8 +579,9 @@ func pathExists(path string) bool {
 
 // parseDockerJSONLog parses logs in Docker JSON log format.
 // Docker JSON log format example:
-//   {"log":"content 1","stream":"stdout","time":"2016-10-20T18:39:20.57606443Z"}
-//   {"log":"content 2","stream":"stderr","time":"2016-10-20T18:39:20.57606444Z"}
+//
+//	{"log":"content 1","stream":"stdout","time":"2016-10-20T18:39:20.57606443Z"}
+//	{"log":"content 2","stream":"stderr","time":"2016-10-20T18:39:20.57606444Z"}
 func parseDockerJSONLog(log []byte, msg *logMessage) {
 	var l jsonlog.JSONLog
 
@@ -587,8 +595,9 @@ func parseDockerJSONLog(log []byte, msg *logMessage) {
 
 // parseCRILog parses logs in CRI log format.
 // CRI log format example :
-//   2016-10-06T00:17:09.669794202Z stdout P The content of the log entry 1
-//   2016-10-06T00:17:10.113242941Z stderr F The content of the log entry 2
+//
+//	2016-10-06T00:17:09.669794202Z stdout P The content of the log entry 1
+//	2016-10-06T00:17:10.113242941Z stderr F The content of the log entry 2
 func parseCRILog(log string, msg *logMessage) {
 	logMessage := strings.SplitN(log, " ", 4)
 	if len(log) < 4 {


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
There may be issues with the whole container attach life-cycle which cannot be covered by the existing attach test. This means we now add a dedicated attach test to exit a container and check it's status by using stdin via a tty.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `runtime should support attach to stop a container [Conformance]` critest case.
```
