### PR TITLE
add a root span

### DIFF
--- a/cmd/crictl/crictl_config.go
+++ b/cmd/crictl/crictl_config.go
@@ -116,6 +116,8 @@ type CrictlConfig struct {
 	PullImageOnCreate    bool
 	DisablePullOnRun     bool
 	TracerProvider       *sdktrace.TracerProvider
+	// RootSpan is the root OpenTelemetry span for the command.
+	RootSpan trace.Span
 
 	runtimeServiceOverride internalapi.RuntimeService
 	imageServiceOverride   internalapi.ImageManagerService

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 
 	"sigs.k8s.io/cri-tools/pkg/common"
 	"sigs.k8s.io/cri-tools/pkg/framework"
@@ -217,6 +219,20 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("init tracing: %w", err)
 			}
+
+			// Start a root span named after the invoked command so that all
+			// command operations are recorded as children of it. The span is
+			// ended in main() once app.Run returns.
+			spanName := "crictl"
+			if context.Args().Present() {
+				spanName = context.Args().First()
+			}
+
+			ctx, span := cfg.TracerProvider.Tracer("sigs.k8s.io/cri-tools/cmd/crictl").Start(context.Context, spanName)
+			cfg.RootSpan = span
+			cfg.RootSpan.SetAttributes(attribute.String("command", spanName))
+
+			context.Context = ctx
 		}
 
 		context.App.Metadata[configKey] = cfg
@@ -258,20 +274,34 @@ func main() {
 
 	sort.Sort(cli.FlagsByName(app.Flags))
 
-	if err := app.Run(os.Args); err != nil {
-		logrus.Fatal(err)
-	}
+	err := app.Run(os.Args)
 
-	// Ensure that all spans are processed.
+	// Record the command result on the root span and ensure that all spans are
+	// processed before exiting.
 	if v, ok := app.Metadata[configKey]; ok {
 		cfg, _ := v.(*CrictlConfig)
-		if cfg.TracerProvider != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
-			defer cancel()
+		if cfg != nil {
+			if err != nil && cfg.RootSpan != nil {
+				cfg.RootSpan.SetStatus(codes.Error, err.Error())
+				cfg.RootSpan.RecordError(err)
+			}
 
-			if err := cfg.TracerProvider.Shutdown(ctx); err != nil {
-				logrus.Errorf("Unable to shutdown tracer provider: %v", err)
+			if cfg.RootSpan != nil {
+				cfg.RootSpan.End()
+			}
+
+			if cfg.TracerProvider != nil {
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
+				defer cancel()
+
+				if shutdownErr := cfg.TracerProvider.Shutdown(shutdownCtx); shutdownErr != nil {
+					logrus.Errorf("Unable to shutdown tracer provider: %v", shutdownErr)
+				}
 			}
 		}
+	}
+
+	if err != nil {
+		logrus.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.opentelemetry.io/proto/otlp v1.10.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
@@ -74,7 +75,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.65.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect

--- a/test/e2e/tracing_test.go
+++ b/test/e2e/tracing_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// findSpan returns the first span whose name matches the given predicate.
+func findSpan(spans []*v1.Span, match func(string) bool) *v1.Span {
+	for _, span := range spans {
+		if match(span.GetName()) {
+			return span
+		}
+	}
+
+	return nil
+}
+
+// runTracedCommand runs a crictl command with tracing, waits for spans to
+// arrive, and returns the collected spans along with the root span. If
+// requireSuccess is true and the command exits non-zero, the test is skipped
+// with a detailed message.
+func runTracedCommand(command string, requireSuccess bool) (spans []*v1.Span, root *v1.Span) {
+	res := t.CrictlWithTracing(command)
+
+	if requireSuccess && res.ExitCode() != 0 {
+		Skip("crictl " + command + " failed (likely no runtime access); " +
+			"expected exit code 0 to verify child spans, " +
+			"but got non-zero — skipping child span assertions")
+	}
+
+	Eventually(func() int {
+		return len(t.OtelCollector.GetSpans())
+	}, "5s", "100ms").Should(BeNumerically(">", 0))
+
+	spans = t.OtelCollector.GetSpans()
+	root = findSpan(spans, func(name string) bool { return name == command })
+
+	Expect(root).NotTo(BeNil(), "Root span '%s' not found", command)
+
+	return spans, root
+}
+
+var _ = t.Describe("tracing", func() {
+	It("should generate spans for version command", func() {
+		runTracedCommand("version", false)
+	})
+
+	It("should generate child spans for pods command", func() {
+		spans, rootSpan := runTracedCommand("pods", true)
+
+		childSpan := findSpan(spans, func(name string) bool {
+			return strings.Contains(name, "ListPodSandbox")
+		})
+		Expect(childSpan).NotTo(BeNil(), "Child span 'ListPodSandbox' not found")
+		Expect(bytes.Equal(rootSpan.GetTraceId(), childSpan.GetTraceId())).To(BeTrue(),
+			"Root span and child span should have the same trace ID")
+		Expect(bytes.Equal(childSpan.GetParentSpanId(), rootSpan.GetSpanId())).To(BeTrue(),
+			"Child span should have root span as parent")
+	})
+
+	It("should generate Version gRPC span as a child of the root span", func() {
+		spans, rootSpan := runTracedCommand("version", true)
+
+		versionChild := findSpan(spans, func(name string) bool {
+			return strings.Contains(name, "runtime.v1.RuntimeService/Version")
+		})
+		Expect(versionChild).NotTo(BeNil(), "Child span for Version API not found")
+		Expect(bytes.Equal(versionChild.GetParentSpanId(), rootSpan.GetSpanId())).To(BeTrue(),
+			"Version child span should have root span as parent")
+		Expect(bytes.Equal(versionChild.GetTraceId(), rootSpan.GetTraceId())).To(BeTrue(),
+			"Version child span should share the same trace ID as root span")
+	})
+})

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -42,7 +42,9 @@ func init() {
 }
 
 // TestFramework is used to support commonly used test features.
-type TestFramework struct{}
+type TestFramework struct {
+	OtelCollector *OtelCollector
+}
 
 // NewTestFramework creates a new test framework instance.
 func NewTestFramework() *TestFramework {
@@ -60,6 +62,9 @@ func (t *TestFramework) Setup() {
 // Teardown is the global deinitialization function which runs after each test
 // suite.
 func (t *TestFramework) Teardown() {
+	if t.OtelCollector != nil {
+		t.OtelCollector.Stop()
+	}
 }
 
 // Describe is a convenience wrapper around the `ginkgo.Describe` function.
@@ -111,6 +116,21 @@ func (t *TestFramework) Crictl(args string) *Session {
 // CrictlNoWait runs crictl on the specified endpoint and returns the resulting session without wait.
 func (t *TestFramework) CrictlNoWait(args string) *Session {
 	return lcmd("%s%s %s", crictlBinaryPathFlag(), crictlRuntimeEndpointFlag(), args)
+}
+
+// CrictlWithTracing runs crictl with tracing enabled and returns the resulting session.
+// The OtelCollector is started lazily on the first call.
+func (t *TestFramework) CrictlWithTracing(args string) *Session {
+	if t.OtelCollector == nil {
+		t.OtelCollector = NewOtelCollector()
+		Expect(t.OtelCollector.Start()).To(Succeed())
+	}
+
+	t.OtelCollector.ClearSpans()
+	tracingArgs := fmt.Sprintf("--enable-tracing --tracing-endpoint=%s %s",
+		t.OtelCollector.GetEndpoint(), args)
+
+	return t.Crictl(tracingArgs)
 }
 
 // CrictlExpect runs crictl and expects exit, expectedOut, expectedErr.

--- a/test/framework/otel_collector.go
+++ b/test/framework/otel_collector.go
@@ -1,0 +1,119 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc"
+)
+
+// OtelCollector is a simple OTLP gRPC collector for testing.
+type OtelCollector struct {
+	coltracepb.UnimplementedTraceServiceServer
+
+	mu    sync.Mutex
+	spans []*v1.Span
+	port  int
+	srv   *grpc.Server
+}
+
+// NewOtelCollector creates a new OtelCollector.
+func NewOtelCollector() *OtelCollector {
+	return &OtelCollector{
+		spans: []*v1.Span{},
+	}
+}
+
+// Start starts the collector on a random port.
+func (c *OtelCollector) Start() error {
+	lc := net.ListenConfig{}
+
+	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("failed to listen: %w", err)
+	}
+
+	addr, ok := lis.Addr().(*net.TCPAddr)
+	if !ok {
+		return errors.New("failed to get TCP address")
+	}
+
+	c.port = addr.Port
+
+	c.srv = grpc.NewServer()
+	coltracepb.RegisterTraceServiceServer(c.srv, c)
+
+	go func() {
+		if err := c.srv.Serve(lis); err != nil {
+			fmt.Printf("Collector stopped: %v\n", err)
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the collector.
+func (c *OtelCollector) Stop() {
+	if c.srv != nil {
+		c.srv.Stop()
+	}
+}
+
+// Export implements the OTLP trace service.
+func (c *OtelCollector) Export(ctx context.Context, req *coltracepb.ExportTraceServiceRequest) (*coltracepb.ExportTraceServiceResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, rs := range req.GetResourceSpans() {
+		for _, ss := range rs.GetScopeSpans() {
+			c.spans = append(c.spans, ss.GetSpans()...)
+		}
+	}
+
+	return &coltracepb.ExportTraceServiceResponse{}, nil
+}
+
+// GetSpans returns the collected spans.
+func (c *OtelCollector) GetSpans() []*v1.Span {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	res := make([]*v1.Span, len(c.spans))
+	copy(res, c.spans)
+
+	return res
+}
+
+// ClearSpans clears the collected spans.
+func (c *OtelCollector) ClearSpans() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.spans = []*v1.Span{}
+}
+
+// GetEndpoint returns the collector endpoint.
+func (c *OtelCollector) GetEndpoint() string {
+	return fmt.Sprintf("127.0.0.1:%d", c.port)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a root span to combine all commands executed during the single execution. It also catches "failed" calls.

#### Special notes for your reviewer:


The command without sudo - shows error span:

```sh
 ./build/bin/linux/amd64/crictl --enable-tracing pods
```
<img width="1633" height="636" alt="image" src="https://github.com/user-attachments/assets/b3767c50-f0c9-4d0e-a946-0fe4d27067c7" />

With sudo - shows good a single span for multiple commands:

```sh
sudo ./build/bin/linux/amd64/crictl --enable-tracing pods
```

<img width="1485" height="593" alt="image" src="https://github.com/user-attachments/assets/fffa89b1-5c69-4966-802c-2c50d878ef83" />


```sh
 sudo ./build/bin/linux/amd64/crictl  --enable-tracing inspecti busybox registry.k8s.io/pause
```

<img width="1462" height="813" alt="image" src="https://github.com/user-attachments/assets/502c605d-b6c1-417c-b9a4-27b545aa3466" />

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
opentelemetry tracing will have a root span for each execution that combines together all gRPC calls crictl makes to runttime during execution
```
