### PR TITLE
Fix invalid JSON for multiple images/containers/pods

### DIFF
--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -78,13 +78,14 @@ func Info(cliContext *cli.Context, client internalapi.RuntimeService) error {
 		return err
 	}
 
-	status, err := protobufObjectToJSON(r.Status)
+	statusJSON, err := protobufObjectToJSON(r.Status)
 	if err != nil {
-		return err
+		return fmt.Errorf("create status JSON: %w", err)
 	}
 	handlers, err := json.Marshal(r.RuntimeHandlers) // protobufObjectToJSON cannot be used
 	if err != nil {
 		return err
 	}
-	return outputStatusInfo(status, string(handlers), r.Info, cliContext.String("output"), cliContext.String("template"))
+	data := []statusData{{json: statusJSON, runtimeHandlers: string(handlers), info: r.Info}}
+	return outputStatusData(data, cliContext.String("output"), cliContext.String("template"))
 }

--- a/cmd/crictl/util_test.go
+++ b/cmd/crictl/util_test.go
@@ -73,7 +73,7 @@ func TestNameFilterByRegex(t *testing.T) {
 	}
 }
 
-func TestOutputStatusInfo(t *testing.T) {
+func TestOutputStatusData(t *testing.T) {
 	const (
 		statusResponse = `{"conditions":[
 			{
@@ -180,7 +180,8 @@ func TestOutputStatusInfo(t *testing.T) {
 			}
 
 			outStr, err := captureOutput(func() error {
-				err := outputStatusInfo(tc.status, tc.handlers, tc.info, tc.format, tc.tmplStr)
+				data := []statusData{{json: tc.status, runtimeHandlers: tc.handlers, info: tc.info}}
+				err := outputStatusData(data, tc.format, tc.tmplStr)
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)
 				}

--- a/test/e2e/inspecti_test.go
+++ b/test/e2e/inspecti_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+// The actual test suite
+var _ = t.Describe("inspecti", func() {
+	const (
+		imageSuccessText = "Image is up to date"
+		registry         = "gcr.io/k8s-staging-cri-tools/"
+		image1           = registry + "test-image-2"
+		image2           = registry + "test-image-3"
+	)
+
+	BeforeEach(func() {
+		t.CrictlExpectSuccess("pull "+image1, imageSuccessText)
+		t.CrictlExpectSuccess("pull "+image2, imageSuccessText)
+	})
+
+	AfterEach(func() {
+		Expect(t.Crictl(fmt.Sprintf("rmi %s %s", image1, image2))).To(Exit(0))
+	})
+
+	It("should succeed", func() {
+		// Single response
+		res := t.Crictl("inspecti " + image1)
+		Expect(res).To(Exit(0))
+		contents := res.Out.Contents()
+
+		// Should be no slice
+		singleResponse := map[string]any{}
+		Expect(json.Unmarshal(contents, &singleResponse)).NotTo(HaveOccurred())
+		Expect(singleResponse).To(HaveKey("info"))
+		Expect(singleResponse).To(HaveKey("status"))
+
+		// Multi response
+		res = t.Crictl(fmt.Sprintf("inspecti %s %s", image1, image2))
+		Expect(res).To(Exit(0))
+		contents = res.Out.Contents()
+
+		// Should be a slice
+		multiResponse := []map[string]any{}
+		Expect(json.Unmarshal(contents, &multiResponse)).NotTo(HaveOccurred())
+		const length = 2
+		Expect(multiResponse).To(HaveLen(length))
+		for i := range length {
+			Expect(multiResponse[i]).To(HaveKey("info"))
+			Expect(multiResponse[i]).To(HaveKey("status"))
+		}
+	})
+})

--- a/test/e2e/inspectp_test.go
+++ b/test/e2e/inspectp_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+// The actual test suite
+var _ = t.Describe("inspectp", func() {
+	const sandboxesLength = 2
+	sandboxes := []string{}
+
+	BeforeEach(func() {
+		sandboxes = []string{}
+
+		for i := range sandboxesLength {
+			f, err := os.CreateTemp("", "sandbox-")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = fmt.Fprintf(f, `{ "metadata": { "name": "sb-%d", "uid": "uid-%d", "namespace": "ns" }}`, i, i)
+			Expect(err).NotTo(HaveOccurred())
+
+			res := t.Crictl("runp " + f.Name())
+			Expect(res).To(Exit(0))
+			sandboxes = append(sandboxes, string(bytes.TrimSpace(res.Out.Contents())))
+		}
+	})
+
+	AfterEach(func() {
+		for _, sb := range sandboxes {
+			Expect(os.RemoveAll(sb)).NotTo(HaveOccurred())
+			res := t.Crictl("rmp -f " + sb)
+			Expect(res).To(Exit(0))
+		}
+		Expect(t.Crictl("rmi registry.k8s.io/pause:3.9")).To(Exit(0))
+	})
+
+	It("should succeed", func() {
+		// Single entry
+		res := t.Crictl("inspectp " + sandboxes[0])
+		Expect(res).To(Exit(0))
+		contents := res.Out.Contents()
+
+		// Should be no slice
+		singleResponse := map[string]any{}
+		Expect(json.Unmarshal(contents, &singleResponse)).NotTo(HaveOccurred())
+		Expect(singleResponse).To(HaveKey("info"))
+		Expect(singleResponse).To(HaveKey("status"))
+
+		// Multiple entries
+		res = t.Crictl(fmt.Sprintf("inspectp %s %s", sandboxes[0], sandboxes[1]))
+		Expect(res).To(Exit(0))
+		contents = res.Out.Contents()
+
+		// Should be a slice
+		multiResponse := []map[string]any{}
+		Expect(json.Unmarshal(contents, &multiResponse)).NotTo(HaveOccurred())
+		Expect(multiResponse).To(HaveLen(sandboxesLength))
+		for i := range sandboxesLength {
+			Expect(multiResponse[i]).To(HaveKey("info"))
+			Expect(multiResponse[i]).To(HaveKey("status"))
+		}
+	})
+})


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Follow-up on https://github.com/kubernetes-sigs/cri-tools/pull/1486
#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/cri-tools/issues/669
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Output JSON, YAML and go-template slices correctly for `crictl inspect`, `inspectp` and `images`.
```
