### PR TITLE
Run GitHub actions by `push` only on `master` and tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - master
+  pull_request:
 jobs:
   linters:
     name: lint and vendor check/ on ${{ matrix.os }}

--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -1,6 +1,11 @@
 name: critest containerd
-on: [push, pull_request]
-
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - master
+  pull_request:
 jobs:
   #
   # Run CRI tests against containerd

--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -1,6 +1,11 @@
 name: critest CRI-O
-on: [push, pull_request]
-
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - master
+  pull_request:
 jobs:
   #
   # Run CRI tests against CRI-O

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,11 @@
 name: cri-tools e2e test
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - master
+  pull_request:
 jobs:
   test-e2e:
     name: ${{ matrix.os }}


### PR DESCRIPTION



#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Dependabot creates branches which runs the CI twice per PR. To avoid that, we now filter the branches and tags for the `push` event.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
