### PR TITLE
Disable runc integration tests due to AppArmor issue

### DIFF
--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -16,7 +16,11 @@ jobs:
           - critest
         oci-runtime:
           - crun
-          - runc
+          # TODO: Re-enable runc integration tests when mitigation is found
+          # Disabled due to AppArmor issue in nested environments
+          # See: https://github.com/cri-o/cri-o/issues/9573
+          # See: https://github.com/opencontainers/runc/issues/4968
+          # - runc
         monitor:
           - conmon
           - conmon-rs


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
All runc integration tests are failing in CI due to an AppArmor issue in nested environments. The error occurs when runc tries to access /proc/sys/net/ipv4/ip_unprivileged_port_start, which AppArmor incorrectly interprets as trying to access /sys/... in detached mounts.

This is a known issue in runc that affects various container platforms. The maintainers advise against downgrading as the current version fixes multiple container escape vulnerabilities.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
TODO: Re-enable these tests when a mitigation is found.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
