### PR TITLE
critest: ensure server is running before portforward

### DIFF
--- a/pkg/validate/multi_container_linux.go
+++ b/pkg/validate/multi_container_linux.go
@@ -76,7 +76,7 @@ var _ = framework.KubeDescribe("Multiple Containers [Conformance]", func() {
 		})
 
 		It("should support network", func() {
-			checkMainPage(rc, podID, 0)
+			checkMainPage(rc, podID, 0, httpdContainerPort)
 		})
 
 		It("should support container log", func() {

--- a/pkg/validate/networking.go
+++ b/pkg/validate/networking.go
@@ -100,7 +100,7 @@ var _ = framework.KubeDescribe("Networking", func() {
 			startContainer(rc, containerID)
 
 			By("check the port mapping with only container port")
-			checkMainPage(rc, podID, 0)
+			checkMainPage(rc, podID, 0, webServerContainerPort)
 		})
 
 		It("runtime should support port mapping with host port and container port [Conformance]", func() {
@@ -121,7 +121,7 @@ var _ = framework.KubeDescribe("Networking", func() {
 			startContainer(rc, containerID)
 
 			By("check the port mapping with host port and container port")
-			checkMainPage(rc, "", webServerHostPortForPortMapping)
+			checkMainPage(rc, "", webServerHostPortForPortMapping, 0)
 		})
 	})
 })
@@ -229,7 +229,7 @@ func createHostNetWebServerContainer(rc internalapi.RuntimeService, ic internala
 }
 
 // checkMainPage check if the we can get the main page of the pod via given IP:port.
-func checkMainPage(c internalapi.RuntimeService, podID string, hostPort int32) {
+func checkMainPage(c internalapi.RuntimeService, podID string, hostPort int32, containerPort int32) {
 	By("get the IP:port needed to be checked")
 	var err error
 	var resp *http.Response
@@ -241,7 +241,7 @@ func checkMainPage(c internalapi.RuntimeService, podID string, hostPort int32) {
 		status := getPodSandboxStatus(c, podID)
 		Expect(status.GetNetwork()).NotTo(BeNil(), "The network in status should not be nil.")
 		Expect(status.GetNetwork().Ip).NotTo(BeNil(), "The IP should not be nil.")
-		url += status.GetNetwork().Ip + ":" + strconv.Itoa(int(webServerContainerPort))
+		url += status.GetNetwork().Ip + ":" + strconv.Itoa(int(containerPort))
 	}
 	framework.Logf("the IP:port is " + url)
 

--- a/pkg/validate/streaming.go
+++ b/pkg/validate/streaming.go
@@ -137,6 +137,9 @@ var _ = framework.KubeDescribe("Streaming", func() {
 			By("start the web server container")
 			startContainer(rc, containerID)
 
+			By("ensure the web server container is serving")
+			checkMainPage(rc, podID, 0, webServerContainerPort)
+
 			req := createDefaultPortForward(rc, podID)
 
 			By("check the output of portforward")
@@ -336,6 +339,6 @@ func checkPortForward(c internalapi.RuntimeService, portForwardSeverURL string, 
 	}()
 
 	By(fmt.Sprintf("check if we can get nginx main page via localhost:%d", hostPort))
-	checkMainPage(c, "", hostPort)
+	checkMainPage(c, "", hostPort, 0)
 	framework.Logf("Check port forward url %q succeed", portForwardSeverURL)
 }

--- a/pkg/validate/streaming_linux.go
+++ b/pkg/validate/streaming_linux.go
@@ -61,6 +61,9 @@ var _ = framework.KubeDescribe("Streaming", func() {
 			By("start the web server container")
 			startContainer(rc, containerID)
 
+			By("ensure the web server container is serving")
+			checkMainPage(rc, "", webServerHostNetContainerPort, 0)
+
 			req := createDefaultPortForward(rc, podID)
 
 			By("check the output of portforward")


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake


#### What this PR does / why we need it:

containerd CI hits many times on the connect refused when it run portforward related cases [1]. Since the CI is running in the github-hosted runner, the host is 2-core CPU [2]. When the host is in high load, the nginx server maybe not start in time. If we start to forward the target port which is not working, we will get the error like this:

```
// https://github.com/containerd/containerd/actions/runs/3449072353/jobs/5756699959
E1112 02:09:46.452379    5536 portforward.go:406] an error occurred forwarding 12002 -> 12003: error forwarding port 12003 to pod 416d9f91eeb0d1ed9c5f828b245d75b515ff81806e368334f2b0bc826705ca63, uid : failed to execute portforward in network namespace "host": failed to connect to localhost:12003 inside namespace "416d9f91eeb0d1ed9c5f828b245d75b515ff81806e368334f2b0bc826705ca63", IPv4: dial tcp4 127.0.0.1:12003: connect: connection refused IPv6 dial tcp6 [::1]:12003: connect: connection refused
```

It is easy to reproduce when you update the nginx image with the following changes:

```bash
cat /docker-entrypoint.sh
...
sleep 10s
exec "$@"
```

So we should ensure the port is working before portforward.

[1]: https://github.com/containerd/containerd/issues/7264 
[2]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

#### Which issue(s) this PR fixes:

Fixes: https://github.com/containerd/containerd/issues/7264 

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

Signed-off-by: Wei Fu <fuweid89@gmail.com>