### PR TITLE
Fix `crictl` info for containerd

### DIFF
--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -330,11 +330,19 @@ func outputStatusData(statuses []statusData, format, tmplStr string) (err error)
 		}
 
 		for _, k := range keys {
-			var genericVal map[string]any
-			if err := json.Unmarshal([]byte(status.info[k]), &genericVal); err != nil {
-				return fmt.Errorf("unmarshal status info JSON: %w", err)
+			val := status.info[k]
+
+			if strings.HasPrefix(val, "{") {
+				// Assume a JSON object
+				var genericVal map[string]any
+				if err := json.Unmarshal([]byte(val), &genericVal); err != nil {
+					return fmt.Errorf("unmarshal status info JSON: %w", err)
+				}
+				infoMap[k] = genericVal
+			} else {
+				// Assume a string and remove any double quotes
+				infoMap[k] = strings.Trim(val, `"`)
 			}
-			infoMap[k] = genericVal
 		}
 
 		result = append(result, infoMap)


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We cannot just assume JSON objects because containerd will also return something like:

```
"golang": "go1.22.5",
"lastCNILoadStatus": "OK",
"lastCNILoadStatus.default": "OK",
```

For those values we just assume strings and prevent printing multiple double quotes to restore the v1.30.0 behavior of `crictl`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.



or

None
-->
Fixes https://github.com/kubernetes-sigs/cri-tools/issues/1566
#### Special notes for your reviewer:
This seems to be a regression and we may have to follow-up with v1.31.1
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `crictl info` output for containerd.
```
