### PR TITLE
Fix panic if Metadata is nil

### DIFF
--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -690,7 +690,7 @@ func getSandboxesList(sandboxesList []*pb.PodSandbox, opts *listOptions) []*pb.P
 	filtered := []*pb.PodSandbox{}
 	for _, p := range sandboxesList {
 		// Filter by pod name/namespace regular expressions.
-		if matchesRegex(opts.nameRegexp, p.Metadata.Name) &&
+		if p.Metadata != nil && matchesRegex(opts.nameRegexp, p.Metadata.Name) &&
 			matchesRegex(opts.podNamespaceRegexp, p.Metadata.Namespace) {
 			filtered = append(filtered, p)
 		}


### PR DESCRIPTION
Metadata is nil will cause panic


/kind bug


When use the cri interface to contact with my server, I miss set the Metadata(its nil),and it will cause a panic.

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xfc64f1]

goroutine 1 [running]:
main.getSandboxesList({0xc0003e0040, 0x1, 0x126c9da?}, 0xc00051f818)
        /home/runner/work/cri-tools/cri-tools/cmd/crictl/sandbox.go:693 +0x91
main.ListPodSandboxes({0x1452120, 0xc000455920}, 0xc00051f818)
        /home/runner/work/cri-tools/cri-tools/cmd/crictl/sandbox.go:570 +0x36d
main.OutputPodSandboxes({0x1452120?, 0xc000455920?}, 0xc00051f818)
        /home/runner/work/cri-tools/cri-tools/cmd/crictl/sandbox.go:576 +0x3a
main.init.func34(0xc0004a0cc0)
        /home/runner/work/cri-tools/cri-tools/cmd/crictl/sandbox.go:377 +0x2ae
github.com/urfave/cli/v2.(*Command).Run(0x1d72fa0, 0xc0004a0cc0, {0xc000238980, 0x1, 0x1})
        /home/runner/work/cri-tools/cri-tools/vendor/github.com/urfave/cli/v2/command.go:276 +0x97d
github.com/urfave/cli/v2.(*Command).Run(0xc0003d22c0, 0xc0004a07c0, {0xc00012c120, 0x6, 0x6})
        /home/runner/work/cri-tools/cri-tools/vendor/github.com/urfave/cli/v2/command.go:269 +0xbb7
github.com/urfave/cli/v2.(*App).RunContext(0xc0004a6000, {0x1440ae0, 0x1e03520}, {0xc00012c120, 0x6, 0x6})
        /home/runner/work/cri-tools/cri-tools/vendor/github.com/urfave/cli/v2/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(...)
        /home/runner/work/cri-tools/cri-tools/vendor/github.com/urfave/cli/v2/app.go:307
main.main()
        /home/runner/work/cri-tools/cri-tools/cmd/crictl/main.go:363 +0xcf2
