### PR TITLE
Add buffer pooling for JSON operations

### DIFF
--- a/cmd/crictl/bufferpool.go
+++ b/cmd/crictl/bufferpool.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"sync"
+)
+
+// jsonBufferPool is a pool of bytes.Buffer instances used for JSON operations.
+// This reduces GC pressure by reusing buffers instead of allocating new ones
+// for each JSON indentation operation.
+var jsonBufferPool = sync.Pool{
+	New: func() interface{} {
+		return new(bytes.Buffer)
+	},
+}
+
+// getJSONBuffer retrieves a buffer from the pool.
+// The caller must call putJSONBuffer when done to return it to the pool.
+func getJSONBuffer() *bytes.Buffer {
+	buf, ok := jsonBufferPool.Get().(*bytes.Buffer)
+	if !ok {
+		return new(bytes.Buffer)
+	}
+
+	return buf
+}
+
+// putJSONBuffer resets and returns a buffer to the pool.
+// This should be called with defer after getJSONBuffer.
+func putJSONBuffer(buf *bytes.Buffer) {
+	buf.Reset()
+	jsonBufferPool.Put(buf)
+}

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -421,8 +420,10 @@ func outputStatusData(statuses []statusData, format, tmplStr string) (err error)
 
 		fmt.Println(string(yamlInfo))
 	case outputTypeJSON:
-		var output bytes.Buffer
-		if err := json.Indent(&output, jsonResult, "", "  "); err != nil {
+		output := getJSONBuffer()
+		defer putJSONBuffer(output)
+
+		if err := json.Indent(output, jsonResult, "", "  "); err != nil {
 			return fmt.Errorf("indent JSON result: %w", err)
 		}
 
@@ -519,9 +520,10 @@ func marshalMapInOrder(m map[string]any, t any) (string, error) {
 
 	sb.WriteString("}")
 
-	var buf bytes.Buffer
+	buf := getJSONBuffer()
+	defer putJSONBuffer(buf)
 
-	if err := json.Indent(&buf, []byte(sb.String()), "", "  "); err != nil {
+	if err := json.Indent(buf, []byte(sb.String()), "", "  "); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Implement sync.Pool-based buffer pooling to reduce GC pressure and memory allocations for JSON indentation operations.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
