### PR TITLE
Add TLS support for `crictl` `exec`, `portforward` and `attach`

### DIFF
--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/protobuf/protoadapt"
 	"google.golang.org/protobuf/runtime/protoiface"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/rest"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"sigs.k8s.io/yaml"
@@ -157,7 +158,10 @@ type execOptions struct {
 	cmd []string
 	// transport to be used
 	transport string
+	// TLS configuration for streaming
+	tlsConfig *rest.TLSClientConfig
 }
+
 type attachOptions struct {
 	// id of container
 	id string
@@ -167,6 +171,8 @@ type attachOptions struct {
 	stdin bool
 	// transport to be used
 	transport string
+	// TLS configuration for streaming
+	tlsConfig *rest.TLSClientConfig
 }
 
 type portforwardOptions struct {
@@ -176,6 +182,8 @@ type portforwardOptions struct {
 	ports []string
 	// transport to be used
 	transport string
+	// TLS configuration for streaming
+	tlsConfig *rest.TLSClientConfig
 }
 
 func getSortedKeys(m map[string]string) []string {


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Add flags to allow using the TLS based streaming configuration.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added TLS support for `crictl` `exec`, `portforward` and `attach` using the `--tls-ca`, `--tls-cert`, `--tls-key` and `--tls-server-name` flags.
```
