### PR TITLE
bump go tp 1.26.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -7,7 +7,7 @@ dependencies:
         match: VERSION
 
   - name: go
-    version: 1.26
+    version: 1.26.2
     refPaths:
       - path: go.mod
         match: go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cri-tools
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/distribution/reference v0.6.0


### PR DESCRIPTION
/kind cleanup

containerd bumped to 1.26.2 and now CI fails. This should fix it

```release-note
NONE
```
