### PR TITLE
crictl ps: output container namespace

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -1219,7 +1219,7 @@ func OutputContainers(runtimeClient internalapi.RuntimeService, imageClient inte
 
 	display := newDefaultTableDisplay()
 	if !opts.verbose && !opts.quiet {
-		display.AddRow([]string{columnContainer, columnImage, columnCreated, columnState, columnName, columnAttempt, columnPodID, columnPodName})
+		display.AddRow([]string{columnContainer, columnImage, columnCreated, columnState, columnName, columnAttempt, columnPodID, columnPodName, columnNamespace})
 	}
 	for _, c := range r {
 		if match, err := matchesImage(imageClient, opts.image, c.GetImage().GetImage()); err != nil {
@@ -1234,6 +1234,7 @@ func OutputContainers(runtimeClient internalapi.RuntimeService, imageClient inte
 
 		createdAt := time.Unix(0, c.CreatedAt)
 		ctm := units.HumanDuration(time.Now().UTC().Sub(createdAt)) + " ago"
+		podNamespace := getPodNamespaceFromLabels(c.Labels)
 		if !opts.verbose {
 			id := c.Id
 			image := c.Image.Image
@@ -1256,13 +1257,14 @@ func OutputContainers(runtimeClient internalapi.RuntimeService, imageClient inte
 			podName := getPodNameFromLabels(c.Labels)
 			display.AddRow([]string{
 				id, image, ctm, convertContainerState(c.State), c.Metadata.Name,
-				strconv.FormatUint(uint64(c.Metadata.Attempt), 10), podID, podName,
+				strconv.FormatUint(uint64(c.Metadata.Attempt), 10), podID, podName, podNamespace,
 			})
 			continue
 		}
 
 		fmt.Printf("ID: %s\n", c.Id)
 		fmt.Printf("PodID: %s\n", c.PodSandboxId)
+		fmt.Printf("Namespace: %s\n", podNamespace)
 		if c.Metadata != nil {
 			if c.Metadata.Name != "" {
 				fmt.Printf("Name: %s\n", c.Metadata.Name)


### PR DESCRIPTION

#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Follow-up on https://github.com/kubernetes-sigs/cri-tools/pull/1632 to output the namespace of the container in the same was as for pods.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
`crictl ps`: output container namespace on table or verbose output.
```
