### PR TITLE
No need for overly strict criteria for judgment

### DIFF
--- a/pkg/validate/multi_container_linux.go
+++ b/pkg/validate/multi_container_linux.go
@@ -92,7 +92,7 @@ var _ = framework.KubeDescribe("Multiple Containers [Conformance]", func() {
 			httpdStatus, err := rc.ContainerStatus(context.TODO(), httpdContainerID, false)
 			Expect(err).NotTo(HaveOccurred(), "get httpd container status")
 			Eventually(verifyContainerLog(httpdStatus.GetStatus().GetLogPath(),
-				"httpd -D FOREGROUND"), time.Minute, 100*time.Millisecond).Should(BeTrue())
+				"httpd"), time.Minute, 100*time.Millisecond).Should(BeTrue())
 
 			busyboxStatus, err := rc.ContainerStatus(context.TODO(), busyboxContainerID, false)
 			Expect(err).NotTo(HaveOccurred(), "get busybox container status")


### PR DESCRIPTION
http container support container log. No need http server start success. I think the test case now may so strict. Sometime the http server may not start successful.



/kind design

httpd server may not start successful ,  but for this test case `multi_container_linux.go`  ,have shim log is enough. If the http server do not start success , will not print "httpd -D FOREGROUND";

I go this log:
`
2024-10-30T19:54:35.555822266+08:00 stderr F AH00557: httpd: apr_sockaddr_info_get() failed for host-10-89-230-13
2024-10-30T19:54:35.555855929+08:00 stderr F AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 127.0.0.1. Set the 'ServerName' directive globally to suppress this message
`
it looks host domain case http server start fail. How about making the criteria for judgment more lenient.