### PR TITLE
Fix invalid context on `Status` RPC

### DIFF
--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -71,7 +71,7 @@ func Info(cliContext *cli.Context, client internalapi.RuntimeService) error {
 	request := &pb.StatusRequest{Verbose: !cliContext.Bool("quiet")}
 	logrus.Debugf("StatusRequest: %v", request)
 	r, err := InterruptableRPC(nil, func(ctx context.Context) (*pb.StatusResponse, error) {
-		return client.Status(context.TODO(), request.Verbose)
+		return client.Status(ctx, request.Verbose)
 	})
 	logrus.Debugf("StatusResponse: %v", r)
 	if err != nil {


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We need to pass the context from the `InterruptableRPC`, otherwise it won't be interruptable.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
