### PR TITLE
Make all RPC's interruptable

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -96,7 +96,9 @@ func Attach(ctx context.Context, client internalapi.RuntimeService, opts attachO
 		Stderr:      !opts.tty,
 	}
 	logrus.Debugf("AttachRequest: %v", request)
-	r, err := client.Attach(ctx, request)
+	r, err := InterruptableRPC(ctx, func(ctx context.Context) (*pb.AttachResponse, error) {
+		return client.Attach(ctx, request)
+	})
 	logrus.Debugf("AttachResponse: %v", r)
 	if err != nil {
 		return err

--- a/cmd/crictl/container_stats.go
+++ b/cmd/crictl/container_stats.go
@@ -225,7 +225,9 @@ func (d containerStatsDisplayer) displayStats(ctx context.Context, client intern
 
 func getContainerStats(ctx context.Context, client internalapi.RuntimeService, request *pb.ListContainerStatsRequest) (*pb.ListContainerStatsResponse, error) {
 	logrus.Debugf("ListContainerStatsRequest: %v", request)
-	r, err := client.ListContainerStats(context.TODO(), request.Filter)
+	r, err := InterruptableRPC(ctx, func(ctx context.Context) ([]*pb.ContainerStats, error) {
+		return client.ListContainerStats(ctx, request.Filter)
+	})
 	logrus.Debugf("ListContainerResponse: %v", r)
 	if err != nil {
 		return nil, err

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -394,7 +394,9 @@ var removeImageCommand = &cli.Command{
 
 		// Add all available images to the ID selector
 		if all || prune {
-			r, err := imageClient.ListImages(context.TODO(), nil)
+			r, err := InterruptableRPC(nil, func(ctx context.Context) ([]*pb.Image, error) {
+				return imageClient.ListImages(ctx, nil)
+			})
 			if err != nil {
 				return err
 			}

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -70,7 +70,9 @@ var runtimeStatusCommand = &cli.Command{
 func Info(cliContext *cli.Context, client internalapi.RuntimeService) error {
 	request := &pb.StatusRequest{Verbose: !cliContext.Bool("quiet")}
 	logrus.Debugf("StatusRequest: %v", request)
-	r, err := client.Status(context.TODO(), request.Verbose)
+	r, err := InterruptableRPC(nil, func(ctx context.Context) (*pb.StatusResponse, error) {
+		return client.Status(context.TODO(), request.Verbose)
+	})
 	logrus.Debugf("StatusResponse: %v", r)
 	if err != nil {
 		return err

--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -29,6 +29,7 @@ import (
 	"github.com/urfave/cli/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/cri-client/pkg/logs"
 	"k8s.io/klog/v2"
 )
@@ -100,7 +101,9 @@ var logsCommand = &cli.Command{
 			SinceTime:  since,
 			Timestamps: timestamp,
 		}, time.Now())
-		status, err := runtimeService.ContainerStatus(context.TODO(), containerID, false)
+		status, err := InterruptableRPC(nil, func(ctx context.Context) (*pb.ContainerStatusResponse, error) {
+			return runtimeService.ContainerStatus(ctx, containerID, false)
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/pod_metrics.go
+++ b/cmd/crictl/pod_metrics.go
@@ -112,7 +112,9 @@ func (p *podMetricsDisplayer) displayPodMetrics(
 }
 
 func podSandboxMetrics(client cri.RuntimeService) ([]*pb.PodSandboxMetrics, error) {
-	metrics, err := client.ListPodSandboxMetrics(context.TODO())
+	metrics, err := InterruptableRPC(nil, func(ctx context.Context) ([]*pb.PodSandboxMetrics, error) {
+		return client.ListPodSandboxMetrics(ctx)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list pod sandbox metrics: %w", err)
 	}

--- a/cmd/crictl/pod_stats.go
+++ b/cmd/crictl/pod_stats.go
@@ -258,7 +258,9 @@ func getPodSandboxStats(
 ) ([]*pb.PodSandboxStats, error) {
 	logrus.Debugf("PodSandboxStatsFilter: %v", filter)
 
-	stats, err := client.ListPodSandboxStats(context.TODO(), filter)
+	stats, err := InterruptableRPC(nil, func(ctx context.Context) ([]*pb.PodSandboxStats, error) {
+		return client.ListPodSandboxStats(ctx, filter)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list pod sandbox stats: %w", err)
 	}

--- a/cmd/crictl/portforward.go
+++ b/cmd/crictl/portforward.go
@@ -78,7 +78,9 @@ func PortForward(client internalapi.RuntimeService, opts portforwardOptions) err
 		PodSandboxId: opts.id,
 	}
 	logrus.Debugf("PortForwardRequest: %v", request)
-	r, err := client.PortForward(context.TODO(), request)
+	r, err := InterruptableRPC(nil, func(ctx context.Context) (*pb.PortForwardResponse, error) {
+		return client.PortForward(ctx, request)
+	})
 	logrus.Debugf("PortForwardResponse; %v", r)
 	if err != nil {
 		return err

--- a/cmd/crictl/runtime_config.go
+++ b/cmd/crictl/runtime_config.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 	internalapi "k8s.io/cri-api/pkg/apis"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 var runtimeConfigCommand = &cli.Command{
@@ -44,7 +45,9 @@ var runtimeConfigCommand = &cli.Command{
 
 // Attach sends an AttachRequest to server, and parses the returned AttachResponse
 func runtimeConfig(client internalapi.RuntimeService) error {
-	resp, err := client.RuntimeConfig(context.TODO())
+	resp, err := InterruptableRPC(nil, func(ctx context.Context) (*pb.RuntimeConfigResponse, error) {
+		return client.RuntimeConfig(ctx)
+	})
 	if err != nil {
 		return fmt.Errorf("call RuntimeConfig RPC: %w", err)
 	}

--- a/cmd/crictl/version.go
+++ b/cmd/crictl/version.go
@@ -50,7 +50,9 @@ var runtimeVersionCommand = &cli.Command{
 func Version(client internalapi.RuntimeService, version string) error {
 	request := &pb.VersionRequest{Version: version}
 	logrus.Debugf("VersionRequest: %v", request)
-	r, err := client.Version(context.TODO(), version)
+	r, err := InterruptableRPC(nil, func(ctx context.Context) (*pb.VersionResponse, error) {
+		return client.Version(ctx, version)
+	})
 	logrus.Debugf("VersionResponse: %v", r)
 	if err != nil {
 		return err


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Add other RPCs are now interruptable as well.

#### Which issue(s) this PR fixes:

Follow-up on https://github.com/kubernetes-sigs/cri-tools/pull/1462

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make container and sandbox related commands interruptable using Ctrl-C.
```
