### PR TITLE
Support websocket connections in `critest`

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -26,6 +26,8 @@ import (
 	"github.com/urfave/cli/v2"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"sigs.k8s.io/cri-tools/pkg/common"
 )
 
 var runtimeAttachCommand = &cli.Command{
@@ -47,8 +49,8 @@ var runtimeAttachCommand = &cli.Command{
 		&cli.StringFlag{
 			Name:    transportFlag,
 			Aliases: []string{"r"},
-			Value:   transportSpdy,
-			Usage:   fmt.Sprintf("Transport protocol to use, one of: %s|%s", transportSpdy, transportWebsocket),
+			Value:   common.TransportSpdy,
+			Usage:   fmt.Sprintf("Transport protocol to use, one of: %s|%s", common.TransportSpdy, common.TransportWebsocket),
 		},
 		&cli.StringFlag{
 			Name:    flagTLSSNI,

--- a/pkg/common/streaming.go
+++ b/pkg/common/streaming.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	remoteclient "k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/transport/spdy"
+)
+
+const (
+	TransportWebsocket = "websocket"
+	TransportSpdy      = "spdy"
+)
+
+func GetExecutor(transport string, parsedURL *url.URL, tlsConfig *rest.TLSClientConfig) (exec remoteclient.Executor, err error) {
+	config := &rest.Config{TLSClientConfig: *tlsConfig}
+
+	switch transport {
+	case TransportSpdy:
+		return remoteclient.NewSPDYExecutor(config, "POST", parsedURL)
+
+	case TransportWebsocket:
+		return remoteclient.NewWebSocketExecutor(config, "GET", parsedURL.String())
+
+	default:
+		return nil, fmt.Errorf("unknown transport: %s", transport)
+	}
+}
+
+func GetDialer(transport string, parsedURL *url.URL, tlsConfig *rest.TLSClientConfig) (exec httpstream.Dialer, err error) {
+	config := &rest.Config{TLSClientConfig: *tlsConfig}
+
+	switch transport {
+	case TransportSpdy:
+		tr, upgrader, err := spdy.RoundTripperFor(config)
+		if err != nil {
+			return nil, fmt.Errorf("get SPDY round tripper: %w", err)
+		}
+
+		return spdy.NewDialer(upgrader, &http.Client{Transport: tr}, "POST", parsedURL), nil
+
+	case TransportWebsocket:
+		return portforward.NewSPDYOverWebsocketDialer(parsedURL, config)
+
+	default:
+		return nil, fmt.Errorf("unknown transport: %s", transport)
+	}
+}

--- a/pkg/framework/test_context.go
+++ b/pkg/framework/test_context.go
@@ -112,6 +112,11 @@ type TestContextType struct {
 	IsLcow bool
 
 	RegistryPrefix string
+
+	// Use websocket connections over than SPDY for streaming tests.
+	UseWebsocketForExec        bool
+	UseWebsocketForAttach      bool
+	UseWebsocketForPortForward bool
 }
 
 // TestContext is a test context.
@@ -172,6 +177,10 @@ func RegisterFlags() {
 	}
 
 	flag.StringVar(&TestContext.RegistryPrefix, "registry-prefix", DefaultRegistryPrefix, "A possible registry prefix added to all images, like 'localhost:5000'")
+
+	flag.BoolVar(&TestContext.UseWebsocketForExec, "websocket-exec", false, "Use websocket connections over SPDY for exec streaming tests.")
+	flag.BoolVar(&TestContext.UseWebsocketForAttach, "websocket-attach", false, "Use websocket connections over SPDY for attach streaming tests.")
+	flag.BoolVar(&TestContext.UseWebsocketForPortForward, "websocket-portforward", false, "Use websocket connections over SPDY for portforward streaming tests.")
 }
 
 // Loads any external file-based parameters into the TestContextType.


### PR DESCRIPTION


#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Adding new test flags to be able to utilize websocket connections for the streaming server.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Refers to https://github.com/kubernetes/enhancements/issues/4006
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `critest` flags `websocket-{attach,exec,portforward}` to configure using websockets for the corresponding streaming tests.
```
