### PR TITLE
Fix panic if container metadata is `nil`

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -1332,7 +1332,8 @@ func getContainersList(containersList []*pb.Container, opts *listOptions) []*pb.
 	for _, c := range containersList {
 		podNamespace := getPodNamespaceFromLabels(c.Labels)
 		// Filter by pod name/namespace regular expressions.
-		if matchesRegex(opts.nameRegexp, c.Metadata.Name) &&
+		if c.Metadata != nil &&
+			matchesRegex(opts.nameRegexp, c.Metadata.Name) &&
 			matchesRegex(opts.podNamespaceRegexp, podNamespace) {
 			filtered = append(filtered, c)
 		}


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
The same as https://github.com/kubernetes-sigs/cri-tools/pull/1640, but for containers.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
crictl: fixed runtime panic if container metadata is `nil`.
```
