### PR TITLE
bug fix: Fix panic if c.Image is nil

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -1233,8 +1233,11 @@ func OutputContainers(runtimeClient internalapi.RuntimeService, imageClient inte
 		podNamespace := getPodNamespaceFromLabels(c.Labels)
 		if !opts.verbose {
 			id := c.Id
-			image := c.Image.Image
 			podID := c.PodSandboxId
+			var image string
+			if c.Image != nil {
+				image = c.Image.Image
+			}
 			if !opts.noTrunc {
 				id = getTruncatedID(id, "")
 				podID = getTruncatedID(podID, "")


### PR DESCRIPTION
add judgement of c.Image


/kind bug

if c.Image is nil  Panic found :
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xfc9c7a]

goroutine 1 [running]:
main.OutputContainers({0x1468640?, 0xc000058bd0?}, {0x1458960, 0xc00001e640}, 0xc00061f818)
        sigs.k8s.io/cri-tools/cmd/crictl/container.go:1244 +0x61a
main.init.func11(0xc0000f78c0)
        sigs.k8s.io/cri-tools/cmd/crictl/container.go:705 +0x3f0
github.com/urfave/cli/v2.(*Command).Run(0x1d85020, 0xc0000f78c0, {0xc0005a5690, 0x1, 0x1})
        github.com/urfave/cli/v2@v2.27.5/command.go:276 +0x97d
github.com/urfave/cli/v2.(*Command).Run(0xc00042a160, 0xc0000f73c0, {0xc00003e180, 0x6, 0x6})
        github.com/urfave/cli/v2@v2.27.5/command.go:269 +0xbb7
github.com/urfave/cli/v2.(*App).RunContext(0xc000223000, {0x1456e00, 0x1e17700}, {0xc00003e180, 0x6, 0x6})
        github.com/urfave/cli/v2@v2.27.5/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(...)
        github.com/urfave/cli/v2@v2.27.5/app.go:307
main.main()
        sigs.k8s.io/cri-tools/cmd/crictl/main.go:364 +0xcf2


