### PR TITLE
Add stats label filter test

### DIFF
--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -253,14 +253,20 @@ func BuildContainerMetadata(containerName string, attempt uint32) *runtimeapi.Co
 	}
 }
 
-// CreateDefaultContainer creates a  default container with default options.
+// CreateDefaultContainer creates a default container with default options.
 func CreateDefaultContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, prefix string) string {
+	return CreateDefaultContainerWithLabels(rc, ic, podID, podConfig, prefix, nil)
+}
+
+// CreateDefaultContainerWithLabels creates a default container with default options
+func CreateDefaultContainerWithLabels(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, prefix string, labels map[string]string) string {
 	containerName := prefix + NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: BuildContainerMetadata(containerName, DefaultAttempt),
 		Image:    &runtimeapi.ImageSpec{Image: TestContext.TestImageList.DefaultTestContainerImage},
 		Command:  DefaultContainerCommand,
 		Linux:    &runtimeapi.LinuxContainerConfig{},
+		Labels:   labels,
 	}
 
 	return CreateContainer(rc, ic, containerConfig, podID, podConfig)

--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -239,6 +239,22 @@ var _ = framework.KubeDescribe("Container", func() {
 			Expect(statFound(stats, secondContainerID)).To(BeTrue(), "Stats should be found")
 			Expect(statFound(stats, thirdContainerID)).To(BeTrue(), "Stats should be found")
 		})
+
+		It("runtime should support listing stats for containers filtered by labels [Conformance]", func() {
+			By("create container")
+			labels := map[string]string{"foo": "bar"}
+			containerID := framework.CreateDefaultContainerWithLabels(rc, ic, podID, podConfig, "container-for-stats-with-labels-", labels)
+
+			By("start container")
+			startContainer(rc, containerID)
+
+			By("test container stats")
+			stats := listContainerStats(rc, &runtimeapi.ContainerStatsFilter{LabelSelector: labels})
+			Expect(statFound(stats, containerID)).To(BeTrue(), "Container should be found")
+
+			stats = listContainerStats(rc, &runtimeapi.ContainerStatsFilter{LabelSelector: map[string]string{"foo": "baz"}})
+			Expect(statFound(stats, containerID)).To(BeFalse(), "Container should be filtered")
+		})
 	})
 
 	Context("runtime should support adding volume and device", func() {


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Adding a conformance test for filtering stats by container labels.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #448 
#### Special notes for your reviewer:
Requires https://github.com/cri-o/cri-o/pull/8240
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added stats label filtering conformance test to `critest`.
```
