### PR TITLE
Fix parent dir retrieval lint

### DIFF
--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -1579,7 +1579,7 @@ func rootfsPath(info map[string]string) string {
 
 	// The stateDir might have not been created yet. Let's use the parent directory that should
 	// always exist.
-	return filepath.Join(cfg.StateDir, "../")
+	return filepath.Dir(cfg.StateDir)
 }
 
 func hostUsernsContent() string {


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now use `filepath.Dir` to make the gocritic linter happy:

```
Error: pkg/validate/security_context_linux.go:1582:37: filepathJoin: "../" contains a path separator (gocritic)
	return filepath.Join(cfg.StateDir, "../")
```

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
cc @rata 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
