### PR TITLE
Pass `nil` as tracer provider

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-	"go.opentelemetry.io/otel/trace"
 
 	internalapi "k8s.io/cri-api/pkg/apis"
 	"k8s.io/kubernetes/pkg/kubelet/cri/remote"
@@ -68,8 +67,6 @@ func getRuntimeService(context *cli.Context, timeout time.Duration) (res interna
 		t = timeout
 	}
 
-	tp := trace.NewNoopTracerProvider()
-
 	// If no EP set then use the default endpoint types
 	if !RuntimeEndpointIsSet {
 		logrus.Warningf("runtime connect using default endpoints: %v. "+
@@ -82,7 +79,7 @@ func getRuntimeService(context *cli.Context, timeout time.Duration) (res interna
 		for _, endPoint := range defaultRuntimeEndpoints {
 			logrus.Debugf("Connect using endpoint %q with %q timeout", endPoint, t)
 
-			res, err = remote.NewRemoteRuntimeService(endPoint, t, tp)
+			res, err = remote.NewRemoteRuntimeService(endPoint, t, nil)
 			if err != nil {
 				logrus.Error(err)
 				continue
@@ -93,7 +90,7 @@ func getRuntimeService(context *cli.Context, timeout time.Duration) (res interna
 		}
 		return res, err
 	}
-	return remote.NewRemoteRuntimeService(RuntimeEndpoint, t, tp)
+	return remote.NewRemoteRuntimeService(RuntimeEndpoint, t, nil)
 }
 
 func getImageService(context *cli.Context) (res internalapi.ImageManagerService, err error) {
@@ -104,7 +101,6 @@ func getImageService(context *cli.Context) (res internalapi.ImageManagerService,
 		ImageEndpoint = RuntimeEndpoint
 		ImageEndpointIsSet = RuntimeEndpointIsSet
 	}
-	tp := trace.NewNoopTracerProvider()
 
 	logrus.Debugf("get image connection")
 	// If no EP set then use the default endpoint types
@@ -119,7 +115,7 @@ func getImageService(context *cli.Context) (res internalapi.ImageManagerService,
 		for _, endPoint := range defaultRuntimeEndpoints {
 			logrus.Debugf("Connect using endpoint %q with %q timeout", endPoint, Timeout)
 
-			res, err = remote.NewRemoteImageService(endPoint, Timeout, tp)
+			res, err = remote.NewRemoteImageService(endPoint, Timeout, nil)
 			if err != nil {
 				logrus.Error(err)
 				continue
@@ -130,7 +126,7 @@ func getImageService(context *cli.Context) (res internalapi.ImageManagerService,
 		}
 		return res, err
 	}
-	return remote.NewRemoteImageService(ImageEndpoint, Timeout, tp)
+	return remote.NewRemoteImageService(ImageEndpoint, Timeout, nil)
 }
 
 func getTimeout(timeDuration time.Duration) time.Duration {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/pborman/uuid v1.2.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/urfave/cli/v2 v2.23.7
-	go.opentelemetry.io/otel/trace v1.10.0
 	golang.org/x/net v0.5.0
 	golang.org/x/sys v0.4.0
 	golang.org/x/term v0.4.0
@@ -82,6 +81,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.10.0 // indirect
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.10.0 // indirect
+	go.opentelemetry.io/otel/trace v1.10.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/text v0.6.0 // indirect

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/pborman/uuid"
-	"go.opentelemetry.io/otel/trace"
 	"gopkg.in/yaml.v3"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -140,7 +139,7 @@ func LoadCRIClient() (*InternalAPIClient, error) {
 	rService, err := remote.NewRemoteRuntimeService(
 		TestContext.RuntimeServiceAddr,
 		TestContext.RuntimeServiceTimeout,
-		trace.NewNoopTracerProvider(),
+		nil,
 	)
 	if err != nil {
 		return nil, err
@@ -151,9 +150,7 @@ func LoadCRIClient() (*InternalAPIClient, error) {
 		// Fallback to runtime service endpoint
 		imageServiceAddr = TestContext.RuntimeServiceAddr
 	}
-	iService, err := remote.NewRemoteImageService(imageServiceAddr, TestContext.ImageServiceTimeout,
-		trace.NewNoopTracerProvider(),
-	)
+	iService, err := remote.NewRemoteImageService(imageServiceAddr, TestContext.ImageServiceTimeout, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This allows us to get rid of the direct dependency of `go.opentelemetry.io/otel/trace` and will behave in the same way as the noop-tracer provider.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
