### PR TITLE
Do not auto find runtime handler for user namespaces tests

### DIFF
--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -220,16 +220,9 @@ func RunPodSandbox(c internalapi.RuntimeService, config *runtimeapi.PodSandboxCo
 	return podID
 }
 
-// RunPodSandboxWithRuntimeHandler runs a PodSandbox with a custom runtime handler.
-func RunPodSandboxWithRuntimeHandler(c internalapi.RuntimeService, config *runtimeapi.PodSandboxConfig, runtimeHandler string) string {
-	podID, err := c.RunPodSandbox(context.TODO(), config, runtimeHandler)
-	ExpectNoError(err, "failed to create PodSandbox: %v", err)
-	return podID
-}
-
-// RunPodSandboxErrorWithRuntimeHandler runs a PodSandbox with a custom runtime handler and expects an error.
-func RunPodSandboxErrorWithRuntimeHandler(c internalapi.RuntimeService, config *runtimeapi.PodSandboxConfig, runtimeHandler string) string {
-	podID, err := c.RunPodSandbox(context.TODO(), config, runtimeHandler)
+// RunPodSandboxError runs a PodSandbox and expects an error.
+func RunPodSandboxError(c internalapi.RuntimeService, config *runtimeapi.PodSandboxConfig) string {
+	podID, err := c.RunPodSandbox(context.TODO(), config, TestContext.RuntimeHandler)
 	Expect(err).To(HaveOccurred())
 	return podID
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We rely on the test context runtime handler, which can be empty (`""`) for the default one reported by the runtime.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
