### PR TITLE
Add a .snyk file to configure the Snyk security scanner

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+# References:
+#   https://docs.snyk.io/manage-risk/policies/the-.snyk-file
+#   https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - 'vendor/**'
+    - '**/*_test.go'


### PR DESCRIPTION
#### What type of PR is this?

/kind other
/assign kwilczynski

#### What this PR does / why we need it:

Add a .snyk file to configure the Snyk security scanner.

Why? At the very least, we want to exclude vendored files and tests from being scanned. As for these paths, many false positives are being reported, most of which we can't and won't be fixing.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

As part of efforts to improve the security stance of Open Source projects, Red Hat employs a Snyk security scanner to scan projects like this one periodically. The feedback following a scan is currently available internally (this might change in the future). However, CRI-O maintainers such as @saschagrunert and @haircommander have access to the results, and have a vested interest to keep cri-tools issues free.

#### Does this PR introduce a user-facing change?

```release-note
None
```
