### PR TITLE
Add show pinned information for images

### DIFF
--- a/cmd/crictl/display.go
+++ b/cmd/crictl/display.go
@@ -37,6 +37,7 @@ const (
 	columnNamespace  = "NAMESPACE"
 	columnSize       = "SIZE"
 	columnTag        = "TAG"
+	columnPinned     = "PINNED"
 	columnDigest     = "DIGEST"
 	columnMemory     = "MEM"
 	columnInodes     = "INODES"

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -231,6 +231,9 @@ var listImageCommand = &cli.Command{
 			if image.Username != "" {
 				fmt.Printf("Username: %v\n", image.Username)
 			}
+			if image.Pinned {
+				fmt.Printf("Pinned: %v\n", image.Pinned)
+			}
 			fmt.Printf("\n")
 		}
 		display.Flush()

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -155,6 +155,10 @@ var listImageCommand = &cli.Command{
 			Name:  "no-trunc",
 			Usage: "Show output without truncating the ID",
 		},
+		&cli.BoolFlag{
+			Name:  "pinned",
+			Usage: "Show whether the image is pinned or not",
+		},
 	},
 	Action: func(c *cli.Context) error {
 		if c.NArg() > 1 {
@@ -183,14 +187,19 @@ var listImageCommand = &cli.Command{
 		display := newTableDisplay(20, 1, 3, ' ', 0)
 		verbose := c.Bool("verbose")
 		showDigest := c.Bool("digests")
+		showPinned := c.Bool("pinned")
 		quiet := c.Bool("quiet")
 		noTrunc := c.Bool("no-trunc")
 		if !verbose && !quiet {
+			row := []string{columnImage, columnTag}
 			if showDigest {
-				display.AddRow([]string{columnImage, columnTag, columnDigest, columnImageID, columnSize})
-			} else {
-				display.AddRow([]string{columnImage, columnTag, columnImageID, columnSize})
+				row = append(row, columnDigest)
 			}
+			row = append(row, columnImageID, columnSize)
+			if showPinned {
+				row = append(row, columnPinned)
+			}
+			display.AddRow(row)
 		}
 		for _, image := range r.Images {
 			if quiet {
@@ -207,11 +216,15 @@ var listImageCommand = &cli.Command{
 					repoDigest = getTruncatedID(repoDigest, "sha256:")
 				}
 				for _, repoTagPair := range repoTagPairs {
+					row := []string{repoTagPair[0], repoTagPair[1]}
 					if showDigest {
-						display.AddRow([]string{repoTagPair[0], repoTagPair[1], repoDigest, id, size})
-					} else {
-						display.AddRow([]string{repoTagPair[0], repoTagPair[1], id, size})
+						row = append(row, repoDigest)
 					}
+					row = append(row, id, size)
+					if showPinned {
+						row = append(row, fmt.Sprintf("%v", image.Pinned))
+					}
+					display.AddRow(row)
 				}
 				continue
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:

Add showing of pinned information when using the `crictl images` command.

1. `crictl images -v` prints Pinned when image is pinned
```bash
$ crictl images -v
// ignore some print...

ID: sha256:e6f1816883972d4be47bd48879a08919b96afcd344132622e4d444987919323c
RepoTags: k8s.m.daocloud.io/pause:3.9
RepoDigests: k8s.m.daocloud.io/pause@sha256:7031c1b283388d2c2e09b57badb803c05ebed362dc88d84b480cc47f72a21097
Size: 321520
Uid: &Int64Value{Value:65535,}

ID: sha256:261e6f4fa9213ab2648fe05c7c0abefe50a3ddd561dfa4547a415cd62d8e5fe2
RepoTags: quay.io/tigera/operator:v1.30.4
RepoDigests: quay.io/tigera/operator@sha256:780eeab342e62bd200e533a960b548216b23b8bde7a672c4527f29eec9ce2d79
Size: 21216944
Uid: &Int64Value{Value:10001,}

ID: sha256:ed210e3e4a5bae1237f1bb44d72a05a2f1e5c6bfe7a7e73da179e2534269c459
RepoTags: registry.aliyuncs.com/google_containers/pause:3.5
RepoDigests: registry.aliyuncs.com/google_containers/pause@sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07
Size: 301416
Uid: &Int64Value{Value:65535,}
Pinned: true
```


2. add --pinned flag for `crictl images`
```bash
$ crictl images --pinned
IMAGE                                               TAG                 IMAGE ID            SIZE                PINNED
// ignore some print ....
k8s.m.daocloud.io/kube-scheduler                    v1.27.4             98ef2570f3cde       18.2MB              false
k8s.m.daocloud.io/pause                             3.9                 e6f1816883972       322kB               false
quay.io/tigera/operator                             v1.30.4             261e6f4fa9213       21.2MB              false
registry.aliyuncs.com/google_containers/pause       3.5                 ed210e3e4a5ba       301kB               true
```
```bash
crictl images --digests --pinned
IMAGE                                               TAG                 DIGEST              IMAGE ID            SIZE                PINNED
k8s.m.daocloud.io/kube-proxy                        v1.27.4             4bcb707da9898       6848d7eda0341       23.9MB              false
k8s.m.daocloud.io/kube-scheduler                    v1.27.4             5897d7a97d23d       98ef2570f3cde       18.2MB              false
k8s.m.daocloud.io/pause                             3.9                 7031c1b283388       e6f1816883972       322kB               false
quay.io/tigera/operator                             v1.30.4             780eeab342e62       261e6f4fa9213       21.2MB              false
registry.aliyuncs.com/google_containers/pause       3.5                 1ff6c18fbef20       ed210e3e4a5ba       301kB               true
```
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add showing of pinned information when using the `crictl images` command.
```
