### PR TITLE
Pass WindowsContainerResources in UpdateContainerResources call

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -962,7 +962,7 @@ func UpdateContainerResources(client internalapi.RuntimeService, id string, opts
 		}
 	}
 	logrus.Debugf("UpdateContainerResourcesRequest: %v", request)
-	resources := &pb.ContainerResources{Linux: request.Linux}
+	resources := &pb.ContainerResources{Linux: request.Linux, Windows: request.Windows}
 	if _, err := InterruptableRPC(nil, func(ctx context.Context) (any, error) {
 		return nil, client.UpdateContainerResources(ctx, id, resources)
 	}); err != nil {


### PR DESCRIPTION
Pass WindowsContainerResources in UpdateContainerResources call
This was regressed in commit 1616f25801272c7507bceb688182d0ed1e47fffc for crictl.exe update command on windows.
https://github.com/kubernetes-sigs/cri-tools/commit/1616f25801272c7507bceb688182d0ed1e47fffc 

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a regression introduced by a commit roughly 3 years ago.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

```release-note

```
