### PR TITLE
doc: add steps to use runp when systemd cgroup driver is used

### DIFF
--- a/docs/crictl.1
+++ b/docs/crictl.1
@@ -308,6 +308,25 @@ $ cat pod-config.json
     "linux": {
     }
 }
+.EE
+
+.PP
+If the runtime uses systemd as the cgroup driver, set the \fB"cgroup_parent"\fR field in the pod-config, similar to
+
+.EX
+$ cat pod-config.json
+{
+    "metadata": {
+        "name": "nginx-sandbox",
+        "namespace": "default",
+        "attempt": 1,
+        "uid": "hdishd83djaidwnduwk28bcsb"
+    },
+    "log_directory": "/tmp",
+    "linux": {
+      "cgroup_parent": "/test.slice"
+    }
+}
 
 $ crictl runp pod-config.json
 f84dd361f8dc51518ed291fbadd6db537b0496536c1d2d6c05ff943ce8c9a54f

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -208,6 +208,24 @@ $ cat pod-config.json
     "linux": {
     }
 }
+```
+
+If the runtime uses systemd as the cgroup driver, set the `"cgroup_parent"` field in the pod-config, similar to
+
+```sh
+$ cat pod-config.json
+{
+    "metadata": {
+        "name": "nginx-sandbox",
+        "namespace": "default",
+        "attempt": 1,
+        "uid": "hdishd83djaidwnduwk28bcsb"
+    },
+    "log_directory": "/tmp",
+    "linux": {
+      "cgroup_parent": "/test.slice"
+    }
+}
 
 $ crictl runp pod-config.json
 f84dd361f8dc51518ed291fbadd6db537b0496536c1d2d6c05ff943ce8c9a54f


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
When the container runtime uses systemd cgroup driver, the `cgroup_parent` field in the PodConfig needs to be set to a systemd slice format. add this configuration also into `crictl runp`  example

#### Which issue(s) this PR fixes:
Fixes #1696 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
