### PR TITLE
Containerd 1.6 is EOL now

### DIFF
--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -26,7 +26,8 @@ jobs:
         os: [ubuntu-22.04, windows-2025]
         # not every command likes the slash in branch name.
         # So will use format command to replace to either `_` or '/'
-        version: [main, "release{0}1.6", "release{0}1.7"]
+        # There is no LTS version of 2.0+ containerd. So main testing covers the latest.
+        version: [main, "release{0}1.7"]
         runtime:
           [
             io.containerd.runtime.v1.linux,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Containerd 1.6 is EOL now

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Containerd 1.6 is EOL and is not being tested any longer.
```
