### PR TITLE
Revert "Disable containerd hostport test"

### DIFF
--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -331,10 +331,7 @@ jobs:
           sudo mount
 
           TEST_RC=0
-          # TODO: re-enable the host port test when
-          # https://github.com/kubernetes-sigs/cri-tools/issues/1821
-          # got resolved.
-          sudo -E PATH=$PATH critest --ginkgo.vv --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8 --ginkgo.skip 'should support port mapping with host port and container port' || TEST_RC=$?
+          sudo -E PATH=$PATH critest --ginkgo.vv --runtime-endpoint=unix:///${BDIR}/c.sock --parallel=8 || TEST_RC=$?
           test $TEST_RC -ne 0 && cat ${BDIR}/containerd-cri.log
           sudo pkill containerd
           echo "CONTD_CRI_DIR=$BDIR" >> $GITHUB_ENV


### PR DESCRIPTION


#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This reverts commit 197c6bfd60526138a835ce669853205aac51ec08. Since the ubuntu runner images has now been fixed, the containerd hostport tests can be re-enabled

#### Which issue(s) this PR fixes:
Fixes #1821 


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
