### PR TITLE
Increase default timeout on Windows

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 )
 
 const defaultTimeout = 2 * time.Second
+const defaultTimeoutWindows = 200 * time.Second
 
 var (
 	// RuntimeEndpoint is CRI server runtime endpoint
@@ -44,7 +46,7 @@ var (
 	ImageEndpoint string
 	// ImageEndpointIsSet is true when ImageEndpoint is configured
 	ImageEndpointIsSet bool
-	// Timeout  of connecting to server (default: 10s)
+	// Timeout  of connecting to server (default: 2s on Linux, 200s on Windows)
 	Timeout time.Duration
 	// Debug enable debug output
 	Debug bool
@@ -135,6 +137,11 @@ func getTimeout(timeDuration time.Duration) time.Duration {
 	if timeDuration.Seconds() > 0 {
 		return timeDuration
 	}
+
+	if runtime.GOOS == "windows" {
+		return defaultTimeoutWindows
+	}
+
 	return defaultTimeout // use default
 }
 


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Most interactions against Windows containers take longer than 2s. This increases the default so the user experience on Windows is better without having to modify every command or know to create a config file with the timeout.  

When creating the first pod it can take a long time to pull due to image container sizes so the timeout here is very high to handle this scenario.  Starting a Pod can take longer than 2s even when the image is already pulled.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
/cc @dcantah @marosset 
/sig windows

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Increase default timeout to 200s when running on Windows 
```
