### PR TITLE
Fixes invalid JSON in crictl info

### DIFF
--- a/cmd/crictl/util_test.go
+++ b/cmd/crictl/util_test.go
@@ -17,7 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"io"
+	"os"
+	"strings"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestNameFilterByRegex(t *testing.T) {
@@ -64,7 +69,99 @@ func TestNameFilterByRegex(t *testing.T) {
 			if r != tc.isMatch {
 				t.Errorf("expected matched to be %v; actual result is %v", tc.isMatch, r)
 			}
+		})
+	}
+}
 
+func TestOutputStatusInfo(t *testing.T) {
+	const (
+		statusResponse = `{"conditions":[{
+				"message": "no network config found in C:\\Program Files",
+        		"reason": "NetworkPluginNotReady",
+        		"status": false,
+        		"type": "NetworkReady"
+      		}]}`
+	)
+	testCases := []struct {
+		name        string
+		status      string
+		handlers    string
+		info        map[string]string
+		format      string
+		tmplStr     string
+		expectedOut string
+	}{
+		{
+			name:        "YAML format",
+			status:      statusResponse,
+			handlers:    `{"handlers":["handler1","handler2"]}`,
+			info:        map[string]string{"key1": "value1", "key2": "/var/lib"},
+			format:      "yaml",
+			tmplStr:     "",
+			expectedOut: "key1: value1\nkey2: /var/lib\nruntimeHandlers:\n  handlers:\n  - handler1\n  - handler2\nstatus:\n  conditions:\n  - message: no network config found in C:\\Program Files\n    reason: NetworkPluginNotReady\n    status: false\n    type: NetworkReady",
+		},
+		{
+			name:        "JSON format",
+			status:      statusResponse,
+			handlers:    `{"handlers":["handler1","handler2"]}`,
+			info:        map[string]string{"key1": "\"value1\"", "key2": "\"C:\\ProgramFiles\""},
+			format:      "json",
+			tmplStr:     "",
+			expectedOut: "{\n  \"key1\": \"value1\",\n  \"key2\": \"C:\\\\ProgramFiles\",\n  \"runtimeHandlers\": {\n    \"handlers\": [\n      \"handler1\",\n      \"handler2\"\n    ]\n  },\n  \"status\": {\n    \"conditions\": [\n      {\n        \"message\": \"no network config found in C:\\\\Program Files\",\n        \"reason\": \"NetworkPluginNotReady\",\n        \"status\": false,\n        \"type\": \"NetworkReady\"\n      }\n    ]\n  }\n}",
+		},
+		{
+			name:        "Go template format",
+			status:      statusResponse,
+			handlers:    `{"handlers":["handler1","handler2"]}`,
+			info:        map[string]string{"key1": "value1", "key2": "value2"},
+			format:      "go-template",
+			tmplStr:     `NetworkReady: {{ (index .status.conditions 0).status }}`,
+			expectedOut: "NetworkReady: false",
+		},
+	}
+
+	// Run tests
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			captureOutput := func(f func() error) (string, error) {
+				var err error
+				old := os.Stdout
+
+				r, w, _ := os.Pipe()
+				os.Stdout = w
+				defer func() {
+					os.Stdout = old
+				}()
+
+				err = f()
+				if err != nil {
+					return "", err
+				}
+
+				err = w.Close()
+				if err != nil {
+					return "", err
+				}
+
+				out, err := io.ReadAll(r)
+				return strings.TrimRight(string(out), "\n"), err
+			}
+
+			outStr, err := captureOutput(func() error {
+				err := outputStatusInfo(tc.status, tc.handlers, tc.info, tc.format, tc.tmplStr)
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				return nil
+			})
+
+			if err != nil {
+				Expect(err).To(BeNil())
+			}
+
+			if outStr != tc.expectedOut {
+				t.Errorf("Expected output:\n%s\nGot:\n%s", tc.expectedOut, outStr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
containerd on Windows may not escape the return message for `Status` request
`lastCNILoadStatus: "cni config load failed: no network config found in C:\Program Files\containerd\cni\conf: cni plugin
not initialized: failed to load cni config"`
This may result in invalid JSON in crictl info
`getting status of runtime: invalid character 'P' in string escape code`

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes: #1426


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
