### PR TITLE
workflows: update to use latest runner images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04]  # TODO: pass linters on 'macos-10.15' and 'windows-2019'
+        os: [ubuntu-18.04]  # TODO: pass linters on 'macos-12' and 'windows-2019'
 
     steps:
       - name: Install Go
@@ -58,7 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]  # TODO: make releases on 'linux-ppc64le' 'windows-2019'
+        os: [ubuntu-18.04, macos-12]  # TODO: make releases on 'linux-ppc64le' 'windows-2019'
                                          # Ref: https://github.com/uraimo/run-on-arch-action
     steps:
       - name: Install Go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04]  # TODO: pass linters on 'macos-12' and 'windows-2019'
+        os: [ubuntu-22.04]  # TODO: pass linters on 'macos-12' and 'windows-2022'
 
     steps:
       - name: Install Go
@@ -58,7 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]  # TODO: make releases on 'linux-ppc64le' 'windows-2019'
+        os: [ubuntu-22.04, macos-12]  # TODO: make releases on 'linux-ppc64le' 'windows-2022'
                                          # Ref: https://github.com/uraimo/run-on-arch-action
     steps:
       - name: Install Go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04]  # TODO: pass linters on 'macos-12' and 'windows-2019'
+        os: [ubuntu-22.04]  # TODO: pass linters on 'macos-12' and 'windows-2019'
 
     steps:
       - name: Install Go
@@ -58,7 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-12]  # TODO: make releases on 'linux-ppc64le' 'windows-2019'
+        os: [ubuntu-22.04, macos-12]  # TODO: make releases on 'linux-ppc64le' 'windows-2019'
                                          # Ref: https://github.com/uraimo/run-on-arch-action
     steps:
       - name: Install Go

--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -22,17 +22,17 @@ jobs:
         # ╟──────────────────┼───────────┼─────────╢
         # ║ hcshim           │           │ runhcs  ║
         # ╚══════════════════╧═══════════╧═════════╝
-        os: [ubuntu-22.04, windows-2019]
+        os: [ubuntu-22.04, windows-2022]
         version: [main, v1.6.12]
         runtime: [io.containerd.runtime.v1.linux, io.containerd.runc.v1, io.containerd.runc.v2, containerd-shim-runhcs-v1]
         runc: [runc, crun]
         exclude:
           - runtime: io.containerd.runc.v1
-            os: windows-2019
+            os: windows-2022
           - runtime: io.containerd.runc.v2
-            os: windows-2019
+            os: windows-2022
           - runtime: io.containerd.runtime.v1.linux
-            os: windows-2019
+            os: windows-2022
           - runtime: containerd-shim-runhcs-v1
             os: ubuntu-22.04
           - runtime: io.containerd.runc.v1
@@ -40,7 +40,7 @@ jobs:
           - runtime: io.containerd.runtime.v1.linux
             runc: crun
           - runc: crun
-            os: windows-2019
+            os: windows-2022
     name: ${{matrix.version}} / ${{ matrix.os }} / ${{matrix.runtime}} / ${{matrix.runc}}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -22,7 +22,7 @@ jobs:
         # ╟──────────────────┼───────────┼─────────╢
         # ║ hcshim           │           │ runhcs  ║
         # ╚══════════════════╧═══════════╧═════════╝
-        os: [ubuntu-18.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
         version: [main, v1.6.12]
         runtime: [io.containerd.runtime.v1.linux, io.containerd.runc.v1, io.containerd.runc.v2, containerd-shim-runhcs-v1]
         runc: [runc, crun]
@@ -34,7 +34,7 @@ jobs:
           - runtime: io.containerd.runtime.v1.linux
             os: windows-2019
           - runtime: containerd-shim-runhcs-v1
-            os: ubuntu-18.04
+            os: ubuntu-22.04
           - runtime: io.containerd.runc.v1
             runc: crun
           - runtime: io.containerd.runtime.v1.linux

--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         version: [main]
     name: ${{matrix.version}} / linux amd64
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install go
         uses: actions/setup-go@v2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The github action workflows are referencing some legacy image runners, which are gonna be fully decommissioned soon, for example, for macos-10.15, it would be removed by March 31 2023.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Just workflow setup changes.

#### Does this PR introduce a user-facing change?

NONE

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
