### PR TITLE
Switch to `registry.k8s.io`

### DIFF
--- a/pkg/framework/test_context.go
+++ b/pkg/framework/test_context.go
@@ -117,11 +117,16 @@ type TestContextType struct {
 // TestContext is a test context.
 var TestContext TestContextType
 
-// DefaultRegistryPrefix specifies the default prefix used for images
-const DefaultRegistryPrefix = "docker.io/library"
+const (
+	// DefaultRegistryPrefix specifies the default prefix used for images.
+	DefaultRegistryPrefix = "registry.k8s.io"
 
-const DockerShimSockPathUnix = "unix:///var/run/dockershim.sock"
-const DockerShimSockPathWindows = "npipe:////./pipe/dockershim"
+	// DefaultRegistryE2ETestImagesPrefix is the default prefix for e2e test images.
+	DefaultRegistryE2ETestImagesPrefix = DefaultRegistryPrefix + "/e2e-test-images/"
+
+	DockerShimSockPathUnix    = "unix:///var/run/dockershim.sock"
+	DockerShimSockPathWindows = "npipe:////./pipe/dockershim"
+)
 
 // RegisterFlags registers flags to e2e test suites.
 func RegisterFlags() {
@@ -161,7 +166,7 @@ func RegisterFlags() {
 	} else {
 		TestContext.IsLcow = false
 	}
-	flag.StringVar(&TestContext.RegistryPrefix, "registry-prefix", DefaultRegistryPrefix, "A possible registry prefix added to all images, like 'localhost:5000/'")
+	flag.StringVar(&TestContext.RegistryPrefix, "registry-prefix", DefaultRegistryPrefix, "A possible registry prefix added to all images, like 'localhost:5000'")
 }
 
 // Loads any external file-based parameters into the TestContextType.

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -94,10 +94,10 @@ const (
 	DefaultStopContainerTimeout int64 = 60
 
 	// DefaultLinuxContainerImage default container image for Linux
-	DefaultLinuxContainerImage string = "k8s.gcr.io/e2e-test-images/busybox:1.29-2"
+	DefaultLinuxContainerImage string = DefaultRegistryE2ETestImagesPrefix + "busybox:1.29-2"
 
 	// DefaultWindowsContainerImage default container image for Windows
-	DefaultWindowsContainerImage string = "k8s.gcr.io/e2e-test-images/busybox:1.29-2"
+	DefaultWindowsContainerImage string = DefaultLinuxContainerImage
 )
 
 // Set the constants based on operating system and flags

--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -197,12 +197,12 @@ const (
 	webServerHostNetContainerPort int32 = 12003
 
 	// Linux defaults
-	webServerLinuxImage        = "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
+	webServerLinuxImage        = framework.DefaultRegistryE2ETestImagesPrefix + "nginx:1.14-2"
 	hostNetWebServerLinuxImage = registry + "hostnet-nginx-" + runtime.GOARCH
 
 	// Windows defaults
-	webServerWindowsImage        = "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
-	hostNetWebServerWindowsImage = "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
+	webServerWindowsImage        = webServerLinuxImage
+	hostNetWebServerWindowsImage = webServerLinuxImage
 )
 
 var (

--- a/pkg/validate/multi_container_linux.go
+++ b/pkg/validate/multi_container_linux.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	httpdContainerPort = 80
-	httpdImage         = "k8s.gcr.io/e2e-test-images/httpd:2.4.39-4"
+	httpdImage         = framework.DefaultRegistryE2ETestImagesPrefix + "httpd:2.4.39-4"
 )
 
 var _ = framework.KubeDescribe("Multiple Containers [Conformance]", func() {

--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -36,9 +36,9 @@ import (
 )
 
 const (
-	nginxContainerImage string = "k8s.gcr.io/e2e-test-images/nginx:1.14-2"
+	nginxContainerImage string = framework.DefaultRegistryE2ETestImagesPrefix + "nginx:1.14-2"
 	localhost           string = "localhost/"
-	noNewPrivsImage     string = "k8s.gcr.io/e2e-test-images/nonewprivs:1.3"
+	noNewPrivsImage     string = framework.DefaultRegistryE2ETestImagesPrefix + "nonewprivs:1.3"
 )
 
 var _ = framework.KubeDescribe("Security Context", func() {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now use `registry.k8s.io` instead of `k8s.gcr.io` for official test images.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Part of https://github.com/kubernetes-sigs/cri-tools/issues/1059
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Switch to `registry.k8s.io` for e2e test images.
```
