### PR TITLE
Do not display help when deleting all pods/containers

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -351,6 +351,10 @@ var removeContainerCommand = &cli.Command{
 		}
 
 		if len(ids) == 0 {
+			if ctx.Bool("all") {
+				logrus.Info("No containers to remove")
+				return nil
+			}
 			return cli.ShowSubcommandHelp(ctx)
 		}
 

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -393,8 +393,11 @@ var removeImageCommand = &cli.Command{
 		}
 
 		if len(ids) == 0 {
-			logrus.Info("No images to remove")
-			return nil
+			if all || prune {
+				logrus.Info("No images to remove")
+				return nil
+			}
+			return cli.ShowSubcommandHelp(cliCtx)
 		}
 
 		errored := false

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -144,8 +144,11 @@ var removePodCommand = &cli.Command{
 			}
 		}
 
-		lenIDs := len(ids)
-		if lenIDs == 0 {
+		if len(ids) == 0 {
+			if ctx.Bool("all") {
+				logrus.Info("No pods to remove")
+				return nil
+			}
 			return cli.ShowSubcommandHelp(ctx)
 		}
 

--- a/test/e2e/help_test.go
+++ b/test/e2e/help_test.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega/gexec"
 )
 
 // The actual test suite
@@ -40,5 +41,45 @@ var _ = t.Describe("help", func() {
 	It("should show help on invalid flag", func() {
 		t.CrictlExpectFailure("--invalid", helpMessageIdentifier,
 			"flag provided but not defined")
+	})
+})
+
+// The actual test suite
+var _ = t.Describe("help subcommand", func() {
+
+	var (
+		endpoint, testDir string
+		crio              *Session
+	)
+	BeforeEach(func() {
+		endpoint, testDir, crio = t.StartCrio()
+	})
+
+	AfterEach(func() {
+		t.StopCrio(testDir, crio)
+	})
+
+	It("should show help running rm without params", func() {
+		t.CrictlExpectSuccessWithEndpoint(endpoint, "rm", "crictl rm command")
+	})
+
+	It("should show help running rmi without params", func() {
+		t.CrictlExpectSuccessWithEndpoint(endpoint, "rmi", "crictl rmi command")
+	})
+
+	It("should show help running rmp without params", func() {
+		t.CrictlExpectSuccessWithEndpoint(endpoint, "rmp", "crictl rmp command")
+	})
+
+	It("should not show help running rm -a", func() {
+		t.CrictlExpect(endpoint, "rm -a", 0, "", "No containers to remove")
+	})
+
+	It("should not show help running rmi -a", func() {
+		t.CrictlExpect(endpoint, "rmi -a", 0, "", "No images to remove")
+	})
+
+	It("should not show help running rmp -a", func() {
+		t.CrictlExpect(endpoint, "rmp -a", 0, "", "No pods to remove")
 	})
 })

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -41,6 +41,6 @@ var _ = t.Describe("info", func() {
 	})
 
 	It("should fail with additional argument", func() {
-		t.CrictlExpectFailure("--invalid", "", "flag provided but not defined")
+		t.CrictlExpectFailure("--invalid", "crictl - client for CRI", "flag provided but not defined")
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Running `crictl rmp -a` or `crictl rm -a` with nothing to delete was displaying the help text instead of saying that there was nothing to delete.

#### Which issue(s) this PR fixes:
Fixes #1144

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
'crictl rm(p) -a' now properly says when there is no containers/pods to delete instead of displaying help text
```
