### PR TITLE
Fix `crictl config --set` if the YAML defines entries multiple times

### DIFF
--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -182,9 +182,9 @@ func setConfigOption(configName, configValue string, yamlData *yaml.Node) {
 	for indx := 0; indx < contentLen-1; {
 		name := yamlData.Content[0].Content[indx].Value
 		if name == configName {
+			// Set the value, even if we have the option defined multiple times.
 			yamlData.Content[0].Content[indx+1].Value = configValue
 			foundOption = true
-			break
 		}
 		indx += 2
 	}

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -87,4 +87,42 @@ pull-image-on-create: false
 disable-pull-on-run: false
 `))
 	})
+
+	It("should succeed to get the right value if duplicate entries are defined", func() {
+		_, err := configFile.WriteString(`
+timeout: 20
+timeout: 5
+timeout: 10
+`)
+		Expect(err).NotTo(HaveOccurred())
+
+		t.CrictlExpectSuccess("--config "+configFile.Name()+" config --get timeout", "10")
+	})
+
+	It("should succeed to set duplicate entries", func() {
+		_, err := configFile.WriteString(`
+timeout: 20
+timeout: 5
+timeout: 10
+`)
+		Expect(err).NotTo(HaveOccurred())
+
+		t.CrictlExpectSuccess("--config "+configFile.Name()+" config --set timeout=30", "")
+
+		cfgContent, err := os.ReadFile(configFile.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(string(cfgContent)).To(Equal(
+			`timeout: 30
+timeout: 30
+timeout: 30
+runtime-endpoint: ""
+image-endpoint: ""
+debug: false
+pull-image-on-create: false
+disable-pull-on-run: false
+`))
+
+		t.CrictlExpectSuccess("--config "+configFile.Name()+" config --get timeout", "30")
+	})
 })


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Only the first entry would be written before applying this patch. This means that a config like this:

```yaml
timeout: 5
timeout: 10
timeout: 20
runtime-endpoint: ""
image-endpoint: ""
debug: false
pull-image-on-create: false
disable-pull-on-run: false
```

Would return the right value (the last one):

```
> crictl --config ./crictl.yaml config --get timeout
20
```

But setting the config will only result in setting the first item:

```
> crictl --config ./crictl.yaml config --set timeout=30
> cat crictl.yaml
timeout: 30
timeout: 10
timeout: 20
runtime-endpoint: ""
image-endpoint: ""
debug: false
pull-image-on-create: false
disable-pull-on-run: false
```

And therefore also a wrong result of `crictl config --get`:

```
> crictl --config ./crictl.yaml config --get timeout
20
```

We now change that behavior and set all values without de-duplicating them:

```
> crictl --config ./crictl.yaml config --set timeout=30
> cat crictl.yaml
timeout: 30
timeout: 30
timeout: 30
runtime-endpoint: ""
image-endpoint: ""
debug: false
pull-image-on-create: false
disable-pull-on-run: false
```

e2e test cases around that scenario have been added as well.
#### Which issue(s) this PR fixes:

None
#### Special notes for your reviewer:
Follow-up on https://github.com/kubernetes-sigs/cri-tools/pull/1659#discussion_r1817010069
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `crictl config --set` if the configuration YAML defines entries multiple times.
```
