### PR TITLE
Move project under `sigs.k8s.io` namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ export GO_BUILD=GOARCH=$(GOARCH) GOOS=$(GOOS) $(GO) build
 export GO_TEST=GOARCH=$(GOARCH) GOOS=$(GOOS) $(GO) test
 endif
 
-PROJECT := github.com/kubernetes-sigs/cri-tools
+PROJECT := sigs.k8s.io/cri-tools
 BINDIR ?= /usr/local/bin
 
 VERSION ?= $(shell git describe --tags --dirty --always | sed 's/^v//')

--- a/cmd/crictl/config.go
+++ b/cmd/crictl/config.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
+	"sigs.k8s.io/cri-tools/pkg/common"
 )
 
 var configCommand = &cli.Command{

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -34,9 +34,9 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	"k8s.io/kubernetes/pkg/kubelet/cri/remote"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
-	"github.com/kubernetes-sigs/cri-tools/pkg/tracing"
-	"github.com/kubernetes-sigs/cri-tools/pkg/version"
+	"sigs.k8s.io/cri-tools/pkg/common"
+	"sigs.k8s.io/cri-tools/pkg/tracing"
+	"sigs.k8s.io/cri-tools/pkg/version"
 )
 
 const defaultTimeout = 2 * time.Second

--- a/cmd/critest/cri_test.go
+++ b/cmd/critest/cri_test.go
@@ -30,11 +30,11 @@ import (
 	ginkgotypes "github.com/onsi/ginkgo/v2/types"
 	"github.com/onsi/gomega"
 
-	_ "github.com/kubernetes-sigs/cri-tools/pkg/benchmark"
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
-	_ "github.com/kubernetes-sigs/cri-tools/pkg/validate"
-	versionconst "github.com/kubernetes-sigs/cri-tools/pkg/version"
+	_ "sigs.k8s.io/cri-tools/pkg/benchmark"
+	"sigs.k8s.io/cri-tools/pkg/common"
+	"sigs.k8s.io/cri-tools/pkg/framework"
+	_ "sigs.k8s.io/cri-tools/pkg/validate"
+	versionconst "sigs.k8s.io/cri-tools/pkg/version"
 )
 
 const (

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -13,7 +13,7 @@ Start with the following guide to setup pre-requisites:
 - [Go](https://golang.org/doc/install)
 - [Build tools](https://github.com/containerd/cri#install-dependencies)
 
-_**Important Note**: `Go` dependencies tend to follow the GitHub project URL path structure, i.e. when installing and trying to use `cri-tools` locally, it should be installed under a folder structure as follows `go/src/github.com/kubernetes-sigs/cri-tools`. Kubernetes is the only exception which does not follow this structure for legacy reasons._
+_**Important Note**: `Go` dependencies tend to follow the GitHub project URL path structure, i.e. when installing and trying to use `cri-tools` locally, it should be installed under a folder structure as follows `go/src/sigs.k8s.io/cri-tools`. Kubernetes is the only exception which does not follow this structure for legacy reasons._
 
 Ensure the following after following the setup:
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-sigs/cri-tools
+module sigs.k8s.io/cri-tools
 
 go 1.22.0
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -46,7 +46,7 @@ CRI_TEST_PLATFORMS=(
 )
 
 # Create releases output directory.
-PROJECT="github.com/kubernetes-sigs/cri-tools"
+PROJECT="sigs.k8s.io/cri-tools"
 CRI_TOOLS_ROOT="$GOPATH/src/$PROJECT"
 OUTPUTDIR=$CRI_TOOLS_ROOT/_output/releases
 mkdir -p "$OUTPUTDIR"

--- a/pkg/benchmark/container.go
+++ b/pkg/benchmark/container.go
@@ -22,10 +22,10 @@ import (
 	"path"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	"github.com/sirupsen/logrus"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega/gmeasure"

--- a/pkg/benchmark/image.go
+++ b/pkg/benchmark/image.go
@@ -23,10 +23,10 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	"github.com/sirupsen/logrus"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega/gmeasure"

--- a/pkg/benchmark/pod.go
+++ b/pkg/benchmark/pod.go
@@ -22,11 +22,11 @@ import (
 	"path"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	"github.com/sirupsen/logrus"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/common"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega/gmeasure"

--- a/pkg/benchmark/pod_container.go
+++ b/pkg/benchmark/pod_container.go
@@ -19,10 +19,10 @@ package benchmark
 import (
 	"context"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/common"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -26,11 +26,11 @@ import (
 
 	"github.com/distribution/reference"
 	"github.com/google/uuid"
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
 	"gopkg.in/yaml.v3"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cri/remote"
+	"sigs.k8s.io/cri-tools/pkg/common"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/apparmor_linux.go
+++ b/pkg/validate/apparmor_linux.go
@@ -24,11 +24,11 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/sirupsen/logrus"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -19,8 +19,8 @@ package validate
 import (
 	"runtime"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 )
 
 // Container test constants

--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -27,9 +27,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/container_linux.go
+++ b/pkg/validate/container_linux.go
@@ -23,10 +23,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	"golang.org/x/sys/unix"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/image.go
+++ b/pkg/validate/image.go
@@ -22,9 +22,9 @@ import (
 	"runtime"
 	"sort"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/multi_container_linux.go
+++ b/pkg/validate/multi_container_linux.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/common"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/networking.go
+++ b/pkg/validate/networking.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/common"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/pod.go
+++ b/pkg/validate/pod.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/common"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/pod_linux.go
+++ b/pkg/validate/pod_linux.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/common"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/runtime_info.go
+++ b/pkg/validate/runtime_info.go
@@ -19,9 +19,9 @@ package validate
 import (
 	"context"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/common"
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/common"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/selinux_linux.go
+++ b/pkg/validate/selinux_linux.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	selinux "github.com/opencontainers/selinux/go-selinux"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/streaming.go
+++ b/pkg/validate/streaming.go
@@ -28,13 +28,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	remoteclient "k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/validate/streaming_linux.go
+++ b/pkg/validate/streaming_linux.go
@@ -19,9 +19,9 @@ package validate
 import (
 	"context"
 
-	"github.com/kubernetes-sigs/cri-tools/pkg/framework"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"sigs.k8s.io/cri-tools/pkg/framework"
 
 	. "github.com/onsi/ginkgo/v2"
 )

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -19,9 +19,9 @@ package e2e
 import (
 	"testing"
 
-	. "github.com/kubernetes-sigs/cri-tools/test/framework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/cri-tools/test/framework"
 )
 
 // TestE2E runs the created specs


### PR DESCRIPTION


#### What type of PR is this?


/kind api-change

#### What this PR does / why we need it:
Projects from Kubernetes SIGs should live under to `sigs.k8s.io` go module namespace. We now apply that to cri-tools and adapt the import paths.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Moved repository source code to `sigs.k8s.io/cri-tools` namespace.
```
