### PR TITLE
Simplify auth handling

### DIFF
--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -632,7 +632,7 @@ func getAuth(creds, auth, username string) (*pb.AuthConfig, error) {
 	if creds != "" {
 		username, password, err := parseCreds(creds)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parse credentials: %w", err)
 		}
 
 		return &pb.AuthConfig{
@@ -641,13 +641,7 @@ func getAuth(creds, auth, username string) (*pb.AuthConfig, error) {
 		}, nil
 	}
 
-	if auth != "" {
-		return &pb.AuthConfig{
-			Auth: auth,
-		}, nil
-	}
-
-	return nil, nil
+	return &pb.AuthConfig{Auth: auth}, nil
 }
 
 // Ideally repo tag should always be image:tag.


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The `auth` string can be empty and will be omitted during serialization in that case. We also extend the credential parsing error message to slightly more information.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
