### PR TITLE
Add `criu` binary to CRI-O tests

### DIFF
--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -50,6 +50,10 @@ jobs:
           sudo sysctl -w net.ipv4.ip_forward=1
           sudo iptables -t nat -I POSTROUTING -s 127.0.0.0/8 ! -d 127.0.0.0/8 -j MASQUERADE
 
+          # enable criu support
+          sudo apt-get update
+          sudo apt-get install -y criu
+
       - name: Install ginkgo
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo@latest


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
Fix the failing tests because CRI-O is now supporting `criu` per default.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
