### PR TITLE
Fix regression in reading crictl config file

### DIFF
--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -59,6 +59,8 @@ func GetServerConfigFromFile(configFileName, currentDir string) (*ServerConfigur
 		if _, err := os.Stat(nextConfigFileName); err != nil {
 			return nil, fmt.Errorf("load config file: %w", err)
 		}
+
+		configFileName = nextConfigFileName
 	}
 
 	// Get config from file.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the regression introduced while reading config by PR https://github.com/kubernetes-sigs/cri-tools/pull/1657 .
When we fallback to the crictl config file in the program's directory, the `configFileName` is not replaced with this alternative. 
Reading config depends on variable `configFileName` . This causes issues with reading config file.

![image](https://github.com/user-attachments/assets/77e3223d-e9b1-4ca9-83a2-658dc806077e)

#### Which issue(s) this PR fixes:

Same as above.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No

```release-note

```
