### PR TITLE
Use `latest` gcb-docker-gcloud for building test images

### DIFF
--- a/images/cloudbuild.yaml
+++ b/images/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: "N1_HIGHCPU_8"
 steps:
-  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90"
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest"
     env:
       - HOME=/root # for docker buildx
     entrypoint: build


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The currently pinned tag is outdated since a couple of years. We now switch to `latest` to ensure not using vulnerable images in CI.

https://console.cloud.google.com/artifacts/docker/k8s-staging-test-infra/us/gcr.io/gcb-docker-gcloud

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
