### PR TITLE
add missing CPU count

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -264,6 +264,7 @@ var updateContainerCommand = &cli.Command{
 		}
 
 		options := updateOptions{
+			CPUCount:           context.Int64("cpu-count"),
 			CPUMaximum:         context.Int64("cpu-maximum"),
 			CPUPeriod:          context.Int64("cpu-period"),
 			CPUQuota:           context.Int64("cpu-quota"),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently, `crictl update --cpu-count` ignores the specified CPU count parameters and sends an empty update container resources request. 
This PR fixed this to include the specified CPU count parameters.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

No

```release-note
None
```
