### PR TITLE
Remove log message for AppArmor profiles

### DIFF
--- a/pkg/validate/apparmor_linux.go
+++ b/pkg/validate/apparmor_linux.go
@@ -297,6 +297,5 @@ func loadTestProfiles() error {
 		return fmt.Errorf("load profiles: %w", err)
 	}
 
-	logrus.Infof("Loaded profiles: %v", out)
 	return nil
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
There is no output from `apparmor_parser` while loading the profiles, which results in meaningless messages during the tests like:

```
time="2024-07-22T08:51:18Z" level=info msg="Loaded profiles: []"
time="2024-07-22T08:51:18Z" level=info msg="Loaded profiles: []"
time="2024-07-22T08:51:19Z" level=info msg="Loaded profiles: []"
time="2024-07-22T08:51:19Z" level=info msg="Loaded profiles: []"
time="2024-07-22T08:51:20Z" level=info msg="Loaded profiles: []"
time="2024-07-22T08:51:20Z" level=info msg="Loaded profiles: []"
time="2024-07-22T08:51:21Z" level=info msg="Loaded profiles: []"
time="2024-07-22T08:51:21Z" level=info msg="Loaded profiles: []"
time="2024-07-22T08:51:21Z" level=info msg="Loaded profiles: []"
```

We can skip this message and only report errors for the preloading of profiles.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed meaningless `"Loaded profiles: []"` message during AppArmor `critest` suite runs.
```
