### PR TITLE
Make `crictl events` interruptable

### DIFF
--- a/cmd/crictl/events.go
+++ b/cmd/crictl/events.go
@@ -81,7 +81,9 @@ func Events(cliContext *cli.Context, client internalapi.RuntimeService) error {
 	containerEventsCh := make(chan *pb.ContainerEventResponse)
 	go func() {
 		logrus.Debug("getting container events")
-		err := client.GetContainerEvents(context.Background(), containerEventsCh, nil)
+		_, err := InterruptableRPC(nil, func(ctx context.Context) (any, error) {
+			return nil, client.GetContainerEvents(ctx, containerEventsCh, nil)
+		})
 		if err == io.EOF {
 			errCh <- nil
 			return


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now utilize the new CRI API to make the events method interruptable by the context.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
It's `WIP` because we can wait for a new pinned `cri-{api,client}` tag.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make `crictl events` interruptable.
```
