### PR TITLE
Add `--profile-{cpu,mem}` flags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,6 +122,8 @@ linters-settings:
         disabled: true
   nestif:
     min-complexity: 17
+  maintidx:
+    under: 10
   godox:
     keywords:
       - BUG
@@ -132,7 +134,7 @@ linters-settings:
   cyclop:
     max-complexity: 37
   gocognit:
-    min-complexity: 53
+    min-complexity: 71
   gci:
     sections:
       - standard


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
The flags allow debugging `crictl` with respect to CPU and memory consumption.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Users reported strange memory behavior when running `crictl ps` which is not reproducible for me. Adding the flags will give us more insights and could be beneficial to others.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added crictl `--profile-{cpu,mem}` flags for debugging the application.
```
