### PR TITLE
support websocket for exec and attach

### DIFF
--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -70,6 +70,10 @@ func SetupInterruptSignalHandler() <-chan struct{} {
 	return signalIntStopCh
 }
 
+func IsEnabledWebsockets() bool {
+	return strings.ToLower(os.Getenv("CRICTL_REMOTE_COMMAND_WEBSOCKETS")) == "true"
+}
+
 type listOptions struct {
 	// id of container or sandbox
 	id string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#1296 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

add new option for `exec/attach`, manual is: `crictl exec/attach -w -it ${container-id} ls`

#### test

i use container engine is [iSulad](https://github.com/openeuler-mirror/iSulad) which implement stream server is websocket.

```
$ export CRICTL_REMOTE_COMMAND_WEBSOCKETS=true
$ mycrictl exec -w -it b277916602c7 ls
bin   dev   etc   home  proc  root  sys   tmp   usr   var

# tcpdump logs
08:53:15.674128 IP localhost.10350 > localhost.40462: Flags [.], ack 303, win 510, options [nop,nop,TS val 1395824017 ecr 1395824017], length 0
E..4o.@.@..,........(n...       ..T=.......(.....
S2..S2..
08:53:15.675140 IP localhost.10350 > localhost.40462: Flags [P.], seq 1:173, ack 303, win 512, options [nop,nop,TS val 1395824018 ecr 1395824017], length 172
E...o.@.@...........(n...       ..T=.............
S2..S2..HTTP/1.1 101 Switching Protocols
Upgrade: WebSocket
Connection: Upgrade
Sec-WebSocket-Accept: mvvvKmgjEhY8040cH4xt8YSYr+Y=
Sec-WebSocket-Protocol: v5.channel.k8s.io


08:53:15.675156 IP localhost.40462 > localhost.10350: Flags [.], ack 173, win 511, options [nop,nop,TS val 1395824018 ecr 1395824018], length 0
E..4|w@.@..J..........(nT=...   .......(.....
S2..S2..
08:53:15.675527 IP localhost.40462 > localhost.10350: Flags [P.], seq 303:336, ack 173, win 512, options [nop,nop,TS val 1395824018 ecr 1395824018], length 33
E..U|x@.@..(..........(nT=...   .......I.....
S2..S2....S..mW..::...q..^g..%6...'..^c..
08:53:15.716065 IP localhost.10350 > localhost.40462: Flags [.], ack 336, win 512, options [nop,nop,TS val 1395824059 ecr 1395824018], length 0
E..4o.@.@..*........(n...       ..T=.......(.....
S2..S2..
08:53:15.755820 IP localhost.10350 > localhost.40462: Flags [P.], seq 173:337, ack 336, win 512, options [nop,nop,TS val 1395824099 ecr 1395824018], length 164
E...o.@.@...........(n...       ..T=.............
S2..S2...~....[1;34mbin.[m   .[1;34mdev.[m   .[1;34metc.[m   .[1;34mhome.[m  .[1;34mproc.[m  .[1;34mroot.[m  .[1;34msys.[m   .[1;34mtmp.[m   .[1;34musr.[m   .[1;34mvar.[m

08:53:15.796061 IP localhost.40462 > localhost.10350: Flags [.], ack 337, win 512, options [nop,nop,TS val 1395824139 ecr 1395824099], length 0
E..4|y@.@..H..........(nT=...   .2.....(.....
S2..S2..
08:53:15.856882 IP localhost.10350 > localhost.40462: Flags [P.], seq 337:360, ack 336, win 512, options [nop,nop,TS val 1395824200 ecr 1395824139], length 23
E..Ko.@.@...........(n...       .2T=.......?.....
S2.HS2.....{"status":"Success"}
08:53:15.856891 IP localhost.40462 > localhost.10350: Flags [.], ack 360, win 512, options [nop,nop,TS val 1395824200 ecr 1395824200], length 0

```


