### PR TITLE
Validate sandbox and container metadata

### DIFF
--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -152,6 +152,15 @@ func loadContainerConfig(path string) (*pb.ContainerConfig, error) {
 	if err := utilyaml.NewYAMLOrJSONDecoder(f, 4096).Decode(&config); err != nil {
 		return nil, err
 	}
+
+	if config.Metadata == nil {
+		return nil, errors.New("metadata is not set")
+	}
+
+	if config.Metadata.Name == "" {
+		return nil, fmt.Errorf("name is not in metadata %q", config.Metadata)
+	}
+
 	return &config, nil
 }
 
@@ -166,6 +175,15 @@ func loadPodSandboxConfig(path string) (*pb.PodSandboxConfig, error) {
 	if err := utilyaml.NewYAMLOrJSONDecoder(f, 4096).Decode(&config); err != nil {
 		return nil, err
 	}
+
+	if config.Metadata == nil {
+		return nil, errors.New("metadata is not set")
+	}
+
+	if config.Metadata.Name == "" || config.Metadata.Namespace == "" || config.Metadata.Uid == "" {
+		return nil, fmt.Errorf("name, namespace or uid is not in metadata %q", config.Metadata)
+	}
+
 	return &config, nil
 }
 


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We pre-validate the container metadata before creation the sandbox/container.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes-sigs/cri-tools/issues/1273

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Validate sandbox and container metadata before creating them via `crictl`.
```
