### PR TITLE
Add warning log message about which config files to try

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 // ServerConfiguration is the config for connecting to and using a CRI server.
@@ -50,8 +52,9 @@ func GetServerConfigFromFile(configFileName, currentDir string) (*ServerConfigur
 		// If the config file was not found, try looking in the program's
 		// directory as a fallback. This is to accommodate where the config file
 		// is placed with the cri tools binary.
-		configFileName = filepath.Join(filepath.Dir(currentDir), "crictl.yaml")
-		if _, err := os.Stat(configFileName); err != nil {
+		nextConfigFileName := filepath.Join(filepath.Dir(currentDir), "crictl.yaml")
+		logrus.Warnf("Config %q does not exist, trying next: %q", configFileName, nextConfigFileName)
+		if _, err := os.Stat(nextConfigFileName); err != nil {
 			return nil, fmt.Errorf("load config file: %w", err)
 		}
 	}


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
If the specified `--config` does not exist, then crictl will try the binary directory as last resort. We now log that behavior so that end users don't think unintentionally they specified the wrong `--config` value:

```
> sudo ./build/bin/linux/amd64/crictl --config ~/downloads/crictl.yaml config --list
WARN[0000] Config "/home/x/downloads/crictl.yaml" does not exist, trying: "/home/s/go/src/sigs.k8s.io/cri-tools/build/bin/linux/amd64/crictl.yaml"
FATA[0000] load config file: stat /home/sascha/go/src/sigs.k8s.io/cri-tools/build/bin/linux/amd64/crictl.yaml: no such file or directory
```
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
