### PR TITLE
KEP-3857: Recursive Read-only (RRO) mounts

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -942,7 +942,7 @@ func ContainerStatus(client internalapi.RuntimeService, id, output string, tmplS
 
 	switch output {
 	case "json", "yaml", "go-template":
-		return outputStatusInfo(status, r.Info, output, tmplStr)
+		return outputStatusInfo(status, "", r.Info, output, tmplStr)
 	case "table": // table output is after this switch block
 	default:
 		return fmt.Errorf("output option cannot be %s", output)

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -323,7 +323,7 @@ var imageStatusCommand = &cli.Command{
 			}
 			switch output {
 			case "json", "yaml", "go-template":
-				if err := outputStatusInfo(status, r.Info, output, tmplStr); err != nil {
+				if err := outputStatusInfo(status, "", r.Info, output, tmplStr); err != nil {
 					return fmt.Errorf("output status for %q: %w", id, err)
 				}
 				continue
@@ -521,7 +521,7 @@ var imageFsInfoCommand = &cli.Command{
 
 		switch output {
 		case "json", "yaml", "go-template":
-			if err := outputStatusInfo(status, nil, output, tmplStr); err != nil {
+			if err := outputStatusInfo(status, "", nil, output, tmplStr); err != nil {
 				return fmt.Errorf("output filesystem info: %w", err)
 			}
 			return nil

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -79,5 +80,9 @@ func Info(cliContext *cli.Context, client internalapi.RuntimeService) error {
 	if err != nil {
 		return err
 	}
-	return outputStatusInfo(status, r.Info, cliContext.String("output"), cliContext.String("template"))
+	handlers, err := json.Marshal(r.RuntimeHandlers) // protobufObjectToJSON cannot be used
+	if err != nil {
+		return err
+	}
+	return outputStatusInfo(status, string(handlers), r.Info, cliContext.String("output"), cliContext.String("template"))
 }

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -404,7 +404,7 @@ func PodSandboxStatus(client internalapi.RuntimeService, id, output string, quie
 	}
 	switch output {
 	case "json", "yaml", "go-template":
-		return outputStatusInfo(status, r.Info, output, tmplStr)
+		return outputStatusInfo(status, "", r.Info, output, tmplStr)
 	case "table": // table output is after this switch block
 	default:
 		return fmt.Errorf("output option cannot be %s", output)

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -231,7 +231,7 @@ func outputProtobufObjAsYAML(obj proto.Message) error {
 	return nil
 }
 
-func outputStatusInfo(status string, info map[string]string, format string, tmplStr string) error {
+func outputStatusInfo(status, handlers string, info map[string]string, format string, tmplStr string) error {
 	// Sort all keys
 	keys := []string{}
 	for k := range info {
@@ -240,6 +240,9 @@ func outputStatusInfo(status string, info map[string]string, format string, tmpl
 	sort.Strings(keys)
 
 	jsonInfo := "{" + "\"status\":" + status + ","
+	if handlers != "" {
+		jsonInfo += "\"runtimeHandlers\":" + handlers + ","
+	}
 	for _, k := range keys {
 		var res interface{}
 		// We attempt to convert key into JSON if possible else use it directly


### PR DESCRIPTION
Depends on:
- [x] https://github.com/containerd/containerd/pull/9747
- [x] https://github.com/kubernetes/enhancements/pull/3858
- [x] https://github.com/kubernetes/kubernetes/pull/123272

Depended by:
- https://github.com/containerd/containerd/pull/9787
- - -

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Implement  KEP-3857: Recursive Read-only (RRO) mounts 
- https://github.com/kubernetes/enhancements/issues/3857
- https://github.com/kubernetes/enhancements/pull/3858


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support Recursive Read-only (RRO) mounts  (KEP-3857)
```
