### PR TITLE
Don't remove pinned images on image prune

### DIFF
--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -390,7 +390,12 @@ var removeImageCommand = &cli.Command{
 				return err
 			}
 			for _, img := range r {
-				logrus.Debugf("Adding image to be removed: %v", img.GetId())
+				// Pinned images should not be removed on prune.
+				if prune && img.Pinned {
+					logrus.Debugf("Excluding pinned container image: %v", img.GetId())
+					continue
+				}
+				logrus.Debugf("Adding container image to be removed: %v", img.GetId())
 				ids[img.GetId()] = true
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
On `cricrl rmi --prune`, crictl ignores the pinned images label when removing images. Not only is this unexpected behavior, it also removes the pause container, because the container runtime endpoint doesn't return the pause container in its list of running containers.

This change honors the pinned label on `cricrl rmi --prune`, which also stops the pause container from being removed, as it is pinned in every workflow.

#### Which issue(s) this PR fixes:
Fixes #1356 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
I'd like to add testing for this, but I haven't been able to figure out how to make it work. I just ran a simple workflow of pulling an image, pinning it, and then running `crictl rmi --prune`.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
nerdctl rmi will not remove pinned images on --prune
```
