### PR TITLE
support to auto generate pod uuid

### DIFF
--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/invopop/jsonschema"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/protoadapt"
@@ -250,8 +251,12 @@ func loadPodSandboxConfig(path string) (*pb.PodSandboxConfig, error) {
 		return nil, errors.New("metadata is not set")
 	}
 
-	if config.Metadata.Name == "" || config.Metadata.Namespace == "" || config.Metadata.Uid == "" {
-		return nil, fmt.Errorf("name, namespace or uid is not in metadata %q", config.Metadata)
+	if config.Metadata.Uid == "" {
+		config.Metadata.Uid = uuid.New().String()
+	}
+
+	if config.Metadata.Name == "" || config.Metadata.Namespace == "" {
+		return nil, fmt.Errorf("name or namespace is not in metadata %q", config.Metadata)
 	}
 
 	return &config, nil


### PR DESCRIPTION
I want to create many pods  to make some test.
crictl  run    --no-pull container.json  pod.json
I have to set different uid in pod.json.
So I think we can support to auto generate pod uid if uid is empty in pod.json

```release-note
Automatically generate the pod UUID if not provided by the JSON.
```