### PR TITLE
Implemented the `--filter` flag for `images` command.

### DIFF
--- a/cmd/crictl/image_test.go
+++ b/cmd/crictl/image_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func fakeImage(id string, digest []string, tags []string) *pb.Image {
+	return &pb.Image{Id: id, RepoDigests: digest, RepoTags: tags}
+}
+
+func assert(input []*pb.Image, options []string, images []string) {
+	actual, _ := filterImagesList(input, options)
+	expected := []string{}
+	for _, img := range actual {
+		expected = append(expected, img.Id)
+	}
+	Expect(images).To(Equal(expected))
+}
+
+var _ = DescribeTable("filterImagesListByDangling", assert,
+	Entry("returns filtered images with dangling --filter=dangling=true",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/busybox@sha256:1"}, []string{}),
+			fakeImage("2", []string{"docker.io/library/nginx@sha256:2"}, []string{"latest"}),
+		},
+		[]string{"dangling=true"},
+		[]string{"1"},
+	),
+	Entry("returns filtered images with dangling --filter=dangling=false",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{}),
+			fakeImage("2", []string{"docker.io/library/busybox@sha256:2"}, []string{"1.2.0"}),
+			fakeImage("3", []string{"docker.io/library/nginx@sha256:3"}, []string{}),
+			fakeImage("4", []string{"docker.io/library/app@sha256:4"}, []string{"1.2.2"}),
+		},
+		[]string{"dangling=false"},
+		[]string{"2", "4"},
+	),
+)
+
+var _ = DescribeTable("filterImagesListByReference", assert,
+	Entry("returns filtered images with one reference --filter=reference=busybox",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/busybox@sha256:1"}, []string{"latest"}),
+			fakeImage("2", []string{"docker.io/library/nginx@sha256:2"}, []string{"latest"}),
+		},
+		[]string{"reference=busybox"},
+		[]string{"1"},
+	),
+	Entry("returns filtered images with many reference --filter=reference=busybox, --filter=reference=k8s",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{"0.0.0"}),
+			fakeImage("2", []string{"docker.io/library/busybox@sha256:2"}, []string{"1.2.0"}),
+			fakeImage("3", []string{"docker.io/library/nginx@sha256:3"}, []string{"1.0.0"}),
+			fakeImage("4", []string{"docker.io/library/app@sha256:4"}, []string{"1.2.2"}),
+			fakeImage("5", []string{"registry.k8s.io/e2e-test-images/busybox@sha256:5"}, []string{"1.2.2"}),
+		},
+		[]string{"reference=busybox", "reference=k8s"},
+		[]string{"5"},
+	),
+)
+
+var _ = DescribeTable("filterImagesListByBefore", assert,
+	Entry("returns filtered images with --filter=before=<image-name>[:<tag>]",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{"docker.io/library/server:0.0.0"}),
+			fakeImage("2", []string{"docker.io/library/busybox@sha256:2"}, []string{"docker.io/library/busybox:1.2.0"}),
+			fakeImage("3", []string{"docker.io/library/nginx@sha256:3"}, []string{"docker.io/library/nginx:1.0.0"}),
+			fakeImage("4", []string{"docker.io/library/app@sha256:4"}, []string{"docker.io/library/app:1.2.2"}),
+		},
+		[]string{"before=docker.io/library/nginx:1.0.0"},
+		[]string{"4"},
+	),
+	Entry("returns filtered images with --filter=before=<image id>",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{"docker.io/library/server:0.0.0"}),
+			fakeImage("2", []string{"docker.io/library/busybox@sha256:2"}, []string{"docker.io/library/busybox:1.2.0"}),
+			fakeImage("3", []string{"docker.io/library/nginx@sha256:3"}, []string{"docker.io/library/nginx:1.0.0"}),
+			fakeImage("4", []string{"docker.io/library/app@sha256:4"}, []string{"docker.io/library/app:1.2.2"}),
+		},
+		[]string{"before=1"},
+		[]string{"2", "3", "4"},
+	),
+	Entry("returns filtered images with --filter=before=<image@digest>",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{"docker.io/library/server:0.0.0"}),
+			fakeImage("2", []string{"docker.io/library/busybox@sha256:2"}, []string{"docker.io/library/busybox:1.2.0"}),
+			fakeImage("3", []string{"docker.io/library/nginx@sha256:3"}, []string{"docker.io/library/nginx:1.0.0"}),
+			fakeImage("4", []string{"docker.io/library/app@sha256:4"}, []string{"docker.io/library/app:1.2.2"}),
+		},
+		[]string{"before=docker.io/library/busybox@sha256:2"},
+		[]string{"3", "4"},
+	),
+)
+
+var _ = DescribeTable("filterImagesListBySince", assert,
+	Entry("returns filtered images with --filter=since=<image-name>[:<tag>]",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{"docker.io/library/server:0.0.0"}),
+			fakeImage("2", []string{"docker.io/library/busybox@sha256:2"}, []string{"docker.io/library/busybox:1.2.0"}),
+			fakeImage("3", []string{"docker.io/library/nginx@sha256:3"}, []string{"docker.io/library/nginx:1.0.0"}),
+			fakeImage("4", []string{"docker.io/library/app@sha256:4"}, []string{"docker.io/library/app:1.2.2"}),
+		},
+		[]string{"since=docker.io/library/busybox:1.2.0"},
+		[]string{"1"},
+	),
+	Entry("returns filtered images with --filter=since=<image id>",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{"docker.io/library/server:0.0.0"}),
+			fakeImage("2", []string{"docker.io/library/busybox@sha256:2"}, []string{"docker.io/library/busybox:1.2.0"}),
+			fakeImage("3", []string{"docker.io/library/nginx@sha256:3"}, []string{"docker.io/library/nginx:1.0.0"}),
+			fakeImage("4", []string{"docker.io/library/app@sha256:4"}, []string{"docker.io/library/app:1.2.2"}),
+		},
+		[]string{"since=3"},
+		[]string{"1", "2"},
+	),
+	Entry("returns filtered images with --filter=since=<image@digest>",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{"docker.io/library/server:0.0.0"}),
+			fakeImage("2", []string{"docker.io/library/busybox@sha256:2"}, []string{"docker.io/library/busybox:1.2.0"}),
+			fakeImage("3", []string{"docker.io/library/nginx@sha256:3"}, []string{"docker.io/library/nginx:1.0.0"}),
+			fakeImage("4", []string{"docker.io/library/app@sha256:4"}, []string{"docker.io/library/app:1.2.2"}),
+		},
+		[]string{"since=docker.io/library/nginx@sha256:3"},
+		[]string{"1", "2"},
+	),
+)
+
+var _ = DescribeTable("filterImagesListByChainable", assert,
+	Entry("returns filtered images with --filter=since=<image-id> and --filter=reference=<ref>",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{"docker.io/library/server:0.0.0"}),
+			fakeImage("2", []string{"docker.io/library/busybox@sha256:2"}, []string{"docker.io/library/busybox:1.2.0"}),
+			fakeImage("3", []string{"docker.io/library/nginx@sha256:3"}, []string{"docker.io/library/nginx:1.0.0"}),
+			fakeImage("4", []string{"docker.io/library/app@sha256:4"}, []string{"docker.io/library/app:1.2.2"}),
+		},
+		[]string{"since=3", "reference=busybox"},
+		[]string{"2"},
+	),
+	Entry("returns filtered images with --filter=since=<image-id> and --filter=reference=<ref>",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{"0.0.0"}),
+			fakeImage("2", []string{"registry.k8s.io/e2e-test-images/busybox@sha256:5"}, []string{"1.2.2"}),
+			fakeImage("3", []string{"docker.io/library/busybox@sha256:2"}, []string{"1.2.0"}),
+			fakeImage("4", []string{"docker.io/library/nginx@sha256:3"}, []string{"1.0.0"}),
+			fakeImage("5", []string{"docker.io/library/app@sha256:4"}, []string{"1.2.2"}),
+		},
+		[]string{"since=5", "reference=busybox"},
+		[]string{"2", "3"},
+	),
+	Entry("returns empty images list --filter=since=<image-id> and --filter=reference=<ref>",
+		[]*pb.Image{
+			fakeImage("1", []string{"docker.io/library/server@sha256:1"}, []string{"0.0.0"}),
+			fakeImage("2", []string{"registry.k8s.io/e2e-test-images/busybox@sha256:5"}, []string{"1.2.2"}),
+			fakeImage("3", []string{"docker.io/library/busybox@sha256:2"}, []string{"1.2.0"}),
+			fakeImage("4", []string{"docker.io/library/nginx@sha256:3"}, []string{"1.0.0"}),
+			fakeImage("5", []string{"docker.io/library/app@sha256:4"}, []string{"1.2.2"}),
+		},
+		[]string{"since=5", "reference=kubefun"},
+		[]string{},
+	),
+)

--- a/docs/crictl.1
+++ b/docs/crictl.1
@@ -343,6 +343,22 @@ To override these default pull configuration settings, \fB\fC\-\-no\-pull\fR and
 .RE
 
 .SH Examples
+.RS
+.IP \(bu 2
+Run pod sandbox with config file
+\[la]#run-pod-sandbox-with-config-file\[ra]
+.IP \(bu 2
+Run pod sandbox with runtime handler
+\[la]#run-pod-sandbox-with-runtime-handler\[ra]
+.IP \(bu 2
+Pull a busybox image
+\[la]#pull-a-busybox-image\[ra]
+.IP \(bu 2
+Filter images
+\[la]#filter-images\[ra]
+
+.RE
+
 .SS Run pod sandbox with config file
 .PP
 .RS
@@ -439,6 +455,153 @@ $ crictl images
 IMAGE               TAG                 IMAGE ID            SIZE
 busybox             latest              8c811b4aec35f       1.15MB
 k8s.gcr.io/pause    3.1                 da86e6ba6ca19       742kB
+
+.fi
+.RE
+
+.SS Filter images
+.PP
+The following filters are available \fB\fC\-\-filter\fR, \fB\fC\-f\fR, filters are chainable and processed in the declared order:
+
+.RS
+.IP "  1." 5
+\fB\fCbefore=<image\-name>[:<tag>]|<image id>|<image@digest>\fR
+.IP "  2." 5
+\fB\fCdangling=(true/false)\fR
+.IP "  3." 5
+\fB\fCreference=/regex/\fR
+.IP "  4." 5
+\fB\fCsince=<image\-name>[:<tag>]|<image id>|<image@digest>\fR
+
+.RE
+
+.PP
+List all images:
+
+.PP
+.RS
+
+.nf
+$ crictl images \-\-digests
+IMAGE                                                      TAG                 DIGEST              IMAGE ID            SIZE
+docker.io/library/busybox                                  latest              538721340ded1       3f57d9401f8d4       4.5MB
+docker.io/library/nginx                                    latest              05aa73005987c       e4720093a3c13       191MB
+gcr.io/k8s\-staging\-cri\-tools/hostnet\-nginx\-amd64           latest              aa74ea387dbbe       1ee3f9825c42b       147MB
+gcr.io/k8s\-staging\-cri\-tools/test\-image\-predefined\-group   latest              2b2fc189c502a       84410ab6e30d9       5.11MB
+registry.k8s.io/e2e\-test\-images/busybox                    1.29\-2              c318242786b13       84eebb9ca1734       1.37MB
+registry.k8s.io/e2e\-test\-images/httpd                      2.4.39\-4            3fe7acf013d12       444b9e2765dc9       132MB
+registry.k8s.io/e2e\-test\-images/nginx                      1.14\-2              13616070e3f29       02e45a31af51c       17.2MB
+registry.k8s.io/e2e\-test\-images/nonewprivs                 1.3                 8ac1264691820       3e3d1785c0b6e       7.37MB
+registry.k8s.io/pause                                      3.9                 7031c1b283388       e6f1816883972       750kB
+
+.fi
+.RE
+
+.PP
+List images by \fB\fCreference\fR:
+
+.PP
+.RS
+
+.nf
+$ crictl images \-\-filter 'reference=k8s'
+IMAGE                                                      TAG                 IMAGE ID            SIZE
+gcr.io/k8s\-staging\-cri\-tools/hostnet\-nginx\-amd64           latest              1ee3f9825c42b       147MB
+gcr.io/k8s\-staging\-cri\-tools/test\-image\-predefined\-group   latest              84410ab6e30d9       5.11MB
+registry.k8s.io/e2e\-test\-images/busybox                    1.29\-2              84eebb9ca1734       1.37MB
+registry.k8s.io/e2e\-test\-images/httpd                      2.4.39\-4            444b9e2765dc9       132MB
+registry.k8s.io/e2e\-test\-images/nginx                      1.14\-2              02e45a31af51c       17.2MB
+registry.k8s.io/e2e\-test\-images/nonewprivs                 1.3                 3e3d1785c0b6e       7.37MB
+registry.k8s.io/pause                                      3.9                 e6f1816883972       750kB
+
+.fi
+.RE
+
+.PP
+List images by \fB\fCreference\fR with regex:
+
+.PP
+.RS
+
+.nf
+$ crictl images \-\-filter 'reference=nginx'
+IMAGE                                              TAG                 IMAGE ID            SIZE
+docker.io/library/nginx                            latest              e4720093a3c13       191MB
+gcr.io/k8s\-staging\-cri\-tools/hostnet\-nginx\-amd64   latest              1ee3f9825c42b       147MB
+registry.k8s.io/e2e\-test\-images/nginx              1.14\-2              02e45a31af51c       17.2MB
+$ crictl images \-\-filter 'reference=.*(nginx)$'
+IMAGE                                   TAG                 IMAGE ID            SIZE
+docker.io/library/nginx                 latest              e4720093a3c13       191MB
+registry.k8s.io/e2e\-test\-images/nginx   1.14\-2              02e45a31af51c       17.2MB
+
+.fi
+.RE
+
+.PP
+Chain \fB\fC\-\-filter\fR:
+
+.PP
+.RS
+
+.nf
+$ crictl images \-\-filter 'reference=nginx' \-\-filter 'reference=\\.k8s\\.'
+IMAGE                                   TAG                 IMAGE ID            SIZE
+registry.k8s.io/e2e\-test\-images/nginx   1.14\-2              02e45a31af51c       17.2MB
+$ crictl images \-\-filter 'since=registry.k8s.io/e2e\-test\-images/busybox@sha256:c318242786b139d18676b1c09a0ad7f15fc17f8f16a5b2e625cd0dc8c9703daf' \-\-filter 'reference=nginx'
+IMAGE                                              TAG                 IMAGE ID            SIZE
+docker.io/library/nginx                            latest              e4720093a3c13       191MB
+gcr.io/k8s\-staging\-cri\-tools/hostnet\-nginx\-amd64   latest              1ee3f9825c42b       147MB
+
+.fi
+.RE
+
+.PP
+List images \fB\fCbefore=<image\-name>[:<tag>]\fR:
+
+.PP
+.RS
+
+.nf
+$ crictl images \-\-filter 'before=gcr.io/k8s\-staging\-cri\-tools/hostnet\-nginx\-amd64:latest'
+IMAGE                                                      TAG                 IMAGE ID            SIZE
+gcr.io/k8s\-staging\-cri\-tools/test\-image\-predefined\-group   latest              84410ab6e30d9       5.11MB
+registry.k8s.io/e2e\-test\-images/busybox                    1.29\-2              84eebb9ca1734       1.37MB
+registry.k8s.io/e2e\-test\-images/httpd                      2.4.39\-4            444b9e2765dc9       132MB
+registry.k8s.io/e2e\-test\-images/nginx                      1.14\-2              02e45a31af51c       17.2MB
+registry.k8s.io/e2e\-test\-images/nonewprivs                 1.3                 3e3d1785c0b6e       7.37MB
+registry.k8s.io/pause                                      3.9                 e6f1816883972       750kB
+
+.fi
+.RE
+
+.PP
+List images \fB\fCsince=<image\-name>[:<tag>]\fR:
+
+.PP
+.RS
+
+.nf
+$ crictl images \-\-filter 'since=gcr.io/k8s\-staging\-cri\-tools/hostnet\-nginx\-amd64:latest'
+IMAGE                       TAG                 IMAGE ID            SIZE
+docker.io/library/busybox   latest              3f57d9401f8d4       4.5MB
+docker.io/library/nginx     latest              e4720093a3c13       191MB
+
+.fi
+.RE
+
+.PP
+List images \fB\fCsince=<image@digest>\fR:
+
+.PP
+.RS
+
+.nf
+crictl images \-\-filter 'since=registry.k8s.io/e2e\-test\-images/busybox@sha256:c318242786b139d18676b1c09a0ad7f15fc17f8f16a5b2e625cd0dc8c9703daf'
+IMAGE                                                      TAG                 IMAGE ID            SIZE
+docker.io/library/busybox                                  latest              3f57d9401f8d4       4.5MB
+docker.io/library/nginx                                    latest              e4720093a3c13       191MB
+gcr.io/k8s\-staging\-cri\-tools/hostnet\-nginx\-amd64           latest              1ee3f9825c42b       147MB
+gcr.io/k8s\-staging\-cri\-tools/test\-image\-predefined\-group   latest              84410ab6e30d9       5.11MB
 
 .fi
 .RE


### PR DESCRIPTION
The following filters are available:

1. `dangling=(true/false)`
2. `reference=regex`
3. `before=<image-name>[:<tag>]|<image id>|<image@digest>`
4. `since=<image-name>[:<tag>]|<image id>|<image@digest>`

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
/kind feature

#### What this PR does / why we need it:

Filtering images is a good feature for cluster admins; we need a filter flag for the `crictl images` command to reduce shell scripts complexity.

#### Which issue(s) this PR fixes:


Fixes #1256 

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

None

```release-note
Implemented the `--filter` flag for `crictl images` command.
The following filters are available:

1. `dangling=(true/false)`
2. `reference=regex`
3. `before=<image-name>[:<tag>]|<image id>|<image@digest>`
4. `since=<image-name>[:<tag>]|<image id>|<image@digest>`
```

/c @kubernetes-sigs/cri-tools