### PR TITLE
Revert "fix listCoontainerStats not filter"

### DIFF
--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -214,12 +214,9 @@ var _ = framework.KubeDescribe("Container", func() {
 
 			By("start container")
 			startContainer(rc, containerID)
-			filter := &runtimeapi.ContainerStatsFilter{
-				Id: containerID,
-			}
 
 			By("test container stats")
-			stats := listContainerStats(rc, filter)
+			stats := listContainerStats(rc, nil)
 			Expect(statFound(stats, containerID)).To(BeTrue(), "Stats should be found")
 		})
 
@@ -239,21 +236,10 @@ var _ = framework.KubeDescribe("Container", func() {
 			startContainer(rc, thirdContainerID)
 
 			By("test containers stats")
-			firstFilter := &runtimeapi.ContainerStatsFilter{
-				Id: firstContainerID,
-			}
-			firstStats := listContainerStats(rc, firstFilter)
-			secondFilter := &runtimeapi.ContainerStatsFilter{
-				Id: secondContainerID,
-			}
-			secondStats := listContainerStats(rc, secondFilter)
-			thirdFilter := &runtimeapi.ContainerStatsFilter{
-				Id: thirdContainerID,
-			}
-			thirdStats := listContainerStats(rc, thirdFilter)
-			Expect(statFound(firstStats, firstContainerID)).To(BeTrue(), "Stats should be found")
-			Expect(statFound(secondStats, secondContainerID)).To(BeTrue(), "Stats should be found")
-			Expect(statFound(thirdStats, thirdContainerID)).To(BeTrue(), "Stats should be found")
+			stats := listContainerStats(rc, nil)
+			Expect(statFound(stats, firstContainerID)).To(BeTrue(), "Stats should be found")
+			Expect(statFound(stats, secondContainerID)).To(BeTrue(), "Stats should be found")
+			Expect(statFound(stats, thirdContainerID)).To(BeTrue(), "Stats should be found")
 		})
 	})
 


### PR DESCRIPTION
This reverts commit e64381030fcc76ad92e7ca4ed3924efd07e3c776.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Correct usage when using filter.

#### Which issue(s) this PR fixes:

Fixes # https://github.com/kubernetes-sigs/cri-tools/issues/1201

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes # https://github.com/kubernetes-sigs/cri-tools/issues/1201

or

None
-->

#### Special notes for your reviewer:

https://cloud-native.slack.com/archives/CGEQHPYF4/p1688375027120479

I'm sorry, for the previous pr https://github.com/kubernetes-sigs/cri-tools/pull/1202 the repair is unreasonable, the root cause of this problem is the bug of containerd ListContainerStats api, Although this problem can be avoided by setting filter not empty, this does not conform to the function definition of this interface, so the change of the last pr is rolled back and remains unchanged. containerd fix pr https://github.com/containerd/containerd/pull/8766/files


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
