### PR TITLE
add swap column to crictl stats

### DIFF
--- a/cmd/crictl/container_stats.go
+++ b/cmd/crictl/container_stats.go
@@ -182,7 +182,7 @@ func (d containerStatsDisplayer) displayStats(ctx context.Context, client intern
 		return err
 	}
 
-	d.display.AddRow([]string{columnContainer, columnName, columnCPU, columnMemory, columnDisk, columnInodes})
+	d.display.AddRow([]string{columnContainer, columnName, columnCPU, columnMemory, columnDisk, columnInodes, columnSwap})
 	for _, s := range r.GetStats() {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -193,6 +193,7 @@ func (d containerStatsDisplayer) displayStats(ctx context.Context, client intern
 		mem := s.GetMemory().GetWorkingSetBytes().GetValue()
 		disk := s.GetWritableLayer().GetUsedBytes().GetValue()
 		inodes := s.GetWritableLayer().GetInodesUsed().GetValue()
+		swap := s.GetSwap().GetSwapUsageBytes().GetValue()
 		if !d.opts.all && cpu == 0 && mem == 0 {
 			// Skip non-running container
 			continue
@@ -213,7 +214,7 @@ func (d containerStatsDisplayer) displayStats(ctx context.Context, client intern
 		}
 		d.display.AddRow([]string{
 			id, name, fmt.Sprintf("%.2f", cpuPerc), units.HumanSize(float64(mem)),
-			units.HumanSize(float64(disk)), strconv.FormatUint(inodes, 10),
+			units.HumanSize(float64(disk)), strconv.FormatUint(inodes, 10), units.HumanSize(float64(swap)),
 		})
 	}
 	d.display.ClearScreen()

--- a/cmd/crictl/display.go
+++ b/cmd/crictl/display.go
@@ -41,6 +41,7 @@ const (
 	columnDigest     = "DIGEST"
 	columnMemory     = "MEM"
 	columnInodes     = "INODES"
+	columnSwap       = "SWAP"
 	columnDisk       = "DISK"
 	columnCPU        = "CPU %"
 	columnKey        = "KEY"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add Swap to `crictl stats` display.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add swap to crictl stats default output.
```
