### PR TITLE
Implement password input on the command line

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -77,6 +77,10 @@ type pullOptions struct {
 	// auth is a base64 encoded 'USERNAME[:PASSWORD]' string used for
 	// authentication with a registry when pulling an image
 	auth string
+
+	// Username to use for accessing the registry
+	// password will be requested on the command line
+	username string
 }
 
 var createPullFlags = []cli.Flag{
@@ -98,6 +102,11 @@ var createPullFlags = []cli.Flag{
 		Value: "",
 		Usage: "Use `AUTH_STRING` for accessing the registry. AUTH_STRING is a base64 encoded 'USERNAME[:PASSWORD]'",
 	},
+	&cli.StringFlag{
+		Name:  "username",
+		Value: "",
+		Usage: "Use `USERNAME` for accessing the registry. The password will be requested on the command line",
+	},
 }
 
 var runPullFlags = []cli.Flag{
@@ -118,6 +127,11 @@ var runPullFlags = []cli.Flag{
 		Name:  "auth",
 		Value: "",
 		Usage: "Use `AUTH_STRING` for accessing the registry. AUTH_STRING is a base64 encoded 'USERNAME[:PASSWORD]'",
+	},
+	&cli.StringFlag{
+		Name:  "username",
+		Value: "",
+		Usage: "Use `USERNAME` for accessing the registry. password will be requested",
 	},
 }
 
@@ -158,6 +172,7 @@ var createContainerCommand = &cli.Command{
 					withPull: withPull,
 					creds:    context.String("creds"),
 					auth:     context.String("auth"),
+					username: context.String("username"),
 				},
 				timeout: context.Duration("cancel-timeout"),
 			},
@@ -571,6 +586,7 @@ var runContainerCommand = &cli.Command{
 				withPull: withPull,
 				creds:    context.String("creds"),
 				auth:     context.String("auth"),
+				username: context.String("username"),
 			},
 			timeout: context.Duration("timeout"),
 		}
@@ -684,7 +700,7 @@ func CreateContainer(
 	// reminder if the image is already in cache only the manifest will be pulled
 	// down to verify.
 	if opts.withPull {
-		auth, err := getAuth(opts.creds, opts.auth)
+		auth, err := getAuth(opts.creds, opts.auth, opts.username)
 		if err != nil {
 			return "", err
 		}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/otel/trace v0.20.0
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+	golang.org/x/term v0.0.0-20220919170432-7a66f970e087
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
@@ -76,7 +77,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.20.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	golang.org/x/tools v0.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20220919170432-7a66f970e087 h1:tPwmk4vmvVCMdr98VgL4JH+qZxPL8fqlUOHnyOM8N3w=
+golang.org/x/term v0.0.0-20220919170432-7a66f970e087/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/vendor/golang.org/x/term/AUTHORS
+++ b/vendor/golang.org/x/term/AUTHORS
@@ -1,3 +1,0 @@
-# This source code refers to The Go Authors for copyright purposes.
-# The master list of authors is in the main Go distribution,
-# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/term/CONTRIBUTORS
+++ b/vendor/golang.org/x/term/CONTRIBUTORS
@@ -1,3 +1,0 @@
-# This source code was written by the Go contributors.
-# The master list of contributors is in the main Go distribution,
-# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/term/term.go
+++ b/vendor/golang.org/x/term/term.go
@@ -7,11 +7,11 @@
 //
 // Putting a terminal into raw mode is the most common requirement:
 //
-// 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
-// 	if err != nil {
-// 	        panic(err)
-// 	}
-// 	defer term.Restore(int(os.Stdin.Fd()), oldState)
+//	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+//	if err != nil {
+//	        panic(err)
+//	}
+//	defer term.Restore(int(os.Stdin.Fd()), oldState)
 //
 // Note that on non-Unix systems os.Stdin.Fd() may not be 0.
 package term

--- a/vendor/golang.org/x/term/terminal.go
+++ b/vendor/golang.org/x/term/terminal.go
@@ -935,7 +935,7 @@ func (s *stRingBuffer) Add(a string) {
 // next most recent, and so on. If such an element doesn't exist then ok is
 // false.
 func (s *stRingBuffer) NthPreviousEntry(n int) (value string, ok bool) {
-	if n >= s.size {
+	if n < 0 || n >= s.size {
 		return "", false
 	}
 	index := s.head - n

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -301,7 +301,7 @@ golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/plan9
 golang.org/x/sys/unix
 golang.org/x/sys/windows
-# golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+# golang.org/x/term v0.0.0-20220919170432-7a66f970e087
 ## explicit; go 1.17
 golang.org/x/term
 # golang.org/x/text v0.3.7


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Rather than writing full credentials on the command line when pulling an image this option allows user to pass a username and get asked for the password as can be done with the ssh command line application.

#### Which issue(s) this PR fixes:

Fixes #996

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added: enter password on the command line for pull related commands

A new option has been introduced to allow user to enter the registry password securely on the command line rather than as part of the command itself.

Example:
    crictl pull --username foobar registry.example.com/myimage:mytag
```
