### PR TITLE
Remove the Kubernetes incubator reference from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,6 @@ You can reach the maintainers of this project at:
 - Slack: #sig-node
 - Mailing List: <https://groups.google.com/forum/#!forum/kubernetes-sig-node>
 
-## Kubernetes Incubator
-
-This is a [Kubernetes Incubator project](https://github.com/kubernetes/community/blob/master/archive/incubator.md). The incubator team for the project is:
-
-- Sponsor: Dawn Chen (@dchen1107)
-- Champion: Yu-Ju Hong (@yujuhong)
-- SIG: sig-node
-
 ## Contributing
 
 Interested in contributing? Check out the [documentation](CONTRIBUTING.md).


### PR DESCRIPTION


#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
The project is pretty much in stable mode now, I guess we do not require the reference to "Kubernetes Incubator" any more.

The term is also deprecated per https://github.com/kubernetes/community/blob/master/archive/incubator.md

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
