### PR TITLE
Update documentation with missing features and fixes

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -72,4 +72,4 @@ critest connects to Unix: `unix:///run/containerd/containerd.sock` or Windows: `
 - `-benchmarking-output-dir`: optional path to a pre-existing directory in which to write JSON
   files detailing the results of the benchmarks.
 - `-ginkgo.skip`: Skip the tests that match the regular expression.
-- `-h`: Should help and all supported options.
+- `-h`: Show help and all supported options.

--- a/docs/crictl.1
+++ b/docs/crictl.1
@@ -104,17 +104,19 @@ COMMANDS:
 .IP \(bu 2
 \fBupdate\fR: Update one or more running containers
 .IP \(bu 2
-\fBconfig\fR: Get and set \fBcrictl\fR client configuration options
+\fBconfig\fR: Get, set and list crictl configuration options
 .IP \(bu 2
 \fBstats\fR: List container(s) resource usage statistics
 .IP \(bu 2
-\fBstatsp\fR: List pod(s) resource usage statistics
+\fBstatsp\fR: List pod statistics. Stats represent a structured API that will fulfill the Kubelet's /stats/summary endpoint.
 .IP \(bu 2
 \fBcompletion\fR: Output bash shell completion code
 .IP \(bu 2
 \fBcheckpoint\fR: Checkpoint one or more running containers
 .IP \(bu 2
 \fBevents, event\fR: Stream the events of containers
+.IP \(bu 2
+\fBruntime-config\fR: Retrieve the container runtime configuration
 .IP \(bu 2
 \fBupdate-runtime-config\fR Update the runtime configuration
 .IP \(bu 2
@@ -223,9 +225,19 @@ option for no timeout value set and the smallest supported timeout is \fB1s\fR
 \fB--version\fR, \fB-v\fR: print the version information of \fBcrictl\fR
 .IP \(bu 2
 \fB--config\fR, \fB-c\fR: Location of the client config file (default: \fB/etc/crictl.yaml\fR). Can be changed by setting \fBCRI_CONFIG_FILE\fR environment variable. If not specified and the default does not exist, the program's directory is searched as well
+.IP \(bu 2
+\fB--enable-tracing\fR: Enable OpenTelemetry tracing (default: \fBfalse\fR)
+.IP \(bu 2
+\fB--tracing-endpoint\fR: Address to which the gRPC tracing collector will send spans to (default: \fB127.0.0.1:4317\fR)
+.IP \(bu 2
+\fB--tracing-sampling-rate-per-million\fR: Number of samples to collect per million OpenTelemetry spans. Set to 1000000 or -1 to always sample (default: \fB-1\fR)
+.IP \(bu 2
+\fB--profile-cpu\fR: Write a pprof CPU profile to the provided path
+.IP \(bu 2
+\fB--profile-mem\fR: Write a pprof memory profile to the provided path
 
 .SH Client Configuration Options
-Use the \fBcrictl\fR config command to get and set the \fBcrictl\fR client configuration
+Use the \fBcrictl\fR config command to get, set and list the \fBcrictl\fR client configuration
 options.
 
 .PP
@@ -244,6 +256,8 @@ COMMAND OPTIONS:
 \fB--get value\fR: Show the option value
 .IP \(bu 2
 \fB--set value\fR: Set option (can specify multiple or separate values with commas: opt1=val1,opt2=val2)
+.IP \(bu 2
+\fB--list\fR: Show all option values (default: \fBfalse\fR)
 .IP \(bu 2
 \fB--help\fR, \fB-h\fR: Show help (default: \fBfalse\fR)
 

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -65,12 +65,13 @@ COMMANDS:
 - `stop`: Stop one or more running containers
 - `stopp`: Stop one or more running pods
 - `update`: Update one or more running containers
-- `config`: Get and set `crictl` client configuration options
+- `config`: Get, set and list crictl configuration options
 - `stats`: List container(s) resource usage statistics
-- `statsp`: List pod(s) resource usage statistics
+- `statsp`: List pod statistics. Stats represent a structured API that will fulfill the Kubelet's /stats/summary endpoint.
 - `completion`: Output bash shell completion code
 - `checkpoint`: Checkpoint one or more running containers
 - `events, event`: Stream the events of containers
+- `runtime-config`: Retrieve the container runtime configuration
 - `update-runtime-config` Update the runtime configuration
 - `help, h`: Shows a list of commands or help for one command
 
@@ -147,10 +148,15 @@ via sudo (`sudo -E crictl ...`).
 - `--help`, `-h`: show help
 - `--version`, `-v`: print the version information of `crictl`
 - `--config`, `-c`: Location of the client config file (default: `/etc/crictl.yaml`). Can be changed by setting `CRI_CONFIG_FILE` environment variable. If not specified and the default does not exist, the program's directory is searched as well
+- `--enable-tracing`: Enable OpenTelemetry tracing (default: `false`)
+- `--tracing-endpoint`: Address to which the gRPC tracing collector will send spans to (default: `127.0.0.1:4317`)
+- `--tracing-sampling-rate-per-million`: Number of samples to collect per million OpenTelemetry spans. Set to 1000000 or -1 to always sample (default: `-1`)
+- `--profile-cpu`: Write a pprof CPU profile to the provided path
+- `--profile-mem`: Write a pprof memory profile to the provided path
 
 ## Client Configuration Options
 
-Use the `crictl` config command to get and set the `crictl` client configuration
+Use the `crictl` config command to get, set and list the `crictl` client configuration
 options.
 
 USAGE:
@@ -165,6 +171,7 @@ COMMAND OPTIONS:
 
 - `--get value`: Show the option value
 - `--set value`: Set option (can specify multiple or separate values with commas: opt1=val1,opt2=val2)
+- `--list`: Show all option values (default: `false`)
 - `--help`, `-h`: Show help (default: `false`)
 
 `crictl` OPTIONS:


### PR DESCRIPTION


#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
This commit updates the crictl and benchmark documentation to include missing features and fix inaccuracies:

- Add missing runtime-config command to command list
- Document OpenTelemetry tracing flags (--enable-tracing, --tracing-endpoint, --tracing-sampling-rate-per-million)
- Document profiling flags (--profile-cpu, --profile-mem)
- Add --list flag to config command documentation
- Update statsp command description to match actual implementation
- Update config command description to include "list" capability
- Fix typo in benchmark.md: "Should help" -> "Show help"

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated the docs to include missing features and fixes.
```
