### PR TITLE
Switch to go 1.25

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -7,7 +7,7 @@ dependencies:
         match: VERSION
 
   - name: go
-    version: 1.24
+    version: 1.25
     refPaths:
       - path: go.mod
         match: go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cri-tools
 
-go 1.24.1
+go 1.25
 
 require (
 	github.com/distribution/reference v0.6.0


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Use go 1.25 for build after v1.34.0 got released.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
