### PR TITLE
bug fix: fix panic when no image in container-config

### DIFF
--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -219,6 +219,14 @@ func loadContainerConfig(path string) (*pb.ContainerConfig, error) {
 		return nil, fmt.Errorf("name is not in metadata %q", config.GetMetadata())
 	}
 
+	if config.GetImage() == nil {
+		return nil, errors.New("image is not set")
+	}
+
+	if config.GetImage().GetImage() == "" {
+		return nil, fmt.Errorf("image field is not set in image %q", config.GetImage())
+	}
+
 	return &config, nil
 }
 


### PR DESCRIPTION
add jugement for image in container-config

/kind bug

When running containers, if no image is specified in the container-config, crictl will panic.
$ cat ontainer-config.json/container-config.json 
{
  "metadata": {
      "name": "test"
  },
  "command": [
      "top"
  ],
 "log_path":"xxx22.log",
  "linux": {
  }
}

$ ./crictl run container-config.json pod.json 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xfc8083]

goroutine 1 [running]:
main.CreateContainer({0x1532de8, 0x1f2b840}, {0x0, 0x0}, {0x1548f80, 0xc000122b10}, {0xc000438600?, {0xc000130680?, 0xb8dcc73123c5c24c?}})
       goproject/src/github.com/cri-tools-origin/cmd/crictl/container.go:919 +0x123
main.RunContainer({0x1532de8, 0x1f2b840}, {0x0, 0x0}, {0x1548f80, 0xc000122b10}, {0xc0004ddb80, {0x7ffcc070db71, 0x4b}, {0x7ffcc070dbbd, ...}, ...}, ...)
        goproject/src/github.com/cri-tools-origin/cmd/crictl/container.go:882 +0x1d9
main.init.func13(0xc0004dd800)
       goproject/src/github.com/cri-tools-origin/cmd/crictl/container.go:807 +0x3b8
github.com/urfave/cli/v2.(*Command).Run(0x1ed9480, 0xc0004dd800, {0xc00039de30, 0x3, 0x3})
        goproject/src/github.com/cri-tools-origin/vendor/github.com/urfave/cli/v2/command.go:276 +0x7c2
github.com/urfave/cli/v2.(*Command).Run(0xc0001b51e0, 0xc0004dd280, {0xc000114080, 0x4, 0x4})
        oproject/src/github.com/cri-tools-origin/vendor/github.com/urfave/cli/v2/command.go:269 +0xa30
github.com/urfave/cli/v2.(*App).RunContext(0xc000204000, {0x1532de8, 0x1f2b840}, {0xc000114080, 0x4, 0x4})
        goproject/src/github.com/cri-tools-origin/vendor/github.com/urfave/cli/v2/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(...)
       goproject/src/github.com/cri-tools-origin/vendor/github.com/urfave/cli/v2/app.go:307
main.main()
       goproject/src/github.com/cri-tools-origin/cmd/crictl/main.go:454 +0xe5b

after fix
$./crictl run container-config.json pod.json 
FATA[0001] running container: creating container failed: image is not set 
