### PR TITLE
Use previous and latest tag from git in release script

### DIFF
--- a/hack/release-notes.sh
+++ b/hack/release-notes.sh
@@ -25,9 +25,14 @@ curl -sSfL --retry 5 --retry-delay 10 -o $BINARY \
     https://github.com/kubernetes/release/releases/download/$VERSION/release-notes-linux-amd64
 chmod +x $BINARY
 
+PREVOUS_TAG=$(git tag | tail -2 | head -1)
+LATEST_TAG=$(git tag | tail -1)
+
 $BINARY \
-    --discover patch-to-patch \
     --org kubernetes-sigs \
     --repo cri-tools \
     --required-author "" \
+    --branch master \
+    --start-rev "$PREVOUS_TAG" \
+    --end-rev "$LATEST_TAG" \
     --output release-notes.md


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
We cannot rely on the discover modes of the release notes tool, because we cut patch releases from time to time from `master`. Means we now simply select the latest and previous tag from the git command.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
