### PR TITLE
fix the issue of regexp matching

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -564,9 +564,9 @@ var containerStatusCommand = &cli.Command{
 
 		if len(ids) == 0 {
 			opts := &listOptions{
-				nameRegexp:         c.String("name"),
+				nameRegexp:         c.String("^name$"),
 				podID:              c.String("pod"),
-				podNamespaceRegexp: c.String("namespace"),
+				podNamespaceRegexp: c.String("^namespace$"),
 				image:              c.String("image"),
 				state:              c.String("state"),
 				latest:             c.Bool("latest"),


### PR DESCRIPTION
fork proposal for exact-string regexp match to scope search results more accurately. "--namespace=test" should not match "test1,test2,test3,test4,testtakersnamespace" --name=example" should not match "examplepod,examplehost..etc"

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Observed that `crictl pods --namespace "name" --name "name" -q` results in multiple pod id results:
```
$ crictl pods --namespace test --name msender -q
95d9a10438afa5d01a42c946e0247f96bd994ca22287ef0a550af2dbbe830ed4
ef3815c75a41f5498476ba4e87eefdca822abb407f2a0432b253e148ba735a55
5b0236afd6b2645f81d773c0e3d6bc588a75fe6ea486c4dc33a8a1f51aa079e6 


crictl pods | grep msender                                          
POD ID              CREATED              STATE               NAME                                                                      NAMESPACE                                ATTEMPT             RUNTIME
95d9a10438afa       29 seconds ago       Ready               msender                                                                   test3                                    0                   (default)
00fd513962cc0       36 minutes ago       Ready               mlistener1                                                                test                                     0                   (default)
ef3815c75a41f       2 hours ago          Ready               msender                                                                   test2                                    0                   (default)
5b0236afd6b26       2 hours ago          Ready               msender                                                                   test                                     0                   (default)
```

This is because it's doing an inexact regexp match on the strings for "name" and "namespace":
```
nameRegexp:         c.String("name"),
podNamespaceRegexp: c.String("namespace"),
```
I posit that if we're supplying the string values for this search function, having an exact match will resolve incorrect outputs and ensure we're only returning the exact results from the search that should match.

With the change we'd get the correct string:

```
$ chroot /host crictl pods --namespace test --name msender -q
5b0236afd6b2645f81d773c0e3d6bc588a75fe6ea486c4dc33a8a1f51aa079e6

## matching only:
5b0236afd6b26       2 hours ago          Ready               msender                                                                   test                                     0                   (default)
```

I believe (but will need some help testing) that the function here that we're calling at https://github.com/kubernetes-sigs/cri-tools/blob/de83eda06541a3712faa42b87958e6428c848aef/cmd/crictl/util.go#L535C1-L547C2

Should be able to handle the regexp options.

#### Which issue(s) this PR fixes:
Fixes  #1810 


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:
Low urgency, appreciate your time. 

#### Does this PR introduce a user-facing change?
yes
```
Update modifies container.go handling of `--namespace="string"` and `--name="string"` to exact match regexp (^string$) to avoid errant results caused by multiple namespaces or pod name overlap.
```
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->