### PR TITLE
Update validation.md documentation

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -9,17 +9,17 @@ CRI validation testing is GA since v1.11.0. We encourage the CRI developers to r
 The benchmarking tests binary `critest` can be downloaded from [Releasing page](https://github.com/kubernetes-sigs/cri-tools/releases):
 
 ```sh
-VERSION="v1.27.0"
+VERSION="v1.34.0"
 ARCH="amd64"
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/critest-$VERSION-linux-$ARCH.tar.gz
 sudo tar zxvf critest-$VERSION-linux-$ARCH.tar.gz -C /usr/local/bin
 rm -f critest-$VERSION-linux-$ARCH.tar.gz
 ```
 
-critest requires [ginkgo](https://github.com/onsi/ginkgo) to run parallel tests. It could be installed by
+critest uses [ginkgo v2](https://github.com/onsi/ginkgo) as its test framework. For parallel test execution, ginkgo can be installed by
 
 ```sh
-go get -u github.com/onsi/ginkgo/ginkgo
+go install github.com/onsi/ginkgo/v2/ginkgo@latest
 ```
 
 For v1.0.0-alpha.0 and previous versions, Go and cri-tools source code are also required to run `critest`. The source code could get by running
@@ -51,10 +51,57 @@ critest connects to Unix: `unix:///run/containerd/containerd.sock` or Windows: `
 
 ## Additional options
 
-- `-ginkgo.focus`: Only run the tests that match the regular expression.
-- `-image-endpoint`: Set the endpoint of image service. Same with runtime-endpoint if not specified.
-- `-test-images-file`: Optional path to a YAML file containing references to custom container images to be used in tests.
+### Runtime and Image Service Configuration
+
 - `-runtime-endpoint`: Set the endpoint of runtime service. Default to `unix:///run/containerd/containerd.sock` or Windows: `npipe:////./pipe/containerd-containerd`.
+- `-image-endpoint`: Set the endpoint of image service. Same with runtime-endpoint if not specified.
+- `-runtime-service-timeout`: Timeout when trying to connect to a runtime service (default: 300s).
+- `-image-service-timeout`: Timeout when trying to connect to image service (default: 300s).
+- `-runtime-handler`: Runtime handler to use in the test.
+- `-config`: Location of the client config file. If not specified and the default does not exist, the program's directory is searched as well.
+
+### Test Execution and Filtering
+
+- `-ginkgo.focus`: Only run the tests that match the regular expression.
 - `-ginkgo.skip`: Skip the tests that match the regular expression.
+- `-ginkgo.label-filter`: Filter specs by label expressions (e.g., `(cat || dog) && !fruit`).
 - `-parallel`: The number of parallel test nodes to run (default 1). [ginkgo](https://github.com/onsi/ginkgo) must be installed to run parallel tests.
+- `-ginkgo.fail-fast`: Stop running tests after the first failure.
+- `-ginkgo.flake-attempts`: Make up to N attempts to run each spec. If any attempt succeeds, the spec passes.
+- `-ginkgo.timeout`: Test suite fails if it does not complete within the specified timeout (default: 1h).
+
+### Test Images and Registry
+
+- `-test-images-file`: Optional path to a YAML file containing references to custom container images to be used in tests.
+- `-registry-prefix`: A possible registry prefix added to all images, like 'localhost:5000'.
+
+### Benchmarking
+
+- `-benchmark`: Run benchmarks instead of validation tests.
+- `-benchmarking-params-file`: Optional path to a YAML file specifying benchmarking configuration options.
+- `-benchmarking-output-dir`: Optional path to a directory in which benchmarking data should be placed.
+
+### Reporting
+
+- `-report-dir`: Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.
+- `-report-prefix`: Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.
+- `-ginkgo.json-report`: Generate a JSON-formatted test report at the specified location.
+- `-ginkgo.junit-report`: Generate a conformant junit test report in the specified file.
+
+### Streaming Options
+
+- `-websocket-exec`: Use websocket connections over SPDY for exec streaming tests.
+- `-websocket-attach`: Use websocket connections over SPDY for attach streaming tests.
+- `-websocket-portforward`: Use websocket connections over SPDY for portforward streaming tests.
+
+### Output and Verbosity
+
+- `-ginkgo.v`: Emit more output including GinkgoWriter contents.
+- `-ginkgo.vv`: Emit with maximal verbosity - includes skipped and pending tests.
+- `-ginkgo.no-color`: Suppress color output in default reporter.
+- `-ginkgo.trace`: Print out the full stack trace when a failure occurs.
+
+### Other Options
+
+- `-version`: Display version of critest.
 - `-h`: Show help and all supported options.


### PR DESCRIPTION


#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:

- Update critest version from v1.27.0 to v1.34.0
- Update ginkgo installation to use 'go install' instead of deprecated 'go get'
- Specify ginkgo v2 is now used
- Add comprehensive documentation for all available flags organized by category:
  - Runtime and Image Service Configuration
  - Test Execution and Filtering
  - Test Images and Registry
  - Benchmarking
  - Reporting
  - Streaming Options
  - Output and Verbosity
  - Other Options
- Document previously undocumented flags including benchmarking, reporting, websocket options, and various ginkgo v2 features

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated `docs/validation.md` do contain the most recent additions and changes.
```
