### PR TITLE
override path defaults for FreeBSD

### DIFF
--- a/cmd/crictl/main_freebsd.go
+++ b/cmd/crictl/main_freebsd.go
@@ -1,6 +1,3 @@
-//go:build !windows && !freebsd
-// +build !windows,!freebsd
-
 /*
 Copyright 2017 The Kubernetes Authors.
 
@@ -25,9 +22,9 @@ import (
 )
 
 const (
-	defaultConfigPath = "/etc/crictl.yaml"
+	defaultConfigPath = "/usr/local/etc/crictl.yaml"
 )
 
-var defaultRuntimeEndpoints = []string{"unix:///var/run/dockershim.sock", "unix:///run/containerd/containerd.sock", "unix:///run/crio/crio.sock", "unix:///var/run/cri-dockerd.sock"}
+var defaultRuntimeEndpoints = []string{"unix:///var/run/dockershim.sock", "unix:///var/run/containerd/containerd.sock", "unix:///var/run/crio/crio.sock", "unix:///var/run/cri-dockerd.sock"}
 
 var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}


### PR DESCRIPTION
Sockets should go in /var/run and config files for non-base software in /usr/local/etc.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This matches the socket paths used by my cri-o prototype on FreeBSD

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
