### PR TITLE
Fixes invalid JSON in crictl info

### DIFF
--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -289,37 +289,54 @@ func outputStatusInfo(status, handlers string, info map[string]string, format st
 	}
 	sort.Strings(keys)
 
-	jsonInfo := "{" + "\"status\":" + status + ","
-	if handlers != "" {
-		jsonInfo += "\"runtimeHandlers\":" + handlers + ","
+	infoMap := map[string]any{}
+
+	if status != "" {
+		var statusVal map[string]any
+		err := json.Unmarshal([]byte(status), &statusVal)
+		if err != nil {
+			return err
+		}
+		infoMap["status"] = statusVal
 	}
-	for _, k := range keys {
-		var res interface{}
-		// We attempt to convert key into JSON if possible else use it directly
-		if err := json.Unmarshal([]byte(info[k]), &res); err != nil {
-			jsonInfo += "\"" + k + "\"" + ":" + "\"" + info[k] + "\","
-		} else {
-			jsonInfo += "\"" + k + "\"" + ":" + info[k] + ","
+
+	if handlers != "" {
+		var handlersVal []*any
+		err := json.Unmarshal([]byte(handlers), &handlersVal)
+		if err != nil {
+			return err
+		}
+		if handlersVal != nil {
+			infoMap["runtimeHandlers"] = handlersVal
 		}
 	}
-	jsonInfo = jsonInfo[:len(jsonInfo)-1]
-	jsonInfo += "}"
+
+	for _, k := range keys {
+		var genericVal map[string]any
+		json.Unmarshal([]byte(info[k]), &genericVal)
+		infoMap[k] = genericVal
+	}
+
+	jsonInfo, err := json.Marshal(infoMap)
+	if err != nil {
+		return err
+	}
 
 	switch format {
 	case "yaml":
-		yamlInfo, err := yaml.JSONToYAML([]byte(jsonInfo))
+		yamlInfo, err := yaml.JSONToYAML(jsonInfo)
 		if err != nil {
 			return err
 		}
 		fmt.Println(string(yamlInfo))
 	case "json":
 		var output bytes.Buffer
-		if err := json.Indent(&output, []byte(jsonInfo), "", "  "); err != nil {
+		if err := json.Indent(&output, jsonInfo, "", "  "); err != nil {
 			return err
 		}
 		fmt.Println(output.String())
 	case "go-template":
-		output, err := tmplExecuteRawJSON(tmplStr, jsonInfo)
+		output, err := tmplExecuteRawJSON(tmplStr, string(jsonInfo))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
containerd on Windows may not escape the return message which may result in invalid JSON in crictl info.

Message from containerd:
cni config load failed: no network config found in C:\Program Files \containerd\cni\conf: cni plugin

not initialized: failed to load cni config

Cherry-picked: 88df400df7b1b65dbd9d6fbab447a6b6da5177ad

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes-sigs/cri-tools/issues/1426
#### Special notes for your reviewer:
Taking over the reverts of https://github.com/kubernetes-sigs/cri-tools/pull/1429 and https://github.com/kubernetes-sigs/cri-tools/pull/1446 to finally fix that issue.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed invalid JSON in crictl info on Windows.
```
