### PR TITLE
Makefile: pass in a custom variable GOARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,15 @@
 MAKEFLAGS += --no-print-directory
 GO ?= go
 
+GOARCH ?= $(shell $(GO) env GOARCH)
+
 # test for go module support
 ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
-export GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
-export GO_TEST=GO111MODULE=on $(GO) test -mod=vendor
+export GO_BUILD=GO111MODULE=on GOARCH=$(GOARCH) $(GO) build -mod=vendor
+export GO_TEST=GO111MODULE=on GOARCH=$(GOARCH) $(GO) test -mod=vendor
 else
-export GO_BUILD=$(GO) build
-export GO_TEST=$(GO) test
+export GO_BUILD=GOARCH=$(GOARCH) $(GO) build
+export GO_TEST=GOARCH=$(GOARCH) $(GO) test
 endif
 
 GOOS := $(shell $(GO) env GOOS)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

It should be possible to pass in `$(GOARCH)` to Makefile, like `$(GOOS)` or other env variables. Without that, it is not possible for users to build multi-arch binaries by running `make` commands.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/cri-tools/issues/1072

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
