### PR TITLE
Add user namespaces tests

### DIFF
--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -298,27 +298,28 @@ jobs:
           set -o errexit
           set -o nounset
           set -o pipefail
+          set -x
 
-          BDIR="$(mktemp -d -p $PWD)"
+          BDIR="/var/lib/containerd-critest"
           echo "containerd temp dir: ${BDIR}"
-          mkdir -p ${BDIR}/{root,state}
+          sudo mkdir -p ${BDIR}/{root,state}
 
-          cat > ${BDIR}/config.toml <<EOF
+          sudo bash -c 'cat > ${BDIR}/config.toml <<EOF
           version = 2
           [plugins]
             [plugins.cri.containerd.default_runtime]
               runtime_type = \"${{matrix.runtime}}\"
-          EOF
+          EOF'
 
           # Remove possibly existing containerd configuration
           sudo rm -rf /etc/containerd
-
-          sudo PATH=$PATH /usr/local/bin/containerd -a ${BDIR}/c.sock -root ${BDIR}/root -state ${BDIR}/state -log-level debug &> ${BDIR}/containerd-cri.log &
+          sudo PATH=$PATH bash -c "/usr/local/bin/containerd -a ${BDIR}/c.sock -root ${BDIR}/root -state ${BDIR}/state -log-level debug &> ${BDIR}/containerd-cri.log &"
           sudo /usr/local/bin/ctr -a ${BDIR}/c.sock version
           sudo /usr/local/sbin/runc --version
+          sudo mount
 
-          sudo -E PATH=$PATH critest --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8
-          TEST_RC=$?
+          TEST_RC=0
+          sudo -E PATH=$PATH critest --ginkgo.vv --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8 || TEST_RC=$?
           test $TEST_RC -ne 0 && cat ${BDIR}/containerd-cri.log
           sudo pkill containerd
           echo "CONTD_CRI_DIR=$BDIR" >> $GITHUB_ENV

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -220,6 +220,20 @@ func RunPodSandbox(c internalapi.RuntimeService, config *runtimeapi.PodSandboxCo
 	return podID
 }
 
+// RunPodSandboxWithRuntimeHandler runs a PodSandbox with a custom runtime handler.
+func RunPodSandboxWithRuntimeHandler(c internalapi.RuntimeService, config *runtimeapi.PodSandboxConfig, runtimeHandler string) string {
+	podID, err := c.RunPodSandbox(context.TODO(), config, runtimeHandler)
+	ExpectNoError(err, "failed to create PodSandbox: %v", err)
+	return podID
+}
+
+// RunPodSandboxErrorWithRuntimeHandler runs a PodSandbox with a custom runtime handler and expects an error.
+func RunPodSandboxErrorWithRuntimeHandler(c internalapi.RuntimeService, config *runtimeapi.PodSandboxConfig, runtimeHandler string) string {
+	podID, err := c.RunPodSandbox(context.TODO(), config, runtimeHandler)
+	Expect(err).To(HaveOccurred())
+	return podID
+}
+
 // CreatePodSandboxForContainer creates a PodSandbox for creating containers.
 func CreatePodSandboxForContainer(c internalapi.RuntimeService) (string, *runtimeapi.PodSandboxConfig) {
 	podSandboxName := "create-PodSandbox-for-container-" + NewUUID()

--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -627,6 +628,21 @@ func verifyLogContents(podConfig *runtimeapi.PodSandboxConfig, logPath string, l
 		}
 	}
 	Expect(found).To(BeTrue(), "expected log %q (stream=%q) not found in logs %+v", log, stream, msgs)
+}
+
+// verifyLogContentsRe verifies the contents of container log using the provided regular expression pattern.
+func verifyLogContentsRe(podConfig *runtimeapi.PodSandboxConfig, logPath string, pattern string, stream streamType) {
+	By("verify log contents using regex pattern")
+	msgs := parseLogLine(podConfig, logPath)
+
+	found := false
+	for _, msg := range msgs {
+		if matched, _ := regexp.MatchString(pattern, msg.log); matched && msg.stream == stream {
+			found = true
+			break
+		}
+	}
+	Expect(found).To(BeTrue(), "expected log pattern %q (stream=%q) to match logs %+v", pattern, stream, msgs)
 }
 
 // listContainerStatsForID lists container for containerID.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adding user namespaces tests for covering the `UsernamespaceMode` supported by the CRI.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/cri-tools/issues/1348

#### Special notes for your reviewer:

cc @giuseppe @rata

#### Does this PR introduce a user-facing change?

```release-note
Added user namespaces tests to `critest`. The tests try to find a working runtime handler and automatically skip if not existing.
```
