### PR TITLE
Update Windows test image to use ltsc2022 base

### DIFF
--- a/images/image-test-win/Dockerfile
+++ b/images/image-test-win/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 ARG TEST
 ADD ${TEST} ${TEST}

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -34,7 +34,17 @@ var _ = t.Describe("pull", func() {
 	)
 
 	AfterEach(func() {
+		// Remove images by tag/digest first
 		t.Crictl("rmi " + strings.Join([]string{image1, image2, image3}, " "))
+
+		// Remove any remaining digest references for test-image-1
+		// Note: image1 and image2 both refer to test-image-1
+		res := t.Crictl("images --filter reference=" + image1 + " -q")
+		contents := res.Out.Contents()
+		if len(contents) > 0 {
+			output := strings.Split(string(contents), "\n")
+			t.Crictl("rmi " + strings.TrimSpace(strings.Join(output, " ")))
+		}
 	})
 
 	It("should succeed without tag or digest", func() {


### PR DESCRIPTION


#### What type of PR is this?

/kind failing-test


#### What this PR does / why we need it:
Update the Windows test image Dockerfile to use the ltsc2022 (Windows Server 2022) base image instead of 1809 (Windows Server 2019) to support newer Windows platforms and resolve compatibility issues with containerd CI.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes-sigs/cri-tools/issues/1950
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated the Windows test image Dockerfile to use the ltsc2022.
```
