### PR TITLE
Add `--pull-timeout` flag to `crictl` `create`, `run` and `pull` commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	golang.org/x/sys v0.21.0
 	golang.org/x/term v0.21.0
 	golang.org/x/text v0.16.0
+	google.golang.org/grpc v1.64.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.1
 	k8s.io/apimachinery v0.30.1
@@ -85,7 +86,6 @@ require (
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240520151616-dc85e6b867a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
-	google.golang.org/grpc v1.64.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -328,9 +328,8 @@ func ListImage(c internalapi.ImageManagerService, filter *runtimeapi.ImageFilter
 	return images
 }
 
-// PullPublicImage pulls the public image named imageName.
-func PullPublicImage(c internalapi.ImageManagerService, imageName string, podConfig *runtimeapi.PodSandboxConfig) string {
-
+// PrepareImageName builds a pullable image name for the provided one.
+func PrepareImageName(imageName string) string {
 	ref, err := reference.ParseNamed(imageName)
 	if err == nil {
 		// Modify the image if it's a fully qualified image name
@@ -351,6 +350,13 @@ func PullPublicImage(c internalapi.ImageManagerService, imageName string, podCon
 	} else {
 		Failf("Unable to parse imageName: %v", err)
 	}
+
+	return imageName
+}
+
+// PullPublicImage pulls the public image named imageName.
+func PullPublicImage(c internalapi.ImageManagerService, imageName string, podConfig *runtimeapi.PodSandboxConfig) string {
+	imageName = PrepareImageName(imageName)
 
 	By("Pull image : " + imageName)
 	imageSpec := &runtimeapi.ImageSpec{


### PR DESCRIPTION



#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows to set a pull context timeout for the supported commands. Runtimes may or may not use the timeout from the RPC for image pulls, but `crictl` should generally support that feature.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `--pull-timeout` flag to `crictl` `create`, `run` and `pull` commands.
```
