### PR TITLE
update release support details in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Version matrix:
 
 See the [roadmap](docs/roadmap.md) for information about current and future milestones.
 
+## Release Support Matrix
+
+The [releases](https://github.com/kubernetes-sigs/cri-tools/releases) are in tandem
+with Kubernetes releases in general. As referenced in above version matrix,
+since release `1.16`, we maintain `master` branch of this repo. However, for critical
+fixes in previous releases, we would only consider the releases which are still not EOL
+in Kubernetes releases.
+
 ## Install
 
 ### Install crictl


### PR DESCRIPTION
This commit add details about the release support we follow. This can help end users/consumers of this repo to have clear understanding about the support of cri tools releases.



#### What type of PR is this?


/kind documentation




```release-note
NONE
```
