### PR TITLE
Remove link to outdated kubic repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,6 @@ sudo tar zxvf critest-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
 rm -f critest-$VERSION-linux-amd64.tar.gz
 ```
 
-### deb/rpm packages
-
-Packages for various distributions using deb's and rpm's are available in the
-[OBS repository](https://build.opensuse.org/package/show/devel:kubic:libcontainers:stable/cri-tools).
-
 ## Documentation
 
 - **[CRI `crictl` CLI](docs/crictl.md)**


### PR DESCRIPTION
The last version available in the old Kubic project repo is 1.26:

https://build.opensuse.org/project/show/devel:kubic:libcontainers:stable

Currently it is still available in core, by mistake (since 1.32):

https://build.opensuse.org/project/show/isv:kubernetes:core

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #1806

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
