### PR TITLE
test-image: images/image-predefined-groups: stop specifying group in USER directive in Dockerfile

### DIFF
--- a/images/image-predefined-group/Dockerfile
+++ b/images/image-predefined-group/Dockerfile
@@ -21,4 +21,4 @@ RUN adduser -u 1000 -D default-user && \
     addgroup default-user group-defined-in-image
 
 # Default User of the image is default-user(uid=1000)
-USER 1000:1000
+USER 1000


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

It is just because this is not suitable for the test case for SupplementalGroups with pre-defined groups in the container image. In the test case, default user needs to belong to supplementary group in the container image.

ref: https://docs.docker.com/engine/reference/builder/#user
> When specifying a group for the user, the user will have
> only the specified group membership. Any other configured group
> memberships will be ignored.

The image is used in #1005.

#### Which issue(s) this PR fixes:

#1005 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
