### PR TITLE
Use const defines for config options

### DIFF
--- a/cmd/crictl/config.go
+++ b/cmd/crictl/config.go
@@ -72,17 +72,17 @@ CRICTL OPTIONS:
 		if c.IsSet("get") {
 			get := c.String("get")
 			switch get {
-			case "runtime-endpoint":
+			case common.RuntimeEndpoint:
 				fmt.Println(config.RuntimeEndpoint)
-			case "image-endpoint":
+			case common.ImageEndpoint:
 				fmt.Println(config.ImageEndpoint)
-			case "timeout":
+			case common.Timeout:
 				fmt.Println(config.Timeout)
-			case "debug":
+			case common.Debug:
 				fmt.Println(config.Debug)
-			case "pull-image-on-create":
+			case common.PullImageOnCreate:
 				fmt.Println(config.PullImageOnCreate)
-			case "disable-pull-on-run":
+			case common.DisablePullOnRun:
 				fmt.Println(config.DisablePullOnRun)
 			default:
 				return fmt.Errorf("no configuration option named %s", get)
@@ -108,12 +108,12 @@ CRICTL OPTIONS:
 		} else if c.Bool("list") {
 			display := newDefaultTableDisplay()
 			display.AddRow([]string{columnKey, columnValue})
-			display.AddRow([]string{"runtime-endpoint", config.RuntimeEndpoint})
-			display.AddRow([]string{"image-endpoint", config.ImageEndpoint})
-			display.AddRow([]string{"timeout", strconv.Itoa(config.Timeout)})
-			display.AddRow([]string{"debug", strconv.FormatBool(config.Debug)})
-			display.AddRow([]string{"pull-image-on-create", strconv.FormatBool(config.PullImageOnCreate)})
-			display.AddRow([]string{"disable-pull-on-run", strconv.FormatBool(config.DisablePullOnRun)})
+			display.AddRow([]string{common.RuntimeEndpoint, config.RuntimeEndpoint})
+			display.AddRow([]string{common.ImageEndpoint, config.ImageEndpoint})
+			display.AddRow([]string{common.Timeout, strconv.Itoa(config.Timeout)})
+			display.AddRow([]string{common.Debug, strconv.FormatBool(config.Debug)})
+			display.AddRow([]string{common.PullImageOnCreate, strconv.FormatBool(config.PullImageOnCreate)})
+			display.AddRow([]string{common.DisablePullOnRun, strconv.FormatBool(config.DisablePullOnRun)})
 			display.ClearScreen()
 			display.Flush()
 
@@ -135,29 +135,29 @@ CRICTL OPTIONS:
 
 func setValue(key, value string, config *common.Config) error {
 	switch key {
-	case "runtime-endpoint":
+	case common.RuntimeEndpoint:
 		config.RuntimeEndpoint = value
-	case "image-endpoint":
+	case common.ImageEndpoint:
 		config.ImageEndpoint = value
-	case "timeout":
+	case common.Timeout:
 		n, err := strconv.Atoi(value)
 		if err != nil {
 			return fmt.Errorf("parse timeout value '%s': %w", value, err)
 		}
 		config.Timeout = n
-	case "debug":
+	case common.Debug:
 		debug, err := strconv.ParseBool(value)
 		if err != nil {
 			return fmt.Errorf("parse debug value '%s': %w", value, err)
 		}
 		config.Debug = debug
-	case "pull-image-on-create":
+	case common.PullImageOnCreate:
 		pi, err := strconv.ParseBool(value)
 		if err != nil {
 			return fmt.Errorf("parse pull-image-on-create value '%s': %w", value, err)
 		}
 		config.PullImageOnCreate = pi
-	case "disable-pull-on-run":
+	case common.DisablePullOnRun:
 		pi, err := strconv.ParseBool(value)
 		if err != nil {
 			return fmt.Errorf("parse disable-pull-on-run value '%s': %w", value, err)

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -37,6 +37,26 @@ type Config struct {
 	yamlData          *yaml.Node // YAML representation of config
 }
 
+const (
+	// RuntimeEndpoint is the YAML key for the runtime endpoint config option.
+	RuntimeEndpoint = "runtime-endpoint"
+
+	// ImageEndpoint is the YAML key for the image endpoint config option.
+	ImageEndpoint = "image-endpoint"
+
+	// Timeout is the YAML key for the timeout config option.
+	Timeout = "timeout"
+
+	// Debug is the YAML key for the debug config option.
+	Debug = "debug"
+
+	// PullImageOnCreate is the YAML key for the pull image on create config option.
+	PullImageOnCreate = "pull-image-on-create"
+
+	// DisablePullOnRun is the YAML key for the disable pull on run config option.
+	DisablePullOnRun = "disable-pull-on-run"
+)
+
 // ReadConfig reads from a file with the given name and returns a config or
 // an error if the file was unable to be parsed.
 func ReadConfig(filepath string) (*Config, error) {
@@ -99,26 +119,26 @@ func getConfigOptions(yamlData *yaml.Node) (*Config, error) {
 		value := yamlData.Content[0].Content[indx+1].Value
 		var err error
 		switch name {
-		case "runtime-endpoint":
+		case RuntimeEndpoint:
 			config.RuntimeEndpoint = value
-		case "image-endpoint":
+		case ImageEndpoint:
 			config.ImageEndpoint = value
-		case "timeout":
+		case Timeout:
 			config.Timeout, err = strconv.Atoi(value)
 			if err != nil {
 				return nil, fmt.Errorf("parsing config option '%s': %w", name, err)
 			}
-		case "debug":
+		case Debug:
 			config.Debug, err = strconv.ParseBool(value)
 			if err != nil {
 				return nil, fmt.Errorf("parsing config option '%s': %w", name, err)
 			}
-		case "pull-image-on-create":
+		case PullImageOnCreate:
 			config.PullImageOnCreate, err = strconv.ParseBool(value)
 			if err != nil {
 				return nil, fmt.Errorf("parsing config option '%s': %w", name, err)
 			}
-		case "disable-pull-on-run":
+		case DisablePullOnRun:
 			config.DisablePullOnRun, err = strconv.ParseBool(value)
 			if err != nil {
 				return nil, fmt.Errorf("parsing config option '%s': %w", name, err)
@@ -134,12 +154,12 @@ func getConfigOptions(yamlData *yaml.Node) (*Config, error) {
 
 // Set config options on yaml data for persistece to file.
 func setConfigOptions(config *Config) {
-	setConfigOption("runtime-endpoint", config.RuntimeEndpoint, config.yamlData)
-	setConfigOption("image-endpoint", config.ImageEndpoint, config.yamlData)
-	setConfigOption("timeout", strconv.Itoa(config.Timeout), config.yamlData)
-	setConfigOption("debug", strconv.FormatBool(config.Debug), config.yamlData)
-	setConfigOption("pull-image-on-create", strconv.FormatBool(config.PullImageOnCreate), config.yamlData)
-	setConfigOption("disable-pull-on-run", strconv.FormatBool(config.DisablePullOnRun), config.yamlData)
+	setConfigOption(RuntimeEndpoint, config.RuntimeEndpoint, config.yamlData)
+	setConfigOption(ImageEndpoint, config.ImageEndpoint, config.yamlData)
+	setConfigOption(Timeout, strconv.Itoa(config.Timeout), config.yamlData)
+	setConfigOption(Debug, strconv.FormatBool(config.Debug), config.yamlData)
+	setConfigOption(PullImageOnCreate, strconv.FormatBool(config.PullImageOnCreate), config.yamlData)
+	setConfigOption(DisablePullOnRun, strconv.FormatBool(config.DisablePullOnRun), config.yamlData)
 }
 
 // Set config option on yaml.
@@ -188,13 +208,13 @@ func setConfigOption(configName, configValue string, yamlData *yaml.Node) {
 		}
 		var tagType string
 		switch configName {
-		case "timeout":
+		case Timeout:
 			tagType = tagInt
-		case "debug":
+		case Debug:
 			tagType = tagBool
-		case "pull-image-on-create":
+		case PullImageOnCreate:
 			tagType = tagBool
-		case "disable-pull-on-run":
+		case DisablePullOnRun:
 			tagType = tagBool
 		default:
 			tagType = tagStr


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
This allows deduplicating the static strings and using const values which are defined in one place.

#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
