### PR TITLE
Make `--tls-ca` optional

### DIFF
--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -281,9 +281,9 @@ func tlsConfigFromFlags(ctx *cli.Context) (*rest.TLSClientConfig, error) {
 	if cfg.CAFile == "" && cfg.CertFile == "" && cfg.KeyFile == "" {
 		return &rest.TLSClientConfig{Insecure: true}, nil
 	}
-	if cfg.CAFile == "" || cfg.CertFile == "" || cfg.KeyFile == "" {
+	if cfg.CertFile == "" || cfg.KeyFile == "" {
 		return nil, fmt.Errorf(
-			"all three flags --%s, --%s and --%s are required for TLS streaming",
+			"all two flags --%s and --%s are required for TLS streaming, only --%s is optional",
 			flagTLSCA, flagTLSCert, flagTLSKey,
 		)
 	}


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
The CA can be empty and we should not block if it's not set.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Follow-up on https://github.com/kubernetes-sigs/cri-tools/pull/1668
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
