### PR TITLE
pass down the context object wrapped within the urfave/cli.Context st…

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -418,7 +418,7 @@ var removeContainerCommand = &cli.Command{
 
 		ids := ctx.Args().Slice()
 		if ctx.Bool("all") {
-			r, err := InterruptableRPC(context.Background(), func(ctx context.Context) ([]*pb.Container, error) {
+			r, err := InterruptableRPC(ctx.Context, func(ctx context.Context) ([]*pb.Container, error) {
 				return runtimeClient.ListContainers(ctx, nil)
 			})
 			if err != nil {
@@ -443,7 +443,7 @@ var removeContainerCommand = &cli.Command{
 		funcs := []func() error{}
 		for _, id := range ids {
 			funcs = append(funcs, func() error {
-				resp, err := InterruptableRPC(context.Background(), func(ctx context.Context) (*pb.ContainerStatusResponse, error) {
+				resp, err := InterruptableRPC(ctx.Context, func(ctx context.Context) (*pb.ContainerStatusResponse, error) {
 					return runtimeClient.ContainerStatus(ctx, id, false)
 				})
 				if err != nil {

--- a/cmd/crictl/events.go
+++ b/cmd/crictl/events.go
@@ -84,7 +84,7 @@ func Events(cliContext *cli.Context, client internalapi.RuntimeService) error {
 	go func() {
 		logrus.Debug("getting container events")
 
-		_, err := InterruptableRPC(context.Background(), func(ctx context.Context) (any, error) {
+		_, err := InterruptableRPC(cliContext.Context, func(ctx context.Context) (any, error) {
 			return nil, client.GetContainerEvents(ctx, containerEventsCh, nil)
 		})
 		if errors.Is(err, io.EOF) {

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -423,7 +423,7 @@ var removeImageCommand = &cli.Command{
 
 		// Add all available images to the ID selector
 		if all || prune {
-			r, err := InterruptableRPC(context.Background(), func(ctx context.Context) ([]*pb.Image, error) {
+			r, err := InterruptableRPC(cliCtx.Context, func(ctx context.Context) ([]*pb.Image, error) {
 				return imageClient.ListImages(ctx, nil)
 			})
 			if err != nil {
@@ -449,7 +449,7 @@ var removeImageCommand = &cli.Command{
 			}
 
 			// Container images
-			containers, err := InterruptableRPC(context.Background(), func(ctx context.Context) ([]*pb.Container, error) {
+			containers, err := InterruptableRPC(cliCtx.Context, func(ctx context.Context) ([]*pb.Container, error) {
 				return runtimeClient.ListContainers(ctx, nil)
 			})
 			if err != nil {

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -72,7 +72,7 @@ func Info(cliContext *cli.Context, client internalapi.RuntimeService) error {
 	request := &pb.StatusRequest{Verbose: !cliContext.Bool("quiet")}
 	logrus.Debugf("StatusRequest: %v", request)
 
-	r, err := InterruptableRPC(context.Background(), func(ctx context.Context) (*pb.StatusResponse, error) {
+	r, err := InterruptableRPC(cliContext.Context, func(ctx context.Context) (*pb.StatusResponse, error) {
 		return client.Status(ctx, request.Verbose)
 	})
 	logrus.Debugf("StatusResponse: %v", r)

--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -103,7 +103,7 @@ var logsCommand = &cli.Command{
 		}
 
 		if c.Bool("reopen") {
-			if _, err := InterruptableRPC(context.Background(), func(ctx context.Context) (any, error) {
+			if _, err := InterruptableRPC(c.Context, func(ctx context.Context) (any, error) {
 				return nil, runtimeService.ReopenContainerLog(ctx, containerID)
 			}); err != nil {
 				return fmt.Errorf("reopen container logs: %w", err)
@@ -137,7 +137,7 @@ var logsCommand = &cli.Command{
 			SinceTime:  since,
 			Timestamps: timestamp,
 		}, time.Now())
-		status, err := InterruptableRPC(context.Background(), func(ctx context.Context) (*pb.ContainerStatusResponse, error) {
+		status, err := InterruptableRPC(c.Context, func(ctx context.Context) (*pb.ContainerStatusResponse, error) {
 			return runtimeService.ContainerStatus(ctx, containerID, false)
 		})
 		if err != nil {

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -147,7 +147,7 @@ var removePodCommand = &cli.Command{
 
 		ids := ctx.Args().Slice()
 		if ctx.Bool("all") {
-			r, err := InterruptableRPC(context.Background(), func(ctx context.Context) ([]*pb.PodSandbox, error) {
+			r, err := InterruptableRPC(ctx.Context, func(ctx context.Context) ([]*pb.PodSandbox, error) {
 				return runtimeClient.ListPodSandbox(ctx, nil)
 			})
 			if err != nil {
@@ -172,7 +172,7 @@ var removePodCommand = &cli.Command{
 		funcs := []func() error{}
 		for _, id := range ids {
 			funcs = append(funcs, func() error {
-				resp, err := InterruptableRPC(context.Background(), func(ctx context.Context) (*pb.PodSandboxStatusResponse, error) {
+				resp, err := InterruptableRPC(ctx.Context, func(ctx context.Context) (*pb.PodSandboxStatusResponse, error) {
 					return runtimeClient.PodSandboxStatus(ctx, id, false)
 				})
 				if err != nil {

--- a/cmd/crictl/update_runtime_config.go
+++ b/cmd/crictl/update_runtime_config.go
@@ -55,7 +55,7 @@ var updateRuntimeConfigCommand = &cli.Command{
 			return err
 		}
 
-		if _, err := InterruptableRPC(context.Background(), func(ctx context.Context) (any, error) {
+		if _, err := InterruptableRPC(c.Context, func(ctx context.Context) (any, error) {
 			return nil, runtimeClient.UpdateRuntimeConfig(ctx, runtimeConfig)
 		}); err != nil {
 			return fmt.Errorf("update runtime config: %w", err)


### PR DESCRIPTION
This PR reuses the ctx object nested inside the urfave/cli struct instead of instantiating a new `context.Background()` object