### PR TITLE
Disable short name mode in CRI-O e2e tests

### DIFF
--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Configure CRI-O
         run: |
           sudo mkdir -p /etc/crio/crio.conf.d
-          printf '[crio.runtime]\nlog_level = "debug"\n' | sudo tee /etc/crio/crio.conf.d/01-log-level.conf
+          printf '[crio.runtime]\nlog_level = "debug"\n[crio.image]\nshort_name_mode = "disabled"\n' | sudo tee /etc/crio/crio.conf.d/01-log-level.conf
 
       - name: Configure CRI-O to use conmon-rs intead of the default conmon
         if: ${{matrix.monitor == 'conmon-rs'}}


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
Fixing the failing CRI-O e2e tests this way.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
