### PR TITLE
set LTS v1.6.12 into matrix to replace old v1.5 entry

### DIFF
--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -18,7 +18,7 @@ jobs:
         # ║ hcshim           │           │ runhcs  ║
         # ╚══════════════════╧═══════════╧═════════╝
         os: [ubuntu-18.04, windows-2019]
-        version: [main, 10c12954828e7c7c9b6e0ea9b0c02b01407d3ae1]
+        version: [main, v1.6.12]
         runtime: [io.containerd.runtime.v1.linux, io.containerd.runc.v1, io.containerd.runc.v2, containerd-shim-runhcs-v1]
         runc: [runc, crun]
         exclude:


### PR DESCRIPTION
update containerd test matrix

Signed-off-by: Mike Brown <brownwm@us.ibm.com>

