### PR TITLE
Support websocket transport for exec and attach

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -43,6 +43,12 @@ var runtimeAttachCommand = &cli.Command{
 			Aliases: []string{"i"},
 			Usage:   "Keep STDIN open",
 		},
+		&cli.StringFlag{
+			Name:    transportFlag,
+			Aliases: []string{"r"},
+			Value:   transportSpdy,
+			Usage:   fmt.Sprintf("Transport protocol to be used, must be one of: %s, %s", transportSpdy, transportWebsocket),
+		},
 	},
 	Action: func(c *cli.Context) error {
 		id := c.Args().First()
@@ -109,5 +115,5 @@ func Attach(ctx context.Context, client internalapi.RuntimeService, opts attachO
 	}
 
 	logrus.Debugf("Attach URL: %v", URL)
-	return stream(ctx, opts.stdin, opts.tty, URL)
+	return stream(ctx, opts.stdin, opts.tty, opts.transport, URL)
 }

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -114,6 +114,8 @@ type execOptions struct {
 	stdin bool
 	// Command to exec
 	cmd []string
+	// transport to be used
+	transport string
 }
 type attachOptions struct {
 	// id of container
@@ -122,6 +124,8 @@ type attachOptions struct {
 	tty bool
 	// Whether pass Stdin to container
 	stdin bool
+	// transport to be used
+	transport string
 }
 
 type portforwardOptions struct {


### PR DESCRIPTION



#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows end users to choose the transport to be used as well as runtime developers to experiment on feature development.


#### Which issue(s) this PR fixes:

Supersedes: https://github.com/kubernetes-sigs/cri-tools/pull/1305


#### Special notes for your reviewer:
cc @duguhaotian
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--transport / -r` flag to `crictl exec` and `attach` to select between the "spdy" (default) and "websocket" transport.
```
