### PR TITLE
Fix `should not show help running rmi -a` e2e test

### DIFF
--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -54,8 +54,8 @@ var _ = t.Describe("inspect", func() {
 	})
 
 	AfterEach(func() {
-		res := t.Crictl("rmp -f " + sandbox)
-		Expect(res).To(Exit(0))
+		Expect(t.Crictl("rmp -f " + sandbox)).To(Exit(0))
+		Expect(t.Crictl("rmi " + imageLatest)).To(Exit(0))
 	})
 
 	validateSingleResponse := func(contents []byte) {


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
We need to remove the used image otherwise the test will fail. This patch will fix that behavior.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
