### PR TITLE
Drop support for `linux/arm` platform

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -24,7 +24,6 @@ VERSION=$(git describe --abbrev=0 --tag)
 CRI_CTL_PLATFORMS=(
     linux/amd64
     linux/386
-    linux/arm
     linux/arm64
     linux/ppc64le
     linux/s390x
@@ -39,7 +38,6 @@ CRI_CTL_PLATFORMS=(
 CRI_TEST_PLATFORMS=(
     linux/amd64
     linux/386
-    linux/arm
     linux/arm64
     windows/amd64
     windows/386


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The Kubernetes project stopped supported for the platform a while ago, means cri-tools will follow that approach.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Follow-up on https://github.com/kubernetes-sigs/cri-tools/pull/1306#event-11173378321
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed support for `linux/arm` from the release binaries.
```
