### PR TITLE
critest: added a validation case for SupplementalGroups with the pre-defined groups in the container image

### DIFF
--- a/images/image-test/Dockerfile
+++ b/images/image-test/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2018 The Kubernetes Authors.
+# Copyright 2022 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -96,6 +96,9 @@ const (
 	imageUserUIDGroup          = int64(1003)
 	testImageUserUsernameGroup = registry + "test-image-user-username-group"
 	imageUserUsernameGroup     = "www-data"
+	testImagePreDefinedGroup   = registry + "test-image-predefined-group"
+	imagePredefinedGroupUID    = int64(1000)
+	imagePredefinedGroupGID    = int64(50000)
 
 	// Linux defaults
 	testLinuxImageWithoutTag        = registry + "test-image-latest"

--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -322,7 +322,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			podID, podConfig, podLogDir = createPodSandboxWithLogDirectory(rc)
 
 			By("create container for security context SupplementalGroups")
-			supplementalGroups := []int64{1234, 5678}
+			supplementalGroup := int64(1234)
 			containerName := "container-with-SupplementalGroups-and-predefined-group-image-test-" + framework.NewUUID()
 			logPath := fmt.Sprintf("%s.log", containerName)
 			containerConfig := &runtimeapi.ContainerConfig{
@@ -332,7 +332,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 				Linux: &runtimeapi.LinuxContainerConfig{
 					SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
 						RunAsUser:          &runtimeapi.Int64Value{Value: imagePredefinedGroupUID},
-						SupplementalGroups: supplementalGroups,
+						SupplementalGroups: []int64{supplementalGroup},
 					},
 				},
 				LogPath: logPath,
@@ -352,12 +352,12 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			//
 			// thus, supplementary group of the container processes should be
 			// - 1000: self
-			// - 1234 5678: SupplementalGroups
+			// - 1234: SupplementalGroups
 			// - 50000: groups define in the container image
 			//
 			// $ id -G
 			// 1000 1234 5678 50000
-			expectedOutput := fmt.Sprintf("%d 1234 5678 %d\n", imagePredefinedGroupUID, imagePredefinedGroupGID)
+			expectedOutput := fmt.Sprintf("%d %d %d\n", imagePredefinedGroupUID, supplementalGroup, imagePredefinedGroupGID)
 
 			By("verify groups for the first process of the container")
 			verifyLogContents(podConfig, logPath, expectedOutput, stdoutType)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In most cri implementations, at least containerd and cri-o, when the container's primary UID belongs to some groups in the container image, `SupplementalGroups` are just added to them even if `SupplementalGroups` does not include them (see https://github.com/kubernetes/kubernetes/issues/112879). 

However, the behavior is not clearly stated in the API descriptions of `SupplementalGroups` both in [kubernetes](https://github.com/kubernetes/api/blob/master/core/v1/types.go#L3563-L3568) and [cri-api](https://github.com/kubernetes/cri-api/blob/v0.25.3/pkg/apis/runtime/v1/api.proto#L821-L823).

To improve the situation, in https://github.com/kubernetes/kubernetes/pull/113047, I try to clarify the behavior in the API description of `SupplementalGroups` both in kubernetes and cri-api. 

This PR added a test case to critest to validate the behavior as @haircommander recommended in  [the k/k PR](https://github.com/kubernetes/kubernetes/pull/113047#discussion_r997217751).


#### Which issue(s) this PR fixes:

ref: https://github.com/kubernetes/kubernetes/pull/113047#discussion_r997217751

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
