### PR TITLE
Sort commands by their name

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -209,6 +211,8 @@ func main() {
 		runtimeConfigCommand,
 		eventsCommand,
 	}
+
+	slices.SortFunc(app.Commands, func(a, b *cli.Command) int { return strings.Compare(a.Name, b.Name) })
 
 	runtimeEndpointUsage := fmt.Sprintf("Endpoint of CRI container runtime "+
 		"service (default: uses in order the first successful one of %v). "+


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:
The command list of `crictl` is now sorted alphabetically:

```
…

COMMANDS:
   attach              Attach to a running container
   checkpoint          Checkpoint one or more running containers
   completion          Output shell completion code
   config              Get and set crictl client configuration options
   create              Create a new container
   events, event       Stream the events of containers
   exec                Run a command in a running container
   imagefsinfo         Return image filesystem info
   images, image, img  List images
   info                Display information of the container runtime
   inspect             Display the status of one or more containers
   inspecti            Return the status of one or more images
   inspectp            Display the status of one or more pods
   logs                Fetch the logs of a container
   metricsp            List pod metrics. Metrics are unstructured key/value pairs gathered by CRI meant to replace cAdvisor's /metrics/cadvisor endpoint.
   pods                List pods
   port-forward        Forward local port to a pod
   ps                  List containers
   pull                Pull an image from a registry
   rm                  Remove one or more containers
   rmi                 Remove one or more images
   rmp                 Remove one or more pods
   run                 Run a new container inside a sandbox
   runp                Run a new pod
   runtime-config      Retrieve the container runtime configuration
   start               Start one or more created containers
   stats               List container(s) resource usage statistics
   statsp              List pod statistics. Stats represent a structured API that will fulfill the Kubelet's /stats/summary endpoint.
   stop                Stop one or more running containers
   stopp               Stop one or more running pods
   update              Update one or more running containers
   version             Display runtime version information
   help, h             Shows a list of commands or help for one command

…
```
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The `crictl` commands are now sorted alphabetically.
```
