### PR TITLE
add warning about empty cgroup_parent field in pod config

### DIFF
--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/invopop/jsonschema"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/protoadapt"
 	"google.golang.org/protobuf/runtime/protoiface"
@@ -252,6 +253,10 @@ func loadPodSandboxConfig(path string) (*pb.PodSandboxConfig, error) {
 
 	if config.Metadata.Name == "" || config.Metadata.Namespace == "" || config.Metadata.Uid == "" {
 		return nil, fmt.Errorf("name, namespace or uid is not in metadata %q", config.Metadata)
+	}
+
+	if config.Linux != nil && config.Linux.CgroupParent == "" {
+		logrus.Warn("cgroup_parent is not set. Use `runtime-config` to get the runtime cgroup driver")
 	}
 
 	return &config, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds a warning message when cgroup_parent field is empty in the pod config.json. This will ensure that users does not assume that the correct cgroup driver is used always.

```
akhil@akhil-ThinkPad-L14:~/W/d/containerd $ sudo crictl runp pod.json
WARN[0000] cgroup_parent is not set. Use `runtime-config` to get the runtime cgroup driver
```

#### Which issue(s) this PR fixes:
Change as mentioned in https://github.com/kubernetes-sigs/cri-tools/pull/1867#discussion_r2208911193

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
A warning message when the cgroup_parent field is left empty in the pod config.json.
```
