### PR TITLE
Fix `pull-timeout` flag for `crictl pull`

### DIFF
--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -126,7 +126,7 @@ var pullImageCommand = &cli.Command{
 				return err
 			}
 		}
-		timeout := c.Duration("timeout")
+		timeout := c.Duration("pull-timeout")
 		r, err := PullImageWithSandbox(imageClient, imageName, auth, sandbox, ann, timeout)
 		if err != nil {
 			return fmt.Errorf("pulling image: %w", err)
@@ -664,7 +664,7 @@ func PullImageWithSandbox(client internalapi.ImageManagerService, image string, 
 	defer cancel()
 
 	if timeout > 0 {
-		logrus.Debugf("Using context with timeout of %s", timeout)
+		logrus.Debugf("Using pull context with timeout of %s", timeout)
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We need to specify the right timeout. Fixes a flaking CI test in `e2e` as well.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
