### PR TITLE
Various Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ PROJECT := github.com/kubernetes-sigs/cri-tools
 BINDIR ?= /usr/local/bin
 
 VERSION ?= $(shell git describe --tags --dirty --always | sed 's/^v//')
-GO_LDFLAGS := -X $(PROJECT)/pkg/version.Version=$(VERSION)
+GO_LDFLAGS := $(GO_LDFLAGS) -X $(PROJECT)/pkg/version.Version=$(VERSION)
 
 BUILD_PATH := $(shell pwd)/build
 BUILD_BIN_PATH := $(BUILD_PATH)/bin/$(GOOS)/$(GOARCH)

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,7 @@ endif
 PROJECT := github.com/kubernetes-sigs/cri-tools
 BINDIR ?= /usr/local/bin
 
-VERSION := $(shell git describe --tags --dirty --always)
-VERSION := $(VERSION:v%=%)
+VERSION ?= $(shell git describe --tags --dirty --always | sed 's/^v//')
 GO_LDFLAGS := -X $(PROJECT)/pkg/version.Version=$(VERSION)
 
 BUILD_PATH := $(shell pwd)/build

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ PROJECT := github.com/kubernetes-sigs/cri-tools
 BINDIR ?= /usr/local/bin
 
 VERSION ?= $(shell git describe --tags --dirty --always | sed 's/^v//')
+CGO_ENABLED ?= 0
 GOFLAGS ?= -trimpath
 GO_LDFLAGS := $(GO_LDFLAGS) -X $(PROJECT)/pkg/version.Version=$(VERSION)
 
@@ -64,7 +65,7 @@ critest:
 	@$(MAKE) -B $(CRITEST)
 
 $(CRITEST):
-	CGO_ENABLED=0 $(GO_TEST) -c -o $@ \
+	CGO_ENABLED=$(CGO_ENABLED) $(GO_TEST) -c -o $@ \
 		-ldflags '$(GO_LDFLAGS)' \
 		$(GOFLAGS) \
 	     $(PROJECT)/cmd/critest
@@ -73,7 +74,7 @@ crictl:
 	@$(MAKE) -B $(CRICTL)
 
 $(CRICTL):
-	CGO_ENABLED=0 $(GO_BUILD) -o $@ \
+	CGO_ENABLED=$(CGO_ENABLED) $(GO_BUILD) -o $@ \
 		-ldflags '$(GO_LDFLAGS)' \
 		$(GOFLAGS) \
 		$(PROJECT)/cmd/crictl

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ PROJECT := github.com/kubernetes-sigs/cri-tools
 BINDIR ?= /usr/local/bin
 
 VERSION ?= $(shell git describe --tags --dirty --always | sed 's/^v//')
+GOFLAGS ?= -trimpath
 GO_LDFLAGS := $(GO_LDFLAGS) -X $(PROJECT)/pkg/version.Version=$(VERSION)
 
 BUILD_PATH := $(shell pwd)/build
@@ -65,7 +66,7 @@ critest:
 $(CRITEST):
 	CGO_ENABLED=0 $(GO_TEST) -c -o $@ \
 		-ldflags '$(GO_LDFLAGS)' \
-		-trimpath \
+		$(GOFLAGS) \
 	     $(PROJECT)/cmd/critest
 
 crictl:
@@ -74,7 +75,7 @@ crictl:
 $(CRICTL):
 	CGO_ENABLED=0 $(GO_BUILD) -o $@ \
 		-ldflags '$(GO_LDFLAGS)' \
-		-trimpath \
+		$(GOFLAGS) \
 		$(PROJECT)/cmd/crictl
 
 clean:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Allows overriding various go compiler flags (`-ldflags` via `GO_LDFLAGS`, `CGO_ENABLED` and `GOFLAGS`).
Allows building from a source tarball by allowing to provide a custom version string using `VERSION` (`git` is no longer required during build time, which is great if one is relying on source tarballs to build this project).

#### Which issue(s) this PR fixes:

Fixes #676 (auto-closed by bot...)

#### Special notes for your reviewer:

I am packaging this project for Arch Linux and started to more and more hack around the Makefile to be able to provide our own distribution flags and to apply our [go packaging guidelines](https://wiki.archlinux.org/title/Go_package_guidelines).

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The Makefile now allows adding additional `-ldflags` by providing `GO_LDFLAGS`, setting `CGO_ENABLED` by providing `CGO_ENABLED`, overriding build flags by setting `GOFLAGS` (defaults to `-trimpath`) and providing a custom version string using `VERSION` (defaults to using `git` to derive a unique version string based on the latest tag). 
```
