### PR TITLE
Cleanup owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,13 @@
-# See the OWNERS file documentation:
-#  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
+# See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - Random-Liu
-  - dchen1107
   - feiskyer
-  - heartlock
-  - mrunalp
   - saschagrunert
-  - tallclair
-  - xlgao-zju
-  - yujuhong
-  - runcom
+  - sig-node-approvers
 
 emeritus_approvers:
   - euank
+  - heartlock
+  - tallclair
+  - xlgao-zju
+  - runcom

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  # From https://github.com/kubernetes/kubernetes/blob/master/OWNERS_ALIASES#LC220
+  sig-node-approvers:
+    # - dchen1107 # not in k-sigs org
+    # - sjenning # not in k-sigs org
+    - Random-Liu
+    - derekwaynecarr
+    - klueska
+    - mrunalp
+    - yujuhong


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now move all `sig-node-approvers` to a synched alias in `OWNERS_ALIASES` to simplify ownership. We also move @heartlock, @tallclair, @xlgao-zju and @runcom to emeritus since they have not been active in the past year.

Please mention on this PR if you still would like to be approver for this project. :)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

cc @Random-Liu @dchen1107 @derekwaynecarr @yujuhong @sjenning @mrunalp @klueska

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
