### PR TITLE
Log the used connection timeout on debug output

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -72,13 +72,14 @@ func getRuntimeService(_ *cli.Context, timeout time.Duration) (res internalapi.R
 	if RuntimeEndpointIsSet && RuntimeEndpoint == "" {
 		return nil, errors.New("--runtime-endpoint is not set")
 	}
-	logrus.Debug("get runtime connection")
+	logrus.Debug("Get runtime connection")
 
 	// Check if a custom timeout is provided.
 	t := Timeout
 	if timeout != 0 {
 		t = timeout
 	}
+	logrus.Debugf("Using runtime connection timeout: %v", t)
 
 	// Use the noop tracer provider and not tracerProvider directly, otherwise
 	// we'll panic in the unary call interceptor
@@ -124,7 +125,7 @@ func getImageService(*cli.Context) (res internalapi.ImageManagerService, err err
 		ImageEndpointIsSet = RuntimeEndpointIsSet
 	}
 
-	logrus.Debugf("get image connection")
+	logrus.Debug("Get image connection")
 
 	// Use the noop tracer provider and not tracerProvider directly, otherwise
 	// we'll panic in the unary call interceptor
@@ -137,7 +138,7 @@ func getImageService(*cli.Context) (res internalapi.ImageManagerService, err err
 
 	// If no EP set then use the default endpoint types
 	if !ImageEndpointIsSet {
-		logrus.Warningf("image connect using default endpoints: %v. "+
+		logrus.Warningf("Image connect using default endpoints: %v. "+
 			"As the default settings are now deprecated, you should set the "+
 			"endpoint instead.", defaultRuntimeEndpoints)
 		logrus.Debug("Note that performance maybe affected as each default " +


### PR DESCRIPTION



#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The timeout is not logged when the endpoint is explicitly set. We now add this information to hint that a `0` timeout also defaults to the `2s` default after conversion.

We also capitalize logs which start with a lower letter for consistency reasons.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?



```release-note
crictl: log the used connection timeout on debug output.
```
