### PR TITLE
Update Snyk configuration file to exclude vendor directory with a prefix

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,4 +5,5 @@
 exclude:
   global:
     - 'vendor/**'
+    - '*/vendor/**'
     - '**/*_test.go'


### PR DESCRIPTION
#### What type of PR is this?

/kind other
/assign kwilczynski

#### What this PR does / why we need it:

Some security scanners, such as the [csmock](https://github.com/csutils/csmock), wrap the Snyk scanner and often hand paths directly to it that are fully qualified. This seems to make Snyk not apply the exclude configuration correctly, since the `vendor` directory can have a prefix (of some other top-level directory), for example:

```console
"file_name": "cri-tools-3c91ebf539bd2035d60813386f5b1f023937423f/vendor/k8s.io/apimachinery/pkg/util/managedfields/pod.yaml"
```

The above would result in Snyk not respecting directory exclusion and scanning the content of the `vendor` directory, which is undesirable.

Thus, we add a wildcard to accept any prefix in front of the `vendor` directory, should any be provided.

Related to:

- https://github.com/kubernetes-sigs/cri-tools/pull/1315

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```