### PR TITLE
Enable `wsl` and `nlreturn` linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,7 @@ linters:
     - nestif
     - nilerr
     - nilnesserr
+    - nlreturn
     - noctx
     - nolintlint
     - nosprintfhostport
@@ -97,6 +98,7 @@ linters:
     - usetesting
     - wastedassign
     - whitespace
+    - wsl
     - zerologlint
     # - depguard
     # - err113
@@ -110,12 +112,10 @@ linters:
     # - lll
     # - mnd
     # - nilnil
-    # - nlreturn
     # - nonamedreturns
     # - testpackage
     # - varnamelen
     # - wrapcheck
-    # - wsl
 linters-settings:
   stylecheck:
     checks:

--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -102,6 +102,7 @@ var runtimeAttachCommand = &cli.Command{
 		if err = Attach(ctx, runtimeClient, opts); err != nil {
 			return fmt.Errorf("attaching running container failed: %w", err)
 		}
+
 		return nil
 	},
 }
@@ -111,6 +112,7 @@ func Attach(ctx context.Context, client internalapi.RuntimeService, opts attachO
 	if opts.id == "" {
 		return errors.New("ID cannot be empty")
 	}
+
 	request := &pb.AttachRequest{
 		ContainerId: opts.id,
 		Tty:         opts.tty,
@@ -119,13 +121,16 @@ func Attach(ctx context.Context, client internalapi.RuntimeService, opts attachO
 		Stderr:      !opts.tty,
 	}
 	logrus.Debugf("AttachRequest: %v", request)
+
 	r, err := InterruptableRPC(ctx, func(ctx context.Context) (*pb.AttachResponse, error) {
 		return client.Attach(ctx, request)
 	})
 	logrus.Debugf("AttachResponse: %v", r)
+
 	if err != nil {
 		return err
 	}
+
 	attachURL := r.Url
 
 	URL, err := url.Parse(attachURL)
@@ -136,10 +141,12 @@ func Attach(ctx context.Context, client internalapi.RuntimeService, opts attachO
 	if URL.Host == "" {
 		URL.Host = kubeletURLHost
 	}
+
 	if URL.Scheme == "" {
 		URL.Scheme = kubeletURLSchema
 	}
 
 	logrus.Debugf("Attach URL: %v", URL)
+
 	return stream(ctx, opts.stdin, opts.tty, opts.transport, URL, opts.tlsConfig)
 }

--- a/cmd/crictl/completion.go
+++ b/cmd/crictl/completion.go
@@ -37,10 +37,12 @@ complete -F _crictl crictl`
 
 func bashCompletion(c *cli.Context) error {
 	subcommands := []string{}
+
 	for _, command := range c.App.Commands {
 		if command.Hidden {
 			continue
 		}
+
 		subcommands = append(subcommands, command.Names()...)
 	}
 
@@ -50,6 +52,7 @@ func bashCompletion(c *cli.Context) error {
 	}
 
 	fmt.Fprintln(c.App.Writer, fmt.Sprintf(bashCompletionTemplate, strings.Join(subcommands, "\n")))
+
 	return nil
 }
 
@@ -71,10 +74,12 @@ compdef _crictl crictl`
 
 func zshCompletion(c *cli.Context) error {
 	subcommands := []string{}
+
 	for _, command := range c.App.Commands {
 		if command.Hidden {
 			continue
 		}
+
 		for _, name := range command.Names() {
 			subcommands = append(subcommands, name+":"+command.Usage)
 		}
@@ -87,6 +92,7 @@ func zshCompletion(c *cli.Context) error {
 	}
 
 	fmt.Fprintln(c.App.Writer, fmt.Sprintf(zshCompletionTemplate, strings.Join(subcommands, "' '"), strings.Join(opts, "' '")))
+
 	return nil
 }
 
@@ -95,7 +101,9 @@ func fishCompletion(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
 	fmt.Fprintln(c.App.Writer, completion)
+
 	return nil
 }
 

--- a/cmd/crictl/config.go
+++ b/cmd/crictl/config.go
@@ -98,6 +98,7 @@ CRICTL OPTIONS:
 			default:
 				return fmt.Errorf("no configuration option named %s", get)
 			}
+
 			return nil
 		} else if c.IsSet("set") {
 			settings := c.StringSlice("set")
@@ -115,6 +116,7 @@ CRICTL OPTIONS:
 					}
 				}
 			}
+
 			return common.WriteConfig(config, configFile)
 		} else if c.Bool("list") {
 			display := newDefaultTableDisplay()
@@ -141,6 +143,7 @@ CRICTL OPTIONS:
 		if err := setValue(key, value, config); err != nil {
 			return fmt.Errorf("set %q to %q: %w", key, value, err)
 		}
+
 		return common.WriteConfig(config, configFile)
 	},
 }
@@ -156,27 +159,32 @@ func setValue(key, value string, config *common.Config) error {
 		if err != nil {
 			return fmt.Errorf("parse timeout value '%s': %w", value, err)
 		}
+
 		config.Timeout = n
 	case common.Debug:
 		debug, err := strconv.ParseBool(value)
 		if err != nil {
 			return fmt.Errorf("parse debug value '%s': %w", value, err)
 		}
+
 		config.Debug = debug
 	case common.PullImageOnCreate:
 		pi, err := strconv.ParseBool(value)
 		if err != nil {
 			return fmt.Errorf("parse pull-image-on-create value '%s': %w", value, err)
 		}
+
 		config.PullImageOnCreate = pi
 	case common.DisablePullOnRun:
 		pi, err := strconv.ParseBool(value)
 		if err != nil {
 			return fmt.Errorf("parse disable-pull-on-run value '%s': %w", value, err)
 		}
+
 		config.DisablePullOnRun = pi
 	default:
 		return fmt.Errorf("no configuration option named %s", key)
 	}
+
 	return nil
 }

--- a/cmd/crictl/container_test.go
+++ b/cmd/crictl/container_test.go
@@ -29,10 +29,12 @@ import (
 func fakeContainersWithCreatedAtDesc(names ...string) []*pb.Container {
 	containers := make([]*pb.Container, len(names))
 	creationTime := time.Date(2023, 1, 1, 12, 0o0, 0o0, 0o0, time.UTC)
+
 	for i, name := range names {
 		containers[i] = fakeContainer(name, creationTime.UnixNano())
 		creationTime = creationTime.Truncate(time.Hour)
 	}
+
 	return containers
 }
 

--- a/cmd/crictl/display.go
+++ b/cmd/crictl/display.go
@@ -60,6 +60,7 @@ func newDefaultTableDisplay() *display {
 // newTableDisplay creates a display instance, and uses to format output with table.
 func newTableDisplay(minwidth, tabwidth, padding int, padchar byte, flags uint) *display {
 	w := tabwriter.NewWriter(os.Stdout, minwidth, tabwidth, padding, padchar, flags)
+
 	return &display{w}
 }
 

--- a/cmd/crictl/events.go
+++ b/cmd/crictl/events.go
@@ -80,13 +80,16 @@ func Events(cliContext *cli.Context, client internalapi.RuntimeService) error {
 	errCh := make(chan error, 1)
 
 	containerEventsCh := make(chan *pb.ContainerEventResponse)
+
 	go func() {
 		logrus.Debug("getting container events")
+
 		_, err := InterruptableRPC(nil, func(ctx context.Context) (any, error) {
 			return nil, client.GetContainerEvents(ctx, containerEventsCh, nil)
 		})
 		if errors.Is(err, io.EOF) {
 			errCh <- nil
+
 			return
 		}
 		errCh <- err

--- a/cmd/crictl/image_test.go
+++ b/cmd/crictl/image_test.go
@@ -29,9 +29,11 @@ func fakeImage(id string, digest, tags []string) *pb.Image {
 func assert(input []*pb.Image, options, images []string) {
 	actual, _ := filterImagesList(input, options)
 	expected := []string{}
+
 	for _, img := range actual {
 		expected = append(expected, img.Id)
 	}
+
 	Expect(images).To(Equal(expected))
 }
 

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -62,6 +62,7 @@ var runtimeStatusCommand = &cli.Command{
 		if err = Info(c, runtimeClient); err != nil {
 			return fmt.Errorf("getting status of runtime: %w", err)
 		}
+
 		return nil
 	},
 }
@@ -70,10 +71,12 @@ var runtimeStatusCommand = &cli.Command{
 func Info(cliContext *cli.Context, client internalapi.RuntimeService) error {
 	request := &pb.StatusRequest{Verbose: !cliContext.Bool("quiet")}
 	logrus.Debugf("StatusRequest: %v", request)
+
 	r, err := InterruptableRPC(nil, func(ctx context.Context) (*pb.StatusResponse, error) {
 		return client.Status(ctx, request.Verbose)
 	})
 	logrus.Debugf("StatusResponse: %v", r)
+
 	if err != nil {
 		return err
 	}
@@ -82,10 +85,13 @@ func Info(cliContext *cli.Context, client internalapi.RuntimeService) error {
 	if err != nil {
 		return fmt.Errorf("create status JSON: %w", err)
 	}
+
 	handlers, err := json.Marshal(r.RuntimeHandlers) // protobufObjectToJSON cannot be used
 	if err != nil {
 		return err
 	}
+
 	data := []statusData{{json: statusJSON, runtimeHandlers: string(handlers), info: r.Info}}
+
 	return outputStatusData(data, cliContext.String("output"), cliContext.String("template"))
 }

--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -197,14 +197,18 @@ func parseTimestamp(value string) (*metav1.Time, error) {
 	if value == "" {
 		return nil, nil
 	}
+
 	str, err := timetypes.GetTimestamp(value, time.Now())
 	if err != nil {
 		return nil, err
 	}
+
 	s, ns, err := timetypes.ParseTimestamps(str, 0)
 	if err != nil {
 		return nil, err
 	}
+
 	t := metav1.NewTime(time.Unix(s, ns))
+
 	return &t, nil
 }

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -74,6 +74,7 @@ func getRuntimeService(_ *cli.Context, timeout time.Duration) (res internalapi.R
 	if RuntimeEndpointIsSet && RuntimeEndpoint == "" {
 		return nil, errors.New("--runtime-endpoint is not set")
 	}
+
 	logrus.Debug("Get runtime connection")
 
 	// Check if a custom timeout is provided.
@@ -81,6 +82,7 @@ func getRuntimeService(_ *cli.Context, timeout time.Duration) (res internalapi.R
 	if timeout != 0 {
 		t = timeout
 	}
+
 	logrus.Debugf("Using runtime connection timeout: %v", t)
 
 	// Use the noop tracer provider and not tracerProvider directly, otherwise
@@ -107,14 +109,18 @@ func getRuntimeService(_ *cli.Context, timeout time.Duration) (res internalapi.R
 			res, err = remote.NewRemoteRuntimeService(endPoint, t, tp, &logger)
 			if err != nil {
 				logrus.Error(err)
+
 				continue
 			}
 
 			logrus.Debugf("Connected successfully using endpoint: %s", endPoint)
+
 			break
 		}
+
 		return res, err
 	}
+
 	return remote.NewRemoteRuntimeService(RuntimeEndpoint, t, tp, &logger)
 }
 
@@ -123,6 +129,7 @@ func getImageService(*cli.Context) (res internalapi.ImageManagerService, err err
 		if RuntimeEndpointIsSet && RuntimeEndpoint == "" {
 			return nil, errors.New("--image-endpoint is not set")
 		}
+
 		ImageEndpoint = RuntimeEndpoint
 		ImageEndpointIsSet = RuntimeEndpointIsSet
 	}
@@ -153,14 +160,18 @@ func getImageService(*cli.Context) (res internalapi.ImageManagerService, err err
 			res, err = remote.NewRemoteImageService(endPoint, Timeout, tp, &logger)
 			if err != nil {
 				logrus.Error(err)
+
 				continue
 			}
 
 			logrus.Debugf("Connected successfully using endpoint: %s", endPoint)
+
 			break
 		}
+
 		return res, err
 	}
+
 	return remote.NewRemoteImageService(ImageEndpoint, Timeout, tp, &logger)
 }
 
@@ -292,6 +303,7 @@ func main() {
 
 	app.Before = func(context *cli.Context) (err error) {
 		var config *common.ServerConfiguration
+
 		var exePath string
 
 		cpuProfilePath := context.String("profile-cpu")
@@ -316,6 +328,7 @@ func main() {
 		if exePath, err = os.Executable(); err != nil {
 			logrus.Fatal(err)
 		}
+
 		if config, err = common.GetServerConfigFromFile(context.String("config"), exePath); err != nil {
 			if context.IsSet("config") {
 				logrus.Fatal(err)
@@ -324,18 +337,23 @@ func main() {
 
 		if config == nil {
 			RuntimeEndpoint = context.String("runtime-endpoint")
+
 			if context.IsSet("runtime-endpoint") {
 				RuntimeEndpointIsSet = true
 			}
+
 			ImageEndpoint = context.String("image-endpoint")
+
 			if context.IsSet("image-endpoint") {
 				ImageEndpointIsSet = true
 			}
+
 			if context.IsSet("timeout") {
 				Timeout = getTimeout(context.Duration("timeout"))
 			} else {
 				Timeout = context.Duration("timeout")
 			}
+
 			Debug = context.Bool("debug")
 			DisablePullOnRun = false
 		} else {
@@ -349,6 +367,7 @@ func main() {
 			} else {
 				RuntimeEndpoint = context.String("runtime-endpoint")
 			}
+
 			if context.IsSet("image-endpoint") { //nolint:gocritic
 				ImageEndpoint = context.String("image-endpoint")
 				ImageEndpointIsSet = true
@@ -358,6 +377,7 @@ func main() {
 			} else {
 				ImageEndpoint = context.String("image-endpoint")
 			}
+
 			if context.IsSet("timeout") { //nolint:gocritic
 				Timeout = getTimeout(context.Duration("timeout"))
 			} else if config.Timeout > 0 { // 0/neg value set to default timeout
@@ -365,11 +385,13 @@ func main() {
 			} else {
 				Timeout = context.Duration("timeout")
 			}
+
 			if context.IsSet("debug") {
 				Debug = context.Bool("debug")
 			} else {
 				Debug = config.Debug
 			}
+
 			PullImageOnCreate = config.PullImageOnCreate
 			DisablePullOnRun = config.DisablePullOnRun
 		}
@@ -424,6 +446,7 @@ func main() {
 	for _, cmd := range app.Commands {
 		sort.Sort(cli.FlagsByName(cmd.Flags))
 	}
+
 	sort.Sort(cli.FlagsByName(app.Flags))
 
 	if err := app.Run(os.Args); err != nil {
@@ -434,6 +457,7 @@ func main() {
 	if tracerProvider != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), Timeout)
 		defer cancel()
+
 		if err := tracerProvider.Shutdown(ctx); err != nil {
 			logrus.Errorf("Unable to shutdown tracer provider: %v", err)
 		}

--- a/cmd/crictl/pod_metrics.go
+++ b/cmd/crictl/pod_metrics.go
@@ -85,6 +85,7 @@ func podMetrics(
 	opts podMetricsOptions,
 ) error {
 	d := podMetricsDisplayer{opts}
+
 	return handleDisplay(c, client, opts.watch, d.displayPodMetrics)
 }
 
@@ -102,12 +103,14 @@ func (p *podMetricsDisplayer) displayPodMetrics(
 	}
 
 	response := &pb.ListPodSandboxMetricsResponse{PodMetrics: metrics}
+
 	switch p.opts.output {
 	case outputTypeJSON, "":
 		return outputProtobufObjAsJSON(response)
 	case outputTypeYAML:
 		return outputProtobufObjAsYAML(response)
 	}
+
 	return nil
 }
 
@@ -118,6 +121,7 @@ func podSandboxMetrics(ctx context.Context, client cri.RuntimeService) ([]*pb.Po
 	if err != nil {
 		return nil, fmt.Errorf("list pod sandbox metrics: %w", err)
 	}
+
 	logrus.Debugf("PodMetrics: %v", metrics)
 
 	return metrics, nil

--- a/cmd/crictl/pod_stats.go
+++ b/cmd/crictl/pod_stats.go
@@ -134,6 +134,7 @@ func podStats(
 	if opts.id != "" {
 		filter.Id = opts.id
 	}
+
 	if opts.labels != nil {
 		filter.LabelSelector = opts.labels
 	}
@@ -143,6 +144,7 @@ func podStats(
 		opts:    opts,
 		display: newDefaultTableDisplay(),
 	}
+
 	return handleDisplay(c, client, opts.watch, d.displayPodStats)
 }
 
@@ -156,6 +158,7 @@ func (d *podStatsDisplayer) displayPodStats(
 	}
 
 	response := &pb.ListPodSandboxStatsResponse{Stats: stats}
+
 	switch d.opts.output {
 	case outputTypeJSON:
 		return outputProtobufObjAsJSON(response)
@@ -164,10 +167,12 @@ func (d *podStatsDisplayer) displayPodStats(
 	}
 
 	oldStats := make(map[string]*pb.PodSandboxStats)
+
 	for _, s := range stats {
 		if c.Err() != nil {
 			return c.Err()
 		}
+
 		oldStats[s.Attributes.Id] = s
 	}
 
@@ -179,13 +184,16 @@ func (d *podStatsDisplayer) displayPodStats(
 	}
 
 	d.display.AddRow([]string{columnPodName, columnPodID, columnCPU, columnMemory})
+
 	for _, s := range stats {
 		if c.Err() != nil {
 			return c.Err()
 		}
+
 		id := getTruncatedID(s.Attributes.Id, "")
 
 		var cpu, mem uint64
+
 		var ts int64
 
 		linux := s.GetLinux()
@@ -214,6 +222,7 @@ func (d *podStatsDisplayer) displayPodStats(
 			oldCPU   uint64
 			oldCPUTs int64
 		)
+
 		old, ok := oldStats[s.Attributes.Id]
 		if !ok {
 			// Skip new pod
@@ -222,6 +231,7 @@ func (d *podStatsDisplayer) displayPodStats(
 
 		oldLinux := old.GetLinux()
 		oldWindows := old.GetWindows()
+
 		if linux != nil {
 			oldCPUTs = oldLinux.GetCpu().GetTimestamp()
 			oldCPU = oldLinux.GetCpu().GetUsageCoreNanoSeconds().GetValue()
@@ -231,14 +241,17 @@ func (d *podStatsDisplayer) displayPodStats(
 		}
 
 		var cpuPerc float64
+
 		if cpu != 0 {
 			// Only generate cpuPerc for running sandbox
 			duration := ts - oldCPUTs
 			if duration == 0 {
 				return errors.New("cpu stat is not updated during sample")
 			}
+
 			cpuPerc = float64(cpu-oldCPU) / float64(duration) * 100
 		}
+
 		d.display.AddRow([]string{
 			s.Attributes.GetMetadata().GetName(),
 			id,
@@ -246,6 +259,7 @@ func (d *podStatsDisplayer) displayPodStats(
 			units.HumanSize(float64(mem)),
 		})
 	}
+
 	d.display.ClearScreen()
 	d.display.Flush()
 
@@ -265,6 +279,7 @@ func getPodSandboxStats(
 	if err != nil {
 		return nil, fmt.Errorf("list pod sandbox stats: %w", err)
 	}
+
 	logrus.Debugf("Stats: %v", stats)
 
 	sort.Sort(podStatsByID(stats))

--- a/cmd/crictl/portforward.go
+++ b/cmd/crictl/portforward.go
@@ -88,6 +88,7 @@ var runtimePortForwardCommand = &cli.Command{
 		if err = PortForward(runtimeClient, opts); err != nil {
 			return fmt.Errorf("port forward: %w", err)
 		}
+
 		return nil
 	},
 }
@@ -97,14 +98,17 @@ func PortForward(client internalapi.RuntimeService, opts portforwardOptions) err
 	if opts.id == "" {
 		return errors.New("ID cannot be empty")
 	}
+
 	request := &pb.PortForwardRequest{
 		PodSandboxId: opts.id,
 	}
 	logrus.Debugf("PortForwardRequest: %v", request)
+
 	r, err := InterruptableRPC(nil, func(ctx context.Context) (*pb.PortForwardResponse, error) {
 		return client.PortForward(ctx, request)
 	})
 	logrus.Debugf("PortForwardResponse; %v", r)
+
 	if err != nil {
 		return err
 	}
@@ -123,6 +127,7 @@ func PortForward(client internalapi.RuntimeService, opts portforwardOptions) err
 	}
 
 	logrus.Debugf("PortForward URL: %v", parsedURL)
+
 	dialer, err := getDialer(opts.transport, parsedURL, opts.tlsConfig)
 	if err != nil {
 		return fmt.Errorf("get dialer: %w", err)
@@ -131,10 +136,12 @@ func PortForward(client internalapi.RuntimeService, opts portforwardOptions) err
 	readyChan := make(chan struct{})
 
 	logrus.Debugf("Ports to forward: %v", opts.ports)
+
 	pf, err := portforward.New(dialer, opts.ports, SetupInterruptSignalHandler(), readyChan, os.Stdout, os.Stderr)
 	if err != nil {
 		return err
 	}
+
 	return pf.ForwardPorts()
 }
 
@@ -147,6 +154,7 @@ func getDialer(transport string, parsedURL *url.URL, tlsConfig *rest.TLSClientCo
 		if err != nil {
 			return nil, fmt.Errorf("get SPDY round tripper: %w", err)
 		}
+
 		return spdy.NewDialer(upgrader, &http.Client{Transport: tr}, "POST", parsedURL), nil
 
 	case transportWebsocket:

--- a/cmd/crictl/templates.go
+++ b/cmd/crictl/templates.go
@@ -31,6 +31,7 @@ func builtinTmplFuncs() template.FuncMap {
 	t := cases.Title(language.Und, cases.NoLower)
 	l := cases.Lower(language.Und)
 	u := cases.Upper(language.Und)
+
 	return template.FuncMap{
 		outputTypeJSON: jsonBuiltinTmplFunc,
 		"title":        t.String,
@@ -42,10 +43,12 @@ func builtinTmplFuncs() template.FuncMap {
 // jsonBuiltinTmplFunc allows to jsonify result of template execution.
 func jsonBuiltinTmplFunc(v interface{}) string {
 	o := new(bytes.Buffer)
+
 	enc := json.NewEncoder(o)
 	if err := enc.Encode(v); err != nil {
 		logrus.Fatalf("Unable to encode JSON: %v", err)
 	}
+
 	return o.String()
 }
 
@@ -63,6 +66,7 @@ func tmplExecuteRawJSON(tmplStr, rawJSON string) (string, error) {
 	}
 
 	o := new(bytes.Buffer)
+
 	tmpl, err := template.New("tmplExecuteRawJSON").Funcs(builtinTmplFuncs()).Parse(tmplStr)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate go-template: %w", err)
@@ -73,10 +77,12 @@ func tmplExecuteRawJSON(tmplStr, rawJSON string) (string, error) {
 	if err := tmpl.Execute(o, raw); err != nil {
 		return "", fmt.Errorf("failed to template data: %w", err)
 	}
+
 	return o.String(), nil
 }
 
 func validateTemplate(tmplStr string) error {
 	_, err := template.New("").Funcs(builtinTmplFuncs()).Parse(tmplStr)
+
 	return err
 }

--- a/cmd/crictl/templates_test.go
+++ b/cmd/crictl/templates_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestTmplExecuteRawJSON(t *testing.T) {
 	t.Parallel()
+
 	testcases := []struct {
 		rawJSON  string
 		tmplStr  string

--- a/cmd/crictl/update_runtime_config.go
+++ b/cmd/crictl/update_runtime_config.go
@@ -62,6 +62,7 @@ var updateRuntimeConfigCommand = &cli.Command{
 		}
 
 		logrus.Info("Runtime config successfully updated")
+
 		return nil
 	},
 }

--- a/cmd/crictl/util_test.go
+++ b/cmd/crictl/util_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestNameFilterByRegex(t *testing.T) {
 	t.Parallel()
+
 	testCases := []struct {
 		desc    string
 		pattern string
@@ -67,6 +68,7 @@ func TestNameFilterByRegex(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
+
 			r := matchesRegex(tc.pattern, tc.name)
 			if r != tc.isMatch {
 				t.Errorf("expected matched to be %v; actual result is %v", tc.isMatch, r)
@@ -103,6 +105,7 @@ func TestOutputStatusData(t *testing.T) {
 		]`
 		emptyResponse = ""
 	)
+
 	testCases := []struct {
 		name        string
 		status      string
@@ -159,10 +162,12 @@ func TestOutputStatusData(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			captureOutput := func(f func() error) (string, error) {
 				var err error
+
 				old := os.Stdout
 
 				r, w, _ := os.Pipe()
 				os.Stdout = w
+
 				defer func() {
 					os.Stdout = old
 				}()
@@ -178,15 +183,18 @@ func TestOutputStatusData(t *testing.T) {
 				}
 
 				out, err := io.ReadAll(r)
+
 				return strings.TrimRight(string(out), "\n"), err
 			}
 
 			outStr, err := captureOutput(func() error {
 				data := []statusData{{json: tc.status, runtimeHandlers: tc.handlers, info: tc.info}}
+
 				err := outputStatusData(data, tc.format, tc.tmplStr)
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)
 				}
+
 				return nil
 			})
 			if err != nil {

--- a/cmd/crictl/version.go
+++ b/cmd/crictl/version.go
@@ -42,6 +42,7 @@ var runtimeVersionCommand = &cli.Command{
 		if err := Version(runtimeClient, string(remote.CRIVersionV1)); err != nil {
 			return fmt.Errorf("getting the runtime version: %w", err)
 		}
+
 		return nil
 	},
 }
@@ -50,16 +51,20 @@ var runtimeVersionCommand = &cli.Command{
 func Version(client internalapi.RuntimeService, version string) error {
 	request := &pb.VersionRequest{Version: version}
 	logrus.Debugf("VersionRequest: %v", request)
+
 	r, err := InterruptableRPC(nil, func(ctx context.Context) (*pb.VersionResponse, error) {
 		return client.Version(ctx, version)
 	})
 	logrus.Debugf("VersionResponse: %v", r)
+
 	if err != nil {
 		return err
 	}
+
 	fmt.Println("Version: ", r.Version)
 	fmt.Println("RuntimeName: ", r.RuntimeName)
 	fmt.Println("RuntimeVersion: ", r.RuntimeVersion)
 	fmt.Println("RuntimeApiVersion: ", r.RuntimeApiVersion)
+
 	return nil
 }

--- a/pkg/benchmark/pod_container.go
+++ b/pkg/benchmark/pod_container.go
@@ -38,6 +38,7 @@ func getPodContainerBenchmarkTimeoutSeconds() int {
 	if framework.TestContext.BenchmarkingParams.PodContainerStartBenchmarkTimeoutSeconds > 0 {
 		timeout = framework.TestContext.BenchmarkingParams.PodContainerStartBenchmarkTimeoutSeconds
 	}
+
 	return timeout
 }
 

--- a/pkg/benchmark/util.go
+++ b/pkg/benchmark/util.go
@@ -94,14 +94,17 @@ func NewLifecycleBenchmarksResultsManager(initialResultsSet LifecycleBenchmarksR
 	if lbrm.resultsSet.Datapoints == nil {
 		lbrm.resultsSet.Datapoints = make([]LifecycleBenchmarkDatapoint, 0)
 	}
+
 	return &lbrm
 }
 
 // Function which continuously consumes results from the resultsChannel until receiving a nil.
 func (lbrm *LifecycleBenchmarksResultsManager) awaitResult() {
 	numOperations := len(lbrm.resultsSet.OperationsNames)
+
 	for {
 		var res *LifecycleBenchmarkDatapoint
+
 		timeout := time.After(time.Duration(lbrm.resultsChannelTimeoutSeconds) * time.Second)
 
 		select {
@@ -109,8 +112,10 @@ func (lbrm *LifecycleBenchmarksResultsManager) awaitResult() {
 			// Receiving nil indicates results are over:
 			if res == nil {
 				logrus.Info("Results ended")
+
 				lbrm.resultsConsumerRunning = false
 				lbrm.resultsOverChannel <- true
+
 				return
 			}
 
@@ -138,6 +143,7 @@ func (lbrm *LifecycleBenchmarksResultsManager) StartResultsConsumer() chan *Life
 		lbrm.resultsConsumerRunning = true
 		go lbrm.awaitResult()
 	}
+
 	return lbrm.resultsChannel
 }
 
@@ -151,9 +157,11 @@ func (lbrm *LifecycleBenchmarksResultsManager) AwaitAllResults(timeoutSeconds in
 	select {
 	case <-lbrm.resultsOverChannel:
 		lbrm.resultsConsumerRunning = false
+
 		return nil
 	case <-timeout:
 		logrus.Warnf("Failed to await all results. Results registered so far were: %+v", lbrm.resultsSet)
+
 		return fmt.Errorf("benchmark results waiting timed out after %d seconds", timeoutSeconds)
 	}
 }

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -45,6 +45,7 @@ type ServerConfiguration struct {
 // GetServerConfigFromFile returns the CRI server configuration from file.
 func GetServerConfigFromFile(configFileName, currentDir string) (*ServerConfiguration, error) {
 	serverConfig := ServerConfiguration{}
+
 	if _, err := os.Stat(configFileName); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("load config file: %w", err)
@@ -54,6 +55,7 @@ func GetServerConfigFromFile(configFileName, currentDir string) (*ServerConfigur
 		// is placed with the cri tools binary.
 		nextConfigFileName := filepath.Join(filepath.Dir(currentDir), "crictl.yaml")
 		logrus.Warnf("Config %q does not exist, trying next: %q", configFileName, nextConfigFileName)
+
 		if _, err := os.Stat(nextConfigFileName); err != nil {
 			return nil, fmt.Errorf("load config file: %w", err)
 		}
@@ -72,5 +74,6 @@ func GetServerConfigFromFile(configFileName, currentDir string) (*ServerConfigur
 	serverConfig.Debug = config.Debug
 	serverConfig.PullImageOnCreate = config.PullImageOnCreate
 	serverConfig.DisablePullOnRun = config.DisablePullOnRun
+
 	return &serverConfig, nil
 }

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -64,15 +64,19 @@ func ReadConfig(filepath string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	yamlConfig := &yaml.Node{}
+
 	err = yaml.Unmarshal(data, yamlConfig)
 	if err != nil {
 		return nil, err
 	}
+
 	config, err := getConfigOptions(yamlConfig)
 	if err != nil {
 		return nil, err
 	}
+
 	return config, err
 }
 
@@ -82,6 +86,7 @@ func WriteConfig(c *Config, filepath string) error {
 	if c == nil {
 		c = &Config{}
 	}
+
 	if c.yamlData == nil {
 		c.yamlData = &yaml.Node{}
 	}
@@ -96,6 +101,7 @@ func WriteConfig(c *Config, filepath string) error {
 	if err := os.MkdirAll(gofilepath.Dir(filepath), 0o755); err != nil {
 		return err
 	}
+
 	return os.WriteFile(filepath, data, 0o644)
 }
 
@@ -107,6 +113,7 @@ func getConfigOptions(yamlData *yaml.Node) (*Config, error) {
 		yamlData.Content[0].Content == nil {
 		return config, nil
 	}
+
 	contentLen := len(yamlData.Content[0].Content)
 
 	// YAML representation contains 2 yaml ScalarNodes per config option.
@@ -117,7 +124,9 @@ func getConfigOptions(yamlData *yaml.Node) (*Config, error) {
 		configOption := yamlData.Content[0].Content[indx]
 		name := configOption.Value
 		value := yamlData.Content[0].Content[indx+1].Value
+
 		var err error
+
 		switch name {
 		case RuntimeEndpoint:
 			config.RuntimeEndpoint = value
@@ -146,6 +155,7 @@ func getConfigOptions(yamlData *yaml.Node) (*Config, error) {
 		default:
 			return nil, fmt.Errorf("Config option '%s' is not valid", name)
 		}
+
 		indx += 2
 	}
 
@@ -172,8 +182,10 @@ func setConfigOption(configName, configValue string, yamlData *yaml.Node) {
 			Tag:  "!!map",
 		}
 	}
+
 	contentLen := 0
 	foundOption := false
+
 	if yamlData.Content[0].Content != nil {
 		contentLen = len(yamlData.Content[0].Content)
 	}
@@ -186,6 +198,7 @@ func setConfigOption(configName, configValue string, yamlData *yaml.Node) {
 			yamlData.Content[0].Content[indx+1].Value = configValue
 			foundOption = true
 		}
+
 		indx += 2
 	}
 
@@ -201,12 +214,15 @@ func setConfigOption(configName, configValue string, yamlData *yaml.Node) {
 			tagBool   = tagPrefix + "bool"
 			tagInt    = tagPrefix + "int"
 		)
+
 		name := &yaml.Node{
 			Kind:  yaml.ScalarNode,
 			Value: configName,
 			Tag:   tagStr,
 		}
+
 		var tagType string
+
 		switch configName {
 		case Timeout:
 			tagType = tagInt

--- a/pkg/common/file_test.go
+++ b/pkg/common/file_test.go
@@ -37,6 +37,7 @@ var _ = DescribeTable("ReadConfig",
 		readConfig, err := common.ReadConfig(f.Name())
 		if shouldFail {
 			Expect(err).To(HaveOccurred())
+
 			return
 		} else {
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/common/pod_config.go
+++ b/pkg/common/pod_config.go
@@ -32,12 +32,15 @@ func GetCgroupParent(ctx context.Context, c internalapi.RuntimeService) string {
 	if err != nil {
 		return DefaultSystemdCgroupSlice
 	}
+
 	if runtimeConfig == nil || runtimeConfig.Linux == nil {
 		return DefaultSystemdCgroupSlice
 	}
+
 	cgroupDriver := runtimeConfig.Linux.GetCgroupDriver()
 	if cgroupDriver == runtimev1.CgroupDriver_CGROUPFS {
 		return ""
 	}
+
 	return DefaultSystemdCgroupSlice
 }

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -57,6 +57,7 @@ func (f *Framework) BeforeEach() {
 	if f.CRIClient == nil {
 		c, err := LoadCRIClient()
 		Expect(err).NotTo(HaveOccurred())
+
 		f.CRIClient = c
 	}
 }

--- a/pkg/framework/test_context.go
+++ b/pkg/framework/test_context.go
@@ -151,10 +151,12 @@ func RegisterFlags() {
 
 	svcaddr := ContainerdSockPathUnix
 	defaultConfigPath := "/etc/crictl.yaml"
+
 	if runtime.GOOS == OSWindows {
 		svcaddr = ContainerdSockPathWindows
 		defaultConfigPath = filepath.Join(os.Getenv("USERPROFILE"), ".crictl", "crictl.yaml")
 	}
+
 	flag.StringVar(&TestContext.ConfigPath, "config", defaultConfigPath, "Location of the client config file. If not specified and the default does not exist, the program's directory is searched as well")
 	flag.StringVar(&TestContext.RuntimeServiceAddr, "runtime-endpoint", svcaddr, "Runtime service socket for client to connect.")
 	flag.DurationVar(&TestContext.RuntimeServiceTimeout, "runtime-service-timeout", 300*time.Second, "Timeout when trying to connect to a runtime service.")
@@ -168,6 +170,7 @@ func RegisterFlags() {
 	} else {
 		TestContext.IsLcow = false
 	}
+
 	flag.StringVar(&TestContext.RegistryPrefix, "registry-prefix", DefaultRegistryPrefix, "A possible registry prefix added to all images, like 'localhost:5000'")
 }
 
@@ -180,6 +183,7 @@ func (tc *TestContextType) LoadYamlConfigFiles() error {
 			return fmt.Errorf("error loading custom test images file: %w", err)
 		}
 	}
+
 	Logf("Testing context container image list: %+v", TestContext.TestImageList)
 
 	// Attempt to load benchmark settings file:
@@ -189,6 +193,7 @@ func (tc *TestContextType) LoadYamlConfigFiles() error {
 			return err
 		}
 	}
+
 	Logf("Testing context benchmarking params: %+v", TestContext.BenchmarkingParams)
 
 	return nil

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -126,6 +126,7 @@ var _ = BeforeSuite(func() {
 // AddBeforeSuiteCallback adds a callback to run during BeforeSuite.
 func AddBeforeSuiteCallback(callback func()) bool {
 	beforeSuiteCallbacks = append(beforeSuiteCallbacks, callback)
+
 	return true
 }
 
@@ -146,6 +147,7 @@ func LoadCRIClient() (*InternalAPIClient, error) {
 		// Fallback to runtime service endpoint
 		imageServiceAddr = TestContext.RuntimeServiceAddr
 	}
+
 	iService, err := remote.NewRemoteImageService(imageServiceAddr, TestContext.ImageServiceTimeout, nil, nil)
 	if err != nil {
 		return nil, err
@@ -182,6 +184,7 @@ func ExpectNoError(err error, explain ...interface{}) {
 	if err != nil {
 		Logf("Unexpected error occurred: %v", err)
 	}
+
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), explain...)
 }
 
@@ -202,6 +205,7 @@ func RunDefaultPodSandbox(c internalapi.RuntimeService, prefix string) string {
 		},
 		Labels: DefaultPodLabels,
 	}
+
 	return RunPodSandbox(c, config)
 }
 
@@ -219,6 +223,7 @@ func BuildPodSandboxMetadata(podSandboxName, uid, namespace string, attempt uint
 func RunPodSandbox(c internalapi.RuntimeService, config *runtimeapi.PodSandboxConfig) string {
 	podID, err := c.RunPodSandbox(context.TODO(), config, TestContext.RuntimeHandler)
 	ExpectNoError(err, "failed to create PodSandbox: %v", err)
+
 	return podID
 }
 
@@ -226,6 +231,7 @@ func RunPodSandbox(c internalapi.RuntimeService, config *runtimeapi.PodSandboxCo
 func RunPodSandboxError(c internalapi.RuntimeService, config *runtimeapi.PodSandboxConfig) string {
 	podID, err := c.RunPodSandbox(context.TODO(), config, TestContext.RuntimeHandler)
 	Expect(err).To(HaveOccurred())
+
 	return podID
 }
 
@@ -243,6 +249,7 @@ func CreatePodSandboxForContainer(c internalapi.RuntimeService) (string, *runtim
 	}
 
 	podID := RunPodSandbox(c, config)
+
 	return podID, config
 }
 
@@ -292,6 +299,7 @@ func CreateContainerWithError(rc internalapi.RuntimeService, ic internalapi.Imag
 	imageName := config.Image.Image
 	if !strings.Contains(imageName, ":") {
 		imageName += ":latest"
+
 		Logf("Use latest as default image tag.")
 	}
 
@@ -305,7 +313,9 @@ func CreateContainerWithError(rc internalapi.RuntimeService, ic internalapi.Imag
 	}
 
 	By("Create container.")
+
 	containerID, err := rc.CreateContainer(context.TODO(), podID, config, podConfig)
+
 	return containerID, err
 }
 
@@ -314,6 +324,7 @@ func CreateContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerS
 	containerID, err := CreateContainerWithError(rc, ic, config, podID, podConfig)
 	ExpectNoError(err, "failed to create container: %v", err)
 	Logf("Created container %q\n", containerID)
+
 	return containerID
 }
 
@@ -325,6 +336,7 @@ func ImageStatus(c internalapi.ImageManagerService, imageName string) *runtimeap
 	}
 	status, err := c.ImageStatus(context.TODO(), imageSpec, false)
 	ExpectNoError(err, "failed to get image status: %v", err)
+
 	return status.GetImage()
 }
 
@@ -332,6 +344,7 @@ func ImageStatus(c internalapi.ImageManagerService, imageName string) *runtimeap
 func ListImage(c internalapi.ImageManagerService, filter *runtimeapi.ImageFilter) []*runtimeapi.Image {
 	images, err := c.ListImages(context.TODO(), filter)
 	ExpectNoError(err, "Failed to get image list: %v", err)
+
 	return images
 }
 
@@ -353,10 +366,12 @@ func PrepareImageName(imageName string) string {
 		ref, err = reference.ParseNamed(r)
 		ExpectNoError(err, "failed to parse new image name: %v", err)
 	}
+
 	imageName = ref.String()
 
 	if !strings.Contains(imageName, ":") {
 		imageName += ":latest"
+
 		Logf("Use latest as default image tag.")
 	}
 
@@ -373,12 +388,14 @@ func PullPublicImage(c internalapi.ImageManagerService, imageName string, podCon
 	}
 	id, err := c.PullImage(context.TODO(), imageSpec, nil, podConfig)
 	ExpectNoError(err, "failed to pull image: %v", err)
+
 	return id
 }
 
 // LoadYamlFile attempts to load the given YAML file into the given struct.
 func LoadYamlFile(filepath string, obj interface{}) error {
 	Logf("Attempting to load YAML file %q into %+v", filepath, obj)
+
 	fileContent, err := os.ReadFile(filepath)
 	if err != nil {
 		return fmt.Errorf("error reading %q file contents: %w", filepath, err)
@@ -390,5 +407,6 @@ func LoadYamlFile(filepath string, obj interface{}) error {
 	}
 
 	Logf("Successfully loaded YAML file %q into %+v", filepath, obj)
+
 	return nil
 }

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -72,6 +72,7 @@ func Init(ctx context.Context, collectorAddress string, samplingRate int) (*trac
 	)
 
 	tmp := propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
+
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(tmp)
 

--- a/pkg/validate/apparmor_linux.go
+++ b/pkg/validate/apparmor_linux.go
@@ -71,6 +71,7 @@ var _ = framework.KubeDescribe("AppArmor", func() {
 			buf, err := os.ReadFile("/sys/module/apparmor/parameters/enabled")
 			appArmorEnabled = err == nil && len(buf) > 1 && buf[0] == 'Y'
 		})
+
 		return appArmorEnabled
 	}
 
@@ -227,6 +228,7 @@ var _ = framework.KubeDescribe("AppArmor", func() {
 
 func createContainerWithAppArmor(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, sandboxID string, sandboxConfig *runtimeapi.PodSandboxConfig, profile *runtimeapi.LinuxContainerSecurityContext, shouldSucceed bool) string {
 	By("create a container with apparmor")
+
 	containerName := "apparmor-test-" + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -241,6 +243,7 @@ func createContainerWithAppArmor(rc internalapi.RuntimeService, ic internalapi.I
 	if shouldSucceed {
 		Expect(err).ToNot(HaveOccurred())
 		By("start container with apparmor")
+
 		err := rc.StartContainer(context.TODO(), containerID)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -257,6 +260,7 @@ func createContainerWithAppArmor(rc internalapi.RuntimeService, ic internalapi.I
 
 func checkContainerApparmor(rc internalapi.RuntimeService, containerID string, shouldRun bool) {
 	By("get container status")
+
 	resp, err := rc.ContainerStatus(context.TODO(), containerID, false)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -272,6 +276,7 @@ func loadTestProfiles() error {
 	if err != nil {
 		return fmt.Errorf("open temp file: %w", err)
 	}
+
 	defer os.Remove(f.Name())
 	defer f.Close()
 
@@ -290,6 +295,7 @@ func loadTestProfiles() error {
 		if stderr.Len() > 0 {
 			logrus.Warn(stderr.String())
 		}
+
 		if len(out) > 0 {
 			logrus.Infof("apparmor_parser: %s", out)
 		}

--- a/pkg/validate/container_linux.go
+++ b/pkg/validate/container_linux.go
@@ -205,6 +205,7 @@ func createHostPathForMountPropagation(podID string, propagationOpt runtimeapi.M
 
 	clearHostPath = func() {
 		By("clean up the TempDir")
+
 		err := unix.Unmount(propagationMntPoint, unix.MNT_DETACH)
 		framework.ExpectNoError(err, "failed to unmount \"propagationMntPoint\": %v", err)
 		err = unix.Unmount(mntSource, unix.MNT_DETACH)
@@ -230,6 +231,7 @@ func createMountPropagationContainer(
 	propagation runtimeapi.MountPropagation,
 ) string {
 	By("create a container with volume and name")
+
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -253,6 +255,7 @@ func createMountPropagationContainer(
 	containerID := framework.CreateContainer(rc, ic, containerConfig, podID, podConfig)
 
 	By("verifying container status")
+
 	resp, err := rc.ContainerStatus(context.TODO(), containerID, true)
 	framework.ExpectNoError(err, "unable to get container status")
 	Expect(resp.Status.Mounts).To(HaveLen(1))
@@ -282,6 +285,7 @@ func createOOMKilledContainer(
 	podConfig *runtimeapi.PodSandboxConfig,
 ) string {
 	By("create a container that will be killed by OOMKiller")
+
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -302,6 +306,7 @@ func createOOMKilledContainer(
 	containerID := framework.CreateContainer(rc, ic, containerConfig, podID, podConfig)
 
 	By("verifying container status")
+
 	_, err := rc.ContainerStatus(context.TODO(), containerID, true)
 	framework.ExpectNoError(err, "unable to get container status")
 
@@ -337,6 +342,7 @@ var _ = framework.KubeDescribe("Container Mount Readonly", func() {
 		testRRO := func(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, rro bool) {
 			if rro && !runtimeSupportsRRO(rc, framework.TestContext.RuntimeHandler) {
 				Skip("runtime does not implement recursive readonly mounts")
+
 				return
 			}
 
@@ -367,6 +373,7 @@ var _ = framework.KubeDescribe("Container Mount Readonly", func() {
 		testRROInvalidPropagation := func(prop runtimeapi.MountPropagation) {
 			if !runtimeSupportsRRO(rc, framework.TestContext.RuntimeHandler) {
 				Skip("runtime does not implement recursive readonly mounts")
+
 				return
 			}
 			hostPath, clearHostPath := createHostPathForRROMount(podID)
@@ -393,6 +400,7 @@ var _ = framework.KubeDescribe("Container Mount Readonly", func() {
 		It("should reject a recursive readonly mount with ReadOnly: false", func() {
 			if !runtimeSupportsRRO(rc, framework.TestContext.RuntimeHandler) {
 				Skip("runtime does not implement recursive readonly mounts")
+
 				return
 			}
 			hostPath, clearHostPath := createHostPathForRROMount(podID)
@@ -416,6 +424,7 @@ func runtimeSupportsRRO(rc internalapi.RuntimeService, runtimeHandlerName string
 	ctx := context.Background()
 	status, err := rc.Status(ctx, false)
 	framework.ExpectNoError(err, "failed to check runtime status")
+
 	for _, h := range status.RuntimeHandlers {
 		if h.Name == runtimeHandlerName {
 			if f := h.Features; f != nil {
@@ -423,6 +432,7 @@ func runtimeSupportsRRO(rc internalapi.RuntimeService, runtimeHandlerName string
 			}
 		}
 	}
+
 	return false
 }
 
@@ -442,6 +452,7 @@ func createHostPathForRROMount(podID string) (hostPath string, clearHostPath fun
 
 	clearHostPath = func() {
 		By("clean up the TempDir")
+
 		err := unix.Unmount(tmpfsMntPoint, unix.MNT_DETACH)
 		framework.ExpectNoError(err, "failed to unmount \"tmpfsMntPoint\": %v", err)
 		err = os.RemoveAll(hostPath)
@@ -468,6 +479,7 @@ func createRROMountContainer(
 			SelinuxRelabel:    true,
 		},
 	}
+
 	return createMountContainer(rc, ic, podID, podConfig, mounts, false)
 }
 
@@ -480,6 +492,7 @@ func createMountContainer(
 	expectErr bool,
 ) string {
 	By("create a container with volume and name")
+
 	containerName := "test-mount-" + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -491,12 +504,14 @@ func createMountContainer(
 	if expectErr {
 		_, err := framework.CreateContainerWithError(rc, ic, containerConfig, podID, podConfig)
 		Expect(err).To(HaveOccurred())
+
 		return ""
 	}
 
 	containerID := framework.CreateContainer(rc, ic, containerConfig, podID, podConfig)
 
 	By("verifying container status")
+
 	resp, err := rc.ContainerStatus(context.TODO(), containerID, true)
 	framework.ExpectNoError(err, "unable to get container status")
 	Expect(resp.Status.Mounts).To(HaveLen(len(mounts)))

--- a/pkg/validate/image.go
+++ b/pkg/validate/image.go
@@ -158,6 +158,7 @@ var _ = framework.KubeDescribe("Image Manager", func() {
 				if img.Id == id {
 					Expect(img.RepoTags).To(HaveLen(1), "Should only have 1 repo tag")
 					Expect(img.RepoTags[0]).To(Equal(testDifferentTagDifferentImageList[i]), "Repo tag should be correct")
+
 					break
 				}
 			}
@@ -181,6 +182,7 @@ var _ = framework.KubeDescribe("Image Manager", func() {
 			if img.Id == ids[0] {
 				sort.Strings(img.RepoTags)
 				Expect(img.RepoTags).To(Equal(testDifferentTagSameImageList), "Should have 3 repoTags in single image")
+
 				break
 			}
 		}
@@ -193,6 +195,7 @@ func testRemoveImage(c internalapi.ImageManagerService, imageName string) {
 	removeImage(c, imageName)
 
 	By("Check image list empty")
+
 	imageStatus := framework.ImageStatus(c, imageName)
 	Expect(imageStatus).To(BeNil(), "Should have none image in list")
 }
@@ -209,6 +212,7 @@ func testPullPublicImage(c internalapi.ImageManagerService, imageName string, po
 	Expect(imageStatus).NotTo(BeNil(), "Should have one image in list")
 	Expect(imageStatus.Id).NotTo(BeNil(), "Image Id should not be nil")
 	Expect(imageStatus.Size_).NotTo(BeNil(), "Image Size should not be nil")
+
 	if statusCheck != nil {
 		statusCheck(imageStatus)
 	}
@@ -221,6 +225,7 @@ func pullImageList(c internalapi.ImageManagerService, imageList []string, podCon
 	for _, imageName := range imageList {
 		ids = append(ids, framework.PullPublicImage(c, imageName, podConfig))
 	}
+
 	return ids
 }
 

--- a/pkg/validate/multi_container_linux.go
+++ b/pkg/validate/multi_container_linux.go
@@ -86,6 +86,7 @@ var _ = framework.KubeDescribe("Multiple Containers [Conformance]", func() {
 					if err != nil {
 						return false, err
 					}
+
 					return strings.Contains(string(content), expected), nil
 				}
 			}
@@ -126,6 +127,7 @@ func createMultiContainerTestPodSandbox(c internalapi.RuntimeService) (sandboxID
 			CgroupParent: common.GetCgroupParent(context.TODO(), c),
 		},
 	}
+
 	return framework.RunPodSandbox(c, podConfig), podConfig, logDir
 }
 
@@ -140,6 +142,7 @@ func createMultiContainerTestHttpdContainer(rc internalapi.RuntimeService, ic in
 		Linux:    &runtimeapi.LinuxContainerConfig{},
 		LogPath:  containerName + ".log",
 	}
+
 	return framework.CreateContainer(rc, ic, containerConfig, podID, podConfig)
 }
 
@@ -154,5 +157,6 @@ func createMultiContainerTestBusyboxContainer(rc internalapi.RuntimeService, ic 
 		Command:  []string{"sh", "-c", "echo " + defaultLog + "; sleep 1000"},
 		LogPath:  containerName + ".log",
 	}
+
 	return framework.CreateContainer(rc, ic, containerConfig, podID, podConfig)
 }

--- a/pkg/validate/networking.go
+++ b/pkg/validate/networking.go
@@ -143,6 +143,7 @@ func createPodSandWithHostname(c internalapi.RuntimeService, hostname string) (s
 	}
 
 	podID := framework.RunPodSandbox(c, config)
+
 	return podID, config
 }
 
@@ -165,6 +166,7 @@ func createPodSandWithDNSConfig(c internalapi.RuntimeService) (string, *runtimea
 	}
 
 	podID := framework.RunPodSandbox(c, config)
+
 	return podID, config
 }
 
@@ -173,6 +175,7 @@ func createPodSandboxWithPortMapping(c internalapi.RuntimeService, portMappings 
 	podSandboxName := "create-PodSandbox-with-port-mapping" + framework.NewUUID()
 	uid := framework.DefaultUIDPrefix + framework.NewUUID()
 	namespace := framework.DefaultNamespacePrefix + framework.NewUUID()
+
 	config := &runtimeapi.PodSandboxConfig{
 		Metadata:     framework.BuildPodSandboxMetadata(podSandboxName, uid, namespace, framework.DefaultAttempt),
 		PortMappings: portMappings,
@@ -190,12 +193,14 @@ func createPodSandboxWithPortMapping(c internalapi.RuntimeService, portMappings 
 	}
 
 	podID := framework.RunPodSandbox(c, config)
+
 	return podID, config
 }
 
 // checkHostname checks the container hostname.
 func checkHostname(c internalapi.RuntimeService, containerID, hostname string) {
 	By("get the current hostname via execSync")
+
 	stdout, stderr, err := c.ExecSync(context.TODO(), containerID, getHostnameCmd, time.Duration(defaultExecSyncTimeout)*time.Second)
 	framework.ExpectNoError(err, "failed to execSync in container %q", containerID)
 	Expect(strings.EqualFold(strings.TrimSpace(string(stdout)), hostname)).To(BeTrue())
@@ -206,11 +211,14 @@ func checkHostname(c internalapi.RuntimeService, containerID, hostname string) {
 // checkDNSConfig checks the content of /etc/resolv.conf.
 func checkDNSConfig(c internalapi.RuntimeService, containerID string, expectedContent []string) {
 	By("get the current dns config via execSync")
+
 	stdout, stderr, err := c.ExecSync(context.TODO(), containerID, getDNSConfigCmd, time.Duration(defaultExecSyncTimeout)*time.Second)
 	framework.ExpectNoError(err, "failed to execSync in container %q", containerID)
+
 	for _, content := range expectedContent {
 		Expect(string(stdout)).To(ContainSubstring(content), "The stdout output of execSync should contain %q", content)
 	}
+
 	Expect(string(stderr)).To(BeEmpty(), "The stderr should be empty.")
 	framework.Logf("check DNS config succeed")
 }
@@ -223,6 +231,7 @@ func createWebServerContainer(rc internalapi.RuntimeService, ic internalapi.Imag
 		Image:    &runtimeapi.ImageSpec{Image: webServerImage},
 		Linux:    &runtimeapi.LinuxContainerConfig{},
 	}
+
 	return framework.CreateContainer(rc, ic, containerConfig, podID, podConfig)
 }
 
@@ -234,6 +243,7 @@ func createHostNetWebServerContainer(rc internalapi.RuntimeService, ic internala
 		Image:    &runtimeapi.ImageSpec{Image: hostNetWebServerImage},
 		Linux:    &runtimeapi.LinuxContainerConfig{},
 	}
+
 	return framework.CreateContainer(rc, ic, containerConfig, podID, podConfig)
 }
 
@@ -250,6 +260,7 @@ func checkMainPage(c internalapi.RuntimeService, podID string, hostPort, contain
 		Expect(status.GetNetwork().Ip).NotTo(BeNil(), "The IP should not be nil.")
 		url += status.GetNetwork().Ip + ":" + strconv.Itoa(int(containerPort))
 	}
+
 	framework.Logf("the IP:port is " + url)
 
 	By("check the content of " + url)
@@ -272,6 +283,7 @@ func checkMainPage(c internalapi.RuntimeService, podID string, hostPort, contain
 		}
 		defer resp.Body.Close()
 		respChan <- resp
+
 		return nil
 	}, time.Minute, time.Second).Should(Succeed())
 

--- a/pkg/validate/pod.go
+++ b/pkg/validate/pod.go
@@ -89,6 +89,7 @@ func podSandboxFound(podSandboxs []*runtimeapi.PodSandbox, podID string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -102,6 +103,7 @@ func verifyPodSandboxStatus(c internalapi.RuntimeService, podID string, expected
 func testRunDefaultPodSandbox(c internalapi.RuntimeService) string {
 	podID := framework.RunDefaultPodSandbox(c, "PodSandbox-for-create-test-")
 	verifyPodSandboxStatus(c, podID, runtimeapi.PodSandboxState_SANDBOX_READY, "ready")
+
 	return podID
 }
 
@@ -110,6 +112,7 @@ func getPodSandboxStatus(c internalapi.RuntimeService, podID string) *runtimeapi
 	By("Get PodSandbox status for podID: " + podID)
 	status, err := c.PodSandboxStatus(context.TODO(), podID, false)
 	framework.ExpectNoError(err, "failed to get PodSandbox %q status: %v", podID, err)
+
 	return status.GetStatus()
 }
 
@@ -148,15 +151,18 @@ func listPodSandboxForID(c internalapi.RuntimeService, podID string) []*runtimea
 	filter := &runtimeapi.PodSandboxFilter{
 		Id: podID,
 	}
+
 	return listPodSandbox(c, filter)
 }
 
 // listPodSandbox lists PodSandbox.
 func listPodSandbox(c internalapi.RuntimeService, filter *runtimeapi.PodSandboxFilter) []*runtimeapi.PodSandbox {
 	By("List PodSandbox.")
+
 	pods, err := c.ListPodSandbox(context.TODO(), filter)
 	framework.ExpectNoError(err, "failed to list PodSandbox status: %v", err)
 	framework.Logf("List PodSandbox succeed")
+
 	return pods
 }
 
@@ -174,6 +180,7 @@ func createLogTempDir(podSandboxName string) (hostPath, podLogPath string) {
 // createPodSandboxWithLogDirectory creates a PodSandbox with log directory.
 func createPodSandboxWithLogDirectory(c internalapi.RuntimeService) (sandboxID string, podConfig *runtimeapi.PodSandboxConfig, hostPath string) {
 	By("create a PodSandbox with log directory")
+
 	podSandboxName := "PodSandbox-with-log-directory-" + framework.NewUUID()
 	uid := framework.DefaultUIDPrefix + framework.NewUUID()
 	namespace := framework.DefaultNamespacePrefix + framework.NewUUID()
@@ -186,5 +193,6 @@ func createPodSandboxWithLogDirectory(c internalapi.RuntimeService) (sandboxID s
 			CgroupParent: common.GetCgroupParent(context.TODO(), c),
 		},
 	}
+
 	return framework.RunPodSandbox(c, podConfig), podConfig, hostPath
 }

--- a/pkg/validate/pod_linux.go
+++ b/pkg/validate/pod_linux.go
@@ -87,6 +87,7 @@ var _ = framework.KubeDescribe("PodSandbox", func() {
 // createSandboxWithSysctls creates a PodSandbox with specified sysctls.
 func createSandboxWithSysctls(rc internalapi.RuntimeService, sysctls map[string]string) (string, *runtimeapi.PodSandboxConfig) {
 	By("create a PodSandbox with sysctls")
+
 	podSandboxName := "pod-sandbox-with-sysctls-" + framework.NewUUID()
 	uid := framework.DefaultUIDPrefix + framework.NewUUID()
 	namespace := framework.DefaultNamespacePrefix + framework.NewUUID()
@@ -97,6 +98,7 @@ func createSandboxWithSysctls(rc internalapi.RuntimeService, sysctls map[string]
 			Sysctls:      sysctls,
 		},
 	}
+
 	return framework.RunPodSandbox(rc, podConfig), podConfig
 }
 

--- a/pkg/validate/runtime_info.go
+++ b/pkg/validate/runtime_info.go
@@ -64,6 +64,7 @@ func TestGetVersion(c internalapi.RuntimeService) {
 // TestGetRuntimeStatus test if we can get runtime status.
 func TestGetRuntimeStatus(c internalapi.RuntimeService) {
 	var count int
+
 	status, err := c.Status(context.TODO(), false)
 	framework.ExpectNoError(err, "failed to get runtime conditions: %v", err)
 
@@ -71,10 +72,12 @@ func TestGetRuntimeStatus(c internalapi.RuntimeService) {
 		if condition.Type == "RuntimeReady" && condition.Status {
 			count++
 		}
+
 		if condition.Type == "NetworkReady" && condition.Status {
 			count++
 		}
 	}
+
 	Expect(count).To(BeNumerically(">=", 2), "should return all the required runtime conditions")
 }
 
@@ -82,5 +85,6 @@ func TestGetRuntimeStatus(c internalapi.RuntimeService) {
 func getVersion(c internalapi.RuntimeService) *runtimeapi.VersionResponse {
 	version, err := c.Version(context.TODO(), defaultAPIVersion)
 	framework.ExpectNoError(err, "failed to get version: %v", err)
+
 	return version
 }

--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -785,17 +785,20 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			profileDir, err = createSeccompProfileDir()
 			if err != nil {
 				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed creating seccomp profile directory: %v", err))
+
 				return
 			}
 			dirToCleanup = append(dirToCleanup, profileDir)
 			blockHostNameProfilePath, err = createSeccompProfile(seccompBlockHostNameProfile, "block-host-name.json", profileDir)
 			if err != nil {
 				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed creating seccomp block hostname profile: %v", err))
+
 				return
 			}
 			blockchmodProfilePath, err = createSeccompProfile(seccompBlockChmodProfile, "block-chmod.json", profileDir)
 			if err != nil {
 				Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed creating seccomp block chmod profile: %v", err))
+
 				return
 			}
 		})
@@ -987,6 +990,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 				if rh.GetName() == framework.TestContext.RuntimeHandler {
 					if rh.GetFeatures().GetUserNamespaces() {
 						supportsUserNamespaces = true
+
 						break
 					}
 				}
@@ -1128,11 +1132,13 @@ func matchContainerOutputRe(podConfig *runtimeapi.PodSandboxConfig, name, patter
 // createRunAsUserContainer creates the container with specified RunAsUser in ContainerConfig.
 func createRunAsUserContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, prefix string) (containerID, expectedLogMessage string) {
 	By("create RunAsUser container")
+
 	var uidV runtimeapi.Int64Value
 	uidV.Value = 1001
 	expectedLogMessage = "1001\n"
 
 	By("create a container with RunAsUser")
+
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -1151,10 +1157,12 @@ func createRunAsUserContainer(rc internalapi.RuntimeService, ic internalapi.Imag
 // createRunAsUserNameContainer creates the container with specified RunAsUserName in ContainerConfig.
 func createRunAsUserNameContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, prefix string) (containerID, expectedLogMessage string) {
 	By("create RunAsUserName container")
+
 	userName := "nobody"
 	expectedLogMessage = userName + "\n"
 
 	By("create a container with RunAsUserName")
+
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -1166,18 +1174,21 @@ func createRunAsUserNameContainer(rc internalapi.RuntimeService, ic internalapi.
 			},
 		},
 	}
+
 	return framework.CreateContainer(rc, ic, containerConfig, podID, podConfig), expectedLogMessage
 }
 
 // createRunAsGroupContainer creates the container with specified RunAsGroup in ContainerConfig.
 func createRunAsGroupContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, containerName string) (containerID, expectedLogMessage string) {
 	By("create RunAsGroup container")
+
 	var uidV, gidV runtimeapi.Int64Value
 	uidV.Value = 1001
 	gidV.Value = 1002
 	expectedLogMessage = "1001:1002\n"
 
 	By("create a container with RunAsUser and RunAsGroup")
+
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
 		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
@@ -1190,6 +1201,7 @@ func createRunAsGroupContainer(rc internalapi.RuntimeService, ic internalapi.Ima
 		},
 		LogPath: containerName + ".log",
 	}
+
 	return framework.CreateContainer(rc, ic, containerConfig, podID, podConfig), expectedLogMessage
 }
 
@@ -1197,10 +1209,12 @@ func createRunAsGroupContainer(rc internalapi.RuntimeService, ic internalapi.Ima
 // RunAsUser specified in ContainerConfig.
 func createInvalidRunAsGroupContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, containerName string) {
 	By("create invalid RunAsGroup container")
+
 	var gidV runtimeapi.Int64Value
 	gidV.Value = 1002
 
 	By("create a container with RunAsGroup without RunAsUser")
+
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
 		Image:    &runtimeapi.ImageSpec{Image: framework.TestContext.TestImageList.DefaultTestContainerImage},
@@ -1218,6 +1232,7 @@ func createInvalidRunAsGroupContainer(rc internalapi.RuntimeService, ic internal
 // createNamespacePodSandbox creates a PodSandbox with different NamespaceOption config for creating containers.
 func createNamespacePodSandbox(rc internalapi.RuntimeService, podSandboxNamespace *runtimeapi.NamespaceOption, podSandboxName, podLogPath string) (string, *runtimeapi.PodSandboxConfig) {
 	By("create NamespaceOption podSandbox")
+
 	uid := framework.DefaultUIDPrefix + framework.NewUUID()
 	namespace := framework.DefaultNamespacePrefix + framework.NewUUID()
 	config := &runtimeapi.PodSandboxConfig{
@@ -1239,6 +1254,7 @@ func createNamespacePodSandbox(rc internalapi.RuntimeService, podSandboxNamespac
 // createNamespaceContainer creates container with different NamespaceOption config.
 func createNamespaceContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, containerName, image string, containerNamespace *runtimeapi.NamespaceOption, command []string, path string) (containerID, logPath string) {
 	By("create NamespaceOption container")
+
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
 		Image:    &runtimeapi.ImageSpec{Image: image},
@@ -1257,6 +1273,7 @@ func createNamespaceContainer(rc internalapi.RuntimeService, ic internalapi.Imag
 // createReadOnlyRootfsContainer creates the container with specified ReadOnlyRootfs in ContainerConfig.
 func createReadOnlyRootfsContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, prefix string, readonly bool) (containerID, logPath string) {
 	By("create ReadOnlyRootfs container")
+
 	containerName := prefix + framework.NewUUID()
 	path := containerName + ".log"
 	containerConfig := &runtimeapi.ContainerConfig{
@@ -1290,6 +1307,7 @@ func checkRootfs(podConfig *runtimeapi.PodSandboxConfig, logpath string, readOnl
 // createPrivilegedPodSandbox creates a PodSandbox with Privileged of SecurityContext config.
 func createPrivilegedPodSandbox(rc internalapi.RuntimeService, privileged bool) (string, *runtimeapi.PodSandboxConfig) {
 	By("create Privileged podSandbox")
+
 	podSandboxName := "create-Privileged-PodSandbox-for-container-" + framework.NewUUID()
 	uid := framework.DefaultUIDPrefix + framework.NewUUID()
 	namespace := framework.DefaultNamespacePrefix + framework.NewUUID()
@@ -1310,6 +1328,7 @@ func createPrivilegedPodSandbox(rc internalapi.RuntimeService, privileged bool) 
 // createPrivilegedContainer creates container with specified Privileged in ContainerConfig.
 func createPrivilegedContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, prefix string, privileged bool) string {
 	By("create Privileged container")
+
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -1342,6 +1361,7 @@ func checkNetworkManagement(rc internalapi.RuntimeService, containerID string, m
 // createCapabilityContainer creates container with specified Capability in ContainerConfig.
 func createCapabilityContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, prefix string, add, drop []string) string {
 	By("create Capability container")
+
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -1362,10 +1382,12 @@ func createCapabilityContainer(rc internalapi.RuntimeService, ic internalapi.Ima
 
 func createAndCheckHostNetwork(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podSandboxName, hostNetworkPort string, hostNetwork bool) (podID, podLogDir string) {
 	By(fmt.Sprintf("creating a podSandbox with hostNetwork %v", hostNetwork))
+
 	netNSMode := runtimeapi.NamespaceMode_POD
 	if hostNetwork {
 		netNSMode = runtimeapi.NamespaceMode_NODE
 	}
+
 	namespaceOptions := &runtimeapi.NamespaceOption{
 		Pid:     runtimeapi.NamespaceMode_POD,
 		Ipc:     runtimeapi.NamespaceMode_POD,
@@ -1375,6 +1397,7 @@ func createAndCheckHostNetwork(rc internalapi.RuntimeService, ic internalapi.Ima
 	podID, podConfig := createNamespacePodSandbox(rc, namespaceOptions, podSandboxName, podLogPath)
 
 	By("create a container in the sandbox")
+
 	command := []string{"sh", "-c", "netstat -ln"}
 	containerName := "container-with-HostNetwork-test-" + framework.NewUUID()
 	path := containerName + ".log"
@@ -1399,6 +1422,7 @@ func createAndCheckHostNetwork(rc internalapi.RuntimeService, ic internalapi.Ima
 		if hostNetwork {
 			return fmt.Errorf("host port %s should be in container's port list", hostNetworkPort)
 		}
+
 		return nil
 	}, time.Minute, time.Second).Should(Succeed())
 
@@ -1411,22 +1435,24 @@ func createSeccompProfileDir() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("create tempdir %q: %w", hostPath, err)
 	}
+
 	return hostPath, nil
 }
 
 // createSeccompProfile creates a seccomp test profile with profileContents.
 func createSeccompProfile(profileContents, profileName, hostPath string) (string, error) {
 	profilePath := filepath.Join(hostPath, profileName)
-	err := os.WriteFile(profilePath, []byte(profileContents), 0o644)
-	if err != nil {
+	if err := os.WriteFile(profilePath, []byte(profileContents), 0o644); err != nil {
 		return "", fmt.Errorf("create %s: %w", profilePath, err)
 	}
+
 	return profilePath, nil
 }
 
 // seccompTestContainer creates and starts a seccomp sandbox and a container.
 func seccompTestContainer(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, profile *runtimeapi.SecurityProfile) (podID, containerID string) {
 	By("create seccomp sandbox")
+
 	podSandboxName := "seccomp-sandbox-" + framework.NewUUID()
 	uid := framework.DefaultUIDPrefix + framework.NewUUID()
 	namespace := framework.DefaultNamespacePrefix + framework.NewUUID()
@@ -1443,6 +1469,7 @@ func seccompTestContainer(rc internalapi.RuntimeService, ic internalapi.ImageMan
 	podID = framework.RunPodSandbox(rc, podConfig)
 
 	By("create container")
+
 	containerNamePrefix := "seccomp-container-" + framework.NewUUID()
 	containerName := containerNamePrefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
@@ -1491,6 +1518,7 @@ func createSeccompContainer(rc internalapi.RuntimeService,
 	expectContainerCreateToPass bool,
 ) string {
 	By("create " + profile.GetProfileType().String() + " Seccomp container")
+
 	containerName := prefix + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -1527,11 +1555,14 @@ func createContainerWithExpectation(rc internalapi.RuntimeService,
 	if !strings.Contains(imageName, ":") {
 		imageName += ":latest"
 	}
+
 	status := framework.ImageStatus(ic, imageName)
 	if status == nil {
 		framework.PullPublicImage(ic, imageName, nil)
 	}
+
 	By("Create container.")
+
 	containerID, err := rc.CreateContainer(context.TODO(), podID, config, podConfig)
 
 	if !expectContainerCreateToPass {
@@ -1541,6 +1572,7 @@ func createContainerWithExpectation(rc internalapi.RuntimeService,
 		framework.ExpectNoError(err, "failed to create container: %v", err)
 		framework.Logf("Created container %q\n", containerID)
 	}
+
 	return containerID
 }
 
@@ -1566,6 +1598,7 @@ func runUserNamespaceContainer(
 	podConfig *runtimeapi.PodSandboxConfig,
 ) string {
 	By("create user namespaces container")
+
 	containerName := "user-namespaces-container-" + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -1631,19 +1664,24 @@ func supportsIDMap(path string) error {
 		UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: usernsHostID, Size: usernsSize}},
 		GidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: usernsHostID, Size: usernsSize}},
 	}
+
 	if err := cmd.Start(); err != nil {
 		return err
 	}
+
 	defer func() {
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
 	}()
 
 	usernsPath := fmt.Sprintf("/proc/%d/ns/user", cmd.Process.Pid)
+
 	var usernsFile *os.File
+
 	if usernsFile, err = os.Open(usernsPath); err != nil {
 		return err
 	}
+
 	defer usernsFile.Close()
 
 	attr := unix.MountAttr{
@@ -1664,6 +1702,7 @@ func supportsIDMap(path string) error {
 func rootfsPath(info map[string]string) string {
 	defaultPath := "/var/lib"
 	jsonCfg, ok := info["config"]
+
 	if !ok {
 		return defaultPath
 	}
@@ -1672,10 +1711,12 @@ func rootfsPath(info map[string]string) string {
 	type containerdConfig struct {
 		StateDir string `json:"stateDir"`
 	}
+
 	cfg := containerdConfig{}
 	if err := json.Unmarshal([]byte(jsonCfg), &cfg); err != nil {
 		return defaultPath
 	}
+
 	if cfg.StateDir == "" {
 		return defaultPath
 	}
@@ -1687,10 +1728,12 @@ func rootfsPath(info map[string]string) string {
 
 func hostUsernsContent() string {
 	uidMapPath := "/proc/self/uid_map"
+
 	uidMapContent, err := os.ReadFile(uidMapPath)
 	if err != nil {
 		return ""
 	}
+
 	return string(uidMapContent)
 }
 
@@ -1703,5 +1746,6 @@ func parseUsernsMappingLine(line string) []string {
 	m = slices.DeleteFunc(m, func(s string) bool {
 		return s == ""
 	})
+
 	return m
 }

--- a/pkg/validate/selinux_linux.go
+++ b/pkg/validate/selinux_linux.go
@@ -159,6 +159,7 @@ var _ = framework.KubeDescribe("SELinux", func() {
 
 func createContainerWithSelinux(rc internalapi.RuntimeService, ic internalapi.ImageManagerService, sandboxID string, sandboxConfig *runtimeapi.PodSandboxConfig, options *runtimeapi.SELinuxOption, privileged, shouldStart, shouldCreate bool) string {
 	By("create a container with selinux")
+
 	containerName := "selinux-test-" + framework.NewUUID()
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
@@ -171,15 +172,18 @@ func createContainerWithSelinux(rc internalapi.RuntimeService, ic internalapi.Im
 			},
 		},
 	}
+
 	containerID, err := framework.CreateContainerWithError(rc, ic, containerConfig, sandboxID, sandboxConfig)
 	if !shouldCreate {
 		Expect(err).To(HaveOccurred())
+
 		return ""
 	}
 
 	Expect(err).NotTo(HaveOccurred())
 
 	By("start container with selinux")
+
 	err = rc.StartContainer(context.TODO(), containerID)
 	if shouldStart {
 		Expect(err).NotTo(HaveOccurred())
@@ -197,6 +201,7 @@ func createContainerWithSelinux(rc internalapi.RuntimeService, ic internalapi.Im
 
 func checkContainerSelinux(rc internalapi.RuntimeService, containerID string, shouldRun bool) {
 	By("get container status")
+
 	status, err := rc.ContainerStatus(context.TODO(), containerID, false)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -204,6 +209,7 @@ func checkContainerSelinux(rc internalapi.RuntimeService, containerID string, sh
 		Expect(status.GetStatus().GetExitCode()).To(Equal(int32(0)))
 	} else {
 		Expect(status.GetStatus().GetExitCode()).NotTo(Equal(int32(0)))
+
 		return
 	}
 
@@ -236,6 +242,7 @@ func checkProcessLabelRoleType(rc internalapi.RuntimeService, containerID string
 	label := strings.Trim(string(stdout), "\x00")
 	msg := fmt.Sprintf("cmd %v, stdout %q, stderr %q", cmd, stdout, stderr)
 	Expect(err).NotTo(HaveOccurred(), msg)
+
 	if privileged {
 		Expect(label).To(ContainSubstring(":system_r:spc_t:"))
 	} else {
@@ -260,6 +267,7 @@ func checkProcessLabelMCS(rc internalapi.RuntimeService, containerID string, pri
 	label := strings.Trim(string(stdout), "\x00")
 	msg := fmt.Sprintf("cmd %v, stdout %q, stderr %q", cmd, stdout, stderr)
 	Expect(err).NotTo(HaveOccurred(), msg)
+
 	if privileged {
 		// check that a process label exists with optional MCS, where level is always s0 and we permit all categories
 		Expect(label).To(MatchRegexp(`:s0(-s0)?(:c0\.c1023)?$`))
@@ -267,5 +275,6 @@ func checkProcessLabelMCS(rc internalapi.RuntimeService, containerID string, pri
 		// check that a process label exists with MCS, where level is always s0 and there are two or more categories
 		Expect(label).To(MatchRegexp(`:s0(-s0)?:c[0-9]+(,c[0-9]+)+$`))
 	}
+
 	return label
 }

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -40,6 +40,7 @@ var _ = t.Describe("config", func() {
 	listConfig := func() string {
 		res := t.Crictl("--config " + configFile.Name() + " config --list")
 		Expect(res).To(Exit(0))
+
 		return string(res.Out.Contents())
 	}
 

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -69,6 +69,7 @@ func (t *TestFramework) Describe(text string, body func()) bool {
 // Convenience method for command creation.
 func cmd(workDir, format string, args ...interface{}) *Session {
 	c := strings.Split(fmt.Sprintf(format, args...), " ")
+
 	command := exec.Command(c[0], c[1:]...)
 	if workDir != "" {
 		command.Dir = workDir
@@ -84,6 +85,7 @@ func crictlBinaryPathFlag() (path string) {
 	if crictlBinaryPath != "" {
 		return crictlBinaryPath
 	}
+
 	return "crictl"
 }
 
@@ -91,6 +93,7 @@ func crictlRuntimeEndpointFlag() string {
 	if crictlRuntimeEndpoint != "" {
 		return " --runtime-endpoint=" + crictlRuntimeEndpoint
 	}
+
 	return ""
 }
 
@@ -118,11 +121,13 @@ func (t *TestFramework) CrictlExpect(
 
 	// Then
 	Expect(res).To(Exit(exit))
+
 	if expectedOut == "" {
 		Expect(string(res.Out.Contents())).To(BeEmpty())
 	} else {
 		Expect(res.Out).To(Say(expectedOut))
 	}
+
 	if expectedErr == "" {
 		Expect(string(res.Err.Contents())).To(BeEmpty())
 	} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The linters come with a new auto-fix function, means we can enable them without any manual effort.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
