### PR TITLE
The --filter flag improvments

### DIFF
--- a/docs/crictl.1
+++ b/docs/crictl.1
@@ -461,7 +461,7 @@ k8s.gcr.io/pause    3.1                 da86e6ba6ca19       742kB
 
 .SS Filter images
 .PP
-The following filters are available \fB\fC\-\-filter\fR, \fB\fC\-f\fR, filters are chainable and processed in the declared order:
+The following filters are available \fB\fC\-\-filter\fR, \fB\fC\-f\fR:
 
 .RS
 .IP "  1." 5
@@ -474,6 +474,9 @@ The following filters are available \fB\fC\-\-filter\fR, \fB\fC\-f\fR, filters a
 \fB\fCsince=<image\-name>[:<tag>]|<image id>|<image@digest>\fR
 
 .RE
+
+.PP
+Filters can be combined and are applied in the order provided.
 
 .PP
 List all images:
@@ -518,7 +521,7 @@ registry.k8s.io/pause                                      3.9                 e
 .RE
 
 .PP
-List images by \fB\fCreference\fR with regex:
+List images by \fB\fCreference\fR using a regular expression:
 
 .PP
 .RS
@@ -538,7 +541,7 @@ registry.k8s.io/e2e\-test\-images/nginx   1.14\-2              02e45a31af51c    
 .RE
 
 .PP
-Chain \fB\fC\-\-filter\fR:
+Combine multiple \fB\fC\-\-filter\fR arguments together:
 
 .PP
 .RS

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -264,12 +264,14 @@ k8s.gcr.io/pause    3.1                 da86e6ba6ca19       742kB
 
 ### Filter images
 
-The following filters are available `--filter`, `-f`, filters are chainable and processed in the declared order:
+The following filters are available `--filter`, `-f`:
 
 1. `before=<image-name>[:<tag>]|<image id>|<image@digest>`
 1. `dangling=(true/false)`
 1. `reference=/regex/`
 1. `since=<image-name>[:<tag>]|<image id>|<image@digest>`
+
+Filters can be combined and are applied in the order provided.
 
 List all images:
 
@@ -301,7 +303,7 @@ registry.k8s.io/e2e-test-images/nonewprivs                 1.3                 3
 registry.k8s.io/pause                                      3.9                 e6f1816883972       750kB
 ```
 
-List images by `reference` with regex:
+List images by `reference` using a regular expression:
 
 ```sh
 $ crictl images --filter 'reference=nginx'
@@ -315,7 +317,7 @@ docker.io/library/nginx                 latest              e4720093a3c13       
 registry.k8s.io/e2e-test-images/nginx   1.14-2              02e45a31af51c       17.2MB
 ```
 
-Chain `--filter`:
+Combine multiple `--filter` arguments together:
 
 ```sh
 $ crictl images --filter 'reference=nginx' --filter 'reference=\.k8s\.'


### PR DESCRIPTION
A bunch of changes from PR #1359

Follows @kwilczynski comments. 

Better usage:

```sh
 --filter value, -f value [ --filter value, -f value ]  Filter output based on provided conditions.
      Each filter has an AND style relationship with the other others.
      Available filters: 
      * dangling=BOOL
      * reference=/Regular Expression/
      * before=<image-name>[:<tag>]|<image id>|<image@digest>
      * since=<image-name>[:<tag>]|<image id>|<image@digest>
```

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A bunch of changes from previous PR review.

None

#### Does this PR introduce a user-facing change?

None

```release-note
A bunch of changes : 
* handle regexp error
* better usage info
* better documentatio
```
