### PR TITLE
1197: crictl rm to also remove container log files

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -329,9 +329,9 @@ var removeContainerCommand = &cli.Command{
 			Usage:   "Force removal of the container, disregarding if running",
 		},
 		&cli.BoolFlag{
-			Name:    "deletelog",
-			Aliases: []string{"dl"},
-			Usage:   "Delete the container log file and its rotations as well",
+			Name:    "keep-logs",
+			Aliases: []string{"kl"},
+			Usage:   "Preserve the container log file and its rotations",
 		},
 		&cli.BoolFlag{
 			Name:    "all",
@@ -392,12 +392,12 @@ var removeContainerCommand = &cli.Command{
 				logrus.Errorf("removing container %q failed: %v", id, err)
 				errored = true
 				continue
-			} else if ctx.Bool("deletelog") {
-				logFileName := resp.GetStatus().GetLogPath()
-				if logFileName != "" {
-					logRotations, err := filepath.Glob(logFileName + "*")
+			} else if !ctx.Bool("keep-logs") {
+				logPath := resp.GetStatus().GetLogPath()
+				if logPath != "" {
+					logRotations, err := filepath.Glob(logPath + "*")
 					if err != nil {
-						logRotations = []string{logFileName}
+						logRotations = []string{logPath}
 					}
 
 					for _, logFile := range logRotations {

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -397,8 +397,9 @@ var removeContainerCommand = &cli.Command{
 				if logPath != "" {
 					logRotations, err := filepath.Glob(logPath + ".*")
 					if err != nil {
-						logRotations = []string{logPath}
+						logRotations = []string{}
 					}
+					logRotations = append(logRotations, logPath)
 
 					for _, logFile := range logRotations {
 						err = os.Remove(logFile)

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -330,7 +330,7 @@ var removeContainerCommand = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:    "keep-logs",
-			Aliases: []string{"kl"},
+			Aliases: []string{"k"},
 			Usage:   "Preserve the container log file and its rotations",
 		},
 		&cli.BoolFlag{

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -395,7 +395,7 @@ var removeContainerCommand = &cli.Command{
 			} else if !ctx.Bool("keep-logs") {
 				logPath := resp.GetStatus().GetLogPath()
 				if logPath != "" {
-					logRotations, err := filepath.Glob(logPath + "*")
+					logRotations, err := filepath.Glob(logPath + ".*")
 					if err != nil {
 						logRotations = []string{logPath}
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Container log files are not deleted by the runtime, but the user might want to remove them alongside the container.
This PR changes the default behaviour to removing the logs and introduces a new option to the `rm` command to preserve the container log file and its rotations.
Failing to delete files doesn't fail the command and is only logged.

#### Which issue(s) this PR fixes:
Fixes #1197 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed default behaviour in `rm` command to also delete the container's log file.
Added `--keeplogs, -k` option to the `rm` command to preserve logs.
```
