### PR TITLE
KEP-3619: Support RuntimeFeatures(.features) in "crictl info" command

### DIFF
--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -91,7 +91,12 @@ func Info(cliContext *cli.Context, client internalapi.RuntimeService) error {
 		return err
 	}
 
-	data := []statusData{{json: statusJSON, runtimeHandlers: string(handlers), info: r.Info}}
+	features, err := json.Marshal(r.Features) // protobufObjectToJSON cannot be used
+	if err != nil {
+		return err
+	}
+
+	data := []statusData{{json: statusJSON, runtimeHandlers: string(handlers), features: string(features), info: r.Info}}
 
 	return outputStatusData(data, cliContext.String("output"), cliContext.String("template"))
 }

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -315,6 +315,7 @@ func outputProtobufObjAsYAML(obj protoiface.MessageV1) error {
 type statusData struct {
 	json            string
 	runtimeHandlers string
+	features        string
 	info            map[string]string
 }
 
@@ -357,6 +358,19 @@ func outputStatusData(statuses []statusData, format, tmplStr string) (err error)
 
 			if handlersVal != nil {
 				infoMap["runtimeHandlers"] = handlersVal
+			}
+		}
+
+		if status.features != "" {
+			var featuresVal map[string]any = map[string]any{}
+
+			err := json.Unmarshal([]byte(status.features), &featuresVal)
+			if err != nil {
+				return fmt.Errorf("unmarshal features JSON: %w", err)
+			}
+
+			if featuresVal != nil {
+				infoMap["features"] = featuresVal
 			}
 		}
 

--- a/cmd/crictl/util_test.go
+++ b/cmd/crictl/util_test.go
@@ -103,6 +103,9 @@ func TestOutputStatusData(t *testing.T) {
 				"name": "crun"
 			}
 		]`
+		featuresResponse = `{
+			"supplemental_groups_policy": true
+		}`
 		emptyResponse = ""
 	)
 
@@ -110,6 +113,7 @@ func TestOutputStatusData(t *testing.T) {
 		name        string
 		status      string
 		handlers    string
+		features    string
 		info        map[string]string
 		format      string
 		tmplStr     string
@@ -119,10 +123,11 @@ func TestOutputStatusData(t *testing.T) {
 			name:        "YAML format",
 			status:      statusResponse,
 			handlers:    handlerResponse,
+			features:    featuresResponse,
 			info:        map[string]string{"key1": `{"foo": "bar"}`, "key2": `{"bar": "baz"}`},
 			format:      outputTypeYAML,
 			tmplStr:     "",
-			expectedOut: "key1:\n  foo: bar\nkey2:\n  bar: baz\nruntimeHandlers:\n- features:\n    recursive_read_only_mounts: true\n  name: runc\n- features:\n    recursive_read_only_mounts: true\n    user_namespaces: true\n  name: crun\nstatus:\n  conditions:\n  - message: no network config found in C:\\Program Files\n    reason: NetworkPluginNotReady\n    status: false\n    type: NetworkReady",
+			expectedOut: "features:\n  supplemental_groups_policy: true\nkey1:\n  foo: bar\nkey2:\n  bar: baz\nruntimeHandlers:\n- features:\n    recursive_read_only_mounts: true\n  name: runc\n- features:\n    recursive_read_only_mounts: true\n    user_namespaces: true\n  name: crun\nstatus:\n  conditions:\n  - message: no network config found in C:\\Program Files\n    reason: NetworkPluginNotReady\n    status: false\n    type: NetworkReady",
 		},
 		{
 			name:        "YAML format with empty status response",
@@ -139,6 +144,15 @@ func TestOutputStatusData(t *testing.T) {
 			format:      outputTypeYAML,
 			tmplStr:     "",
 			expectedOut: "status:\n  conditions:\n  - message: no network config found in C:\\Program Files\n    reason: NetworkPluginNotReady\n    status: false\n    type: NetworkReady",
+		},
+		{
+			name:        "YAML format with empty features response",
+			status:      statusResponse,
+			handlers:    handlerResponse,
+			features:    emptyResponse,
+			format:      outputTypeYAML,
+			tmplStr:     "",
+			expectedOut: "runtimeHandlers:\n- features:\n    recursive_read_only_mounts: true\n  name: runc\n- features:\n    recursive_read_only_mounts: true\n    user_namespaces: true\n  name: crun\nstatus:\n  conditions:\n  - message: no network config found in C:\\Program Files\n    reason: NetworkPluginNotReady\n    status: false\n    type: NetworkReady",
 		},
 		{
 			name:        "JSON format",
@@ -188,7 +202,7 @@ func TestOutputStatusData(t *testing.T) {
 			}
 
 			outStr, err := captureOutput(func() error {
-				data := []statusData{{json: tc.status, runtimeHandlers: tc.handlers, info: tc.info}}
+				data := []statusData{{json: tc.status, runtimeHandlers: tc.handlers, features: tc.features, info: tc.info}}
 
 				err := outputStatusData(data, tc.format, tc.tmplStr)
 				if err != nil {


### PR DESCRIPTION
For:

- https://github.com/kubernetes/enhancements/issues/3619

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds to display `RuntimeFeatures` object(`.features` field) in "crictl info" command.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
KEP-3619: "crictl info" now shows "RuntimeFeatures" object(in ".features" field)
```
