### PR TITLE
Disable dependency gathering for release notes

### DIFF
--- a/hack/release-notes.sh
+++ b/hack/release-notes.sh
@@ -23,4 +23,5 @@ release-notes \
     --org kubernetes-sigs \
     --repo cri-tools \
     --required-author "" \
+    --dependencies=false \
     --output release-notes.md


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
Right now the collection of the dependencies is broken for the v1.26.0 tag, because we missed vendoring the following bits:

```
k8s.io/dynamic-resource-allocation => k8s.io/kubernetes/staging/src/k8s.io/dynamic-resource-allocation
k8s.io/kms => k8s.io/kubernetes/staging/src/k8s.io/kms
```

For now we disable the dependency collection to unbreak the `release` GitHub action workflow.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
