### PR TITLE
Add InodesUsed and format usedBytes with humansize print in imagefsinfo cmd

### DIFF
--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -497,7 +497,8 @@ var imageFsInfoCommand = &cli.Command{
 
 			// otherwise output in table format
 			fmt.Printf("TimeStamp: %d\n", info.Timestamp)
-			fmt.Printf("UsedBytes: %s\n", info.UsedBytes)
+			fmt.Printf("Disk: %s\n", units.HumanSize(float64(info.UsedBytes.GetValue())))
+			fmt.Printf("Inodes: %d\n", info.InodesUsed.GetValue())
 			fmt.Printf("Mountpoint: %s\n", info.FsId.Mountpoint)
 		}
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

add InodesUsed and format usedBytes with humansize

before
<pre>
[root@node-1 cri-tools]# crictl  imagefsinfo  -o table
TimeStamp: 1687685800184535286
UsedBytes: &UInt64Value{Value:3016945664,}
Mountpoint: /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs
</pre>

modified
<pre>
[root@node-1 cri-tools]# ./crictl  imagefsinfo -o table
TimeStamp: 1687686720185661980
Disk: 3.013GB
Inodes: 38517
Mountpoint: /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs
</pre>



#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
`crictl  imagefsinfo  -o table` will print InodesUsed and humansize UsedBytes 
```
