### PR TITLE
Deflake e2e test `should not show help running rmi -a`

### DIFF
--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -56,6 +56,7 @@ var _ = t.Describe("inspect", func() {
 	AfterEach(func() {
 		Expect(t.Crictl("rmp -f " + sandbox)).To(Exit(0))
 		Expect(t.Crictl("rmi " + imageLatest)).To(Exit(0))
+		t.CrictlRemovePauseImages()
 	})
 
 	validateSingleResponse := func(contents []byte) {

--- a/test/e2e/inspectp_test.go
+++ b/test/e2e/inspectp_test.go
@@ -44,6 +44,8 @@ var _ = t.Describe("inspectp", func() {
 			res := t.Crictl("runp " + f.Name())
 			Expect(res).To(Exit(0))
 			sandboxes = append(sandboxes, string(bytes.TrimSpace(res.Out.Contents())))
+
+			Expect(os.RemoveAll(f.Name())).NotTo(HaveOccurred())
 		}
 	})
 
@@ -53,7 +55,7 @@ var _ = t.Describe("inspectp", func() {
 			res := t.Crictl("rmp -f " + sb)
 			Expect(res).To(Exit(0))
 		}
-		Expect(t.Crictl("rmi -q")).To(Exit(0))
+		t.CrictlRemovePauseImages()
 	})
 
 	It("should succeed", func() {

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package e2e
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 )
 
 // The actual test suite.
@@ -27,29 +27,26 @@ var _ = t.Describe("pull", func() {
 	const (
 		imageSuccessText = "Image is up to date"
 		registry         = "gcr.io/k8s-staging-cri-tools/"
+
+		image1 = registry + "test-image-1"
+		image2 = registry + "test-image-1:latest"
+		image3 = registry + "test-image-digest@sha256:9700f9a2f5bf2c45f2f605a0bd3bce7cf37420ec9d3ed50ac2758413308766bf"
 	)
 
 	AfterEach(func() {
-		Expect(t.Crictl("rmi -a")).To(Exit(0))
+		t.Crictl("rmi " + strings.Join([]string{image1, image2, image3}, " "))
 	})
 
 	It("should succeed without tag or digest", func() {
-		t.CrictlExpectSuccess(
-			"pull "+registry+"test-image-1",
-			imageSuccessText)
+		t.CrictlExpectSuccess("pull "+image1, imageSuccessText)
 	})
 
 	It("should succeed with tag", func() {
-		t.CrictlExpectSuccess(
-			"pull "+registry+"test-image-1:latest",
-			imageSuccessText)
+		t.CrictlExpectSuccess("pull "+image2, imageSuccessText)
 	})
 
 	It("should succeed with digest", func() {
-		t.CrictlExpectSuccess(
-			"pull "+registry+"test-image-digest"+
-				"@sha256:9700f9a2f5bf2c45f2f605a0bd3bce7cf37420ec9d3ed50ac2758413308766bf",
-			imageSuccessText)
+		t.CrictlExpectSuccess("pull "+image3, imageSuccessText)
 	})
 
 	It("should succeed to show the help", func() {

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -146,3 +146,15 @@ func (t *TestFramework) CrictlExpectFailure(
 ) {
 	t.CrictlExpect(args, 1, expectedOut, expectedErr)
 }
+
+// CrictlRemovePause can be uased to cleanup the pause images.
+func (t *TestFramework) CrictlRemovePauseImages() {
+	res := t.Crictl("images --filter reference=registry.k8s.io/pause -q")
+	Expect(res).To(Exit(0))
+
+	contents := res.Out.Contents()
+	if len(contents) > 0 {
+		output := strings.Split(string(contents), "\n")
+		t.CrictlExpectSuccess("rmi "+strings.TrimSpace(strings.Join(output, " ")), "Deleted")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The problem is that the other `inspect` test may have the pause image hanging around depending on the runtime configuration. We fix this by removing all images during the `inspect` suite.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
