### PR TITLE
test-image: add test image for testing SupplementalGroups with predefined groups in the container image

### DIFF
--- a/images/build
+++ b/images/build
@@ -68,6 +68,9 @@ for IMAGE in "${!IMAGE_USERS[@]}"; do
     build_image ./image-user "$IMAGE" --build-arg "USER=$USER"
 done
 
+# Build the user with pre-defined group image
+build_image ./image-predefined-group test-image-predefined-group
+
 # Build the hostnet image
 build_image ./hostnet-nginx hostnet-nginx
 

--- a/images/image-predefined-group/Dockerfile
+++ b/images/image-predefined-group/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox
+
+# User default-user(uid=1000) belongs to
+# group-defined-in-image(gid=50000) group in this image.
+RUN adduser -u 1000 -D default-user && \
+    addgroup -g 50000 group-defined-in-image && \
+    addgroup default-user group-defined-in-image
+
+# Default User of the image is default-user(uid=1000)
+USER 1000:1000


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Added a test image for testing `SupplementalGroups` in the case when there are pre-defined groups in the container image for the container's primary UID.

#### Which issue(s) this PR fixes:

This is a supplementary PR for https://github.com/kubernetes-sigs/cri-tools/pull/1005 to use the test image in CI.
(ref: https://github.com/kubernetes-sigs/cri-tools/pull/1005/files#r997942643)
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:


```

```

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
