### PR TITLE
refactor: move linux-specific validation code to separate files

### DIFF
--- a/pkg/validate/consts.go
+++ b/pkg/validate/consts.go
@@ -198,27 +198,21 @@ const (
 	defaultDNSOption       string = "ndots:8"
 	webServerContainerPort int32  = 80
 	// The following host ports must not be in-use when running the test.
-	webServerHostPortForPortMapping        int32 = 12000
-	webServerHostPortForPortForward        int32 = 12001
-	webServerHostPortForHostNetPortFroward int32 = 12002
-	// The port used in hostNetNginxImage (See images/hostnet-nginx/).
-	webServerHostNetContainerPort int32 = 12003
+	webServerHostPortForPortMapping int32 = 12000
+	webServerHostPortForPortForward int32 = 12001
 
 	// Linux defaults.
-	webServerLinuxImage        = framework.DefaultRegistryE2ETestImagesPrefix + "nginx:1.14-2"
-	hostNetWebServerLinuxImage = registry + "hostnet-nginx-" + runtime.GOARCH
+	webServerLinuxImage = framework.DefaultRegistryE2ETestImagesPrefix + "nginx:1.14-2"
 
 	// Windows defaults.
-	webServerWindowsImage        = webServerLinuxImage
-	hostNetWebServerWindowsImage = webServerLinuxImage
+	webServerWindowsImage = webServerLinuxImage
 )
 
 var (
-	webServerImage        string
-	hostNetWebServerImage string
-	getDNSConfigCmd       []string
-	getDNSConfigContent   []string
-	getHostnameCmd        []string
+	webServerImage      string
+	getDNSConfigCmd     []string
+	getDNSConfigContent []string
+	getHostnameCmd      []string
 
 	// Linux defaults.
 	getDNSConfigLinuxCmd     = []string{"cat", resolvConfigPath}
@@ -243,13 +237,11 @@ var (
 var _ = framework.AddBeforeSuiteCallback(func() {
 	if runtime.GOOS != framework.OSWindows || framework.TestContext.IsLcow {
 		webServerImage = webServerLinuxImage
-		hostNetWebServerImage = hostNetWebServerLinuxImage
 		getDNSConfigCmd = getDNSConfigLinuxCmd
 		getDNSConfigContent = getDNSConfigLinuxContent
 		getHostnameCmd = getHostnameLinuxCmd
 	} else {
 		webServerImage = webServerWindowsImage
-		hostNetWebServerImage = hostNetWebServerWindowsImage
 		getDNSConfigCmd = getDNSConfigWindowsCmd
 		getDNSConfigContent = getDNSConfigWindowsContent
 		getHostnameCmd = getHostnameWindowsCmd

--- a/pkg/validate/consts_linux.go
+++ b/pkg/validate/consts_linux.go
@@ -1,0 +1,31 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validate
+
+import (
+	"runtime"
+)
+
+const (
+	// The port used in hostNetNginxImage (See images/hostnet-nginx/).
+	webServerHostNetContainerPort int32 = 12003
+
+	// The host port for hostnet port-forward tests; only used on Linux.
+	webServerHostPortForHostNetPortForward int32 = 12002
+)
+
+const hostNetWebServerImage = registry + "hostnet-nginx-" + runtime.GOARCH

--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -762,25 +761,6 @@ func verifyLogContents(ctx context.Context, podConfig *runtimeapi.PodSandboxConf
 	}
 
 	Expect(found).To(BeTrue(), "expected log %q (stream=%q) not found in logs %+v", log, stream, msgs)
-}
-
-// verifyLogContentsRe verifies the contents of container log using the provided regular expression pattern.
-func verifyLogContentsRe(ctx context.Context, podConfig *runtimeapi.PodSandboxConfig, logPath, pattern string, stream streamType) {
-	By("verify log contents using regex pattern")
-
-	msgs := parseLogLine(ctx, podConfig, logPath)
-
-	found := false
-
-	for _, msg := range msgs {
-		if matched, _ := regexp.MatchString(pattern, msg.log); matched && msg.stream == stream {
-			found = true
-
-			break
-		}
-	}
-
-	Expect(found).To(BeTrue(), "expected log pattern %q (stream=%q) to match logs %+v", pattern, stream, msgs)
 }
 
 // listContainerStatsForID lists container for containerID.

--- a/pkg/validate/container_linux.go
+++ b/pkg/validate/container_linux.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -552,4 +553,26 @@ func createMountContainer(
 	Expect(resp.GetStatus().GetMounts()).To(HaveLen(len(mounts)))
 
 	return containerID
+}
+
+// verifyLogContentsRe verifies the contents of container log using the provided regular expression pattern.
+func verifyLogContentsRe(ctx context.Context, podConfig *runtimeapi.PodSandboxConfig, logPath, pattern string, stream streamType) {
+	By("verify log contents using regex pattern")
+
+	msgs := parseLogLine(ctx, podConfig, logPath)
+
+	found := false
+
+	re, err := regexp.Compile(pattern)
+	Expect(err).NotTo(HaveOccurred(), "invalid regex pattern %q", pattern)
+
+	for _, msg := range msgs {
+		if re.MatchString(msg.log) && msg.stream == stream {
+			found = true
+
+			break
+		}
+	}
+
+	Expect(found).To(BeTrue(), "expected log pattern %q (stream=%q) to match logs %+v", pattern, stream, msgs)
 }

--- a/pkg/validate/networking.go
+++ b/pkg/validate/networking.go
@@ -251,18 +251,6 @@ func createWebServerContainer(ctx context.Context, rc internalapi.RuntimeService
 	return framework.CreateContainer(ctx, rc, ic, containerConfig, podID, podConfig)
 }
 
-// createHostNetWebServerContainer creates a web server container using webServerHostNetContainerPort.
-func createHostNetWebServerContainer(ctx context.Context, rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, prefix string) string {
-	containerName := prefix + framework.NewUUID()
-	containerConfig := &runtimeapi.ContainerConfig{
-		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
-		Image:    &runtimeapi.ImageSpec{Image: hostNetWebServerImage},
-		Linux:    &runtimeapi.LinuxContainerConfig{},
-	}
-
-	return framework.CreateContainer(ctx, rc, ic, containerConfig, podID, podConfig)
-}
-
 // checkMainPage check if the we can get the main page of the pod via given IP:port.
 func checkMainPage(ctx context.Context, c internalapi.RuntimeService, podID string, hostPort, containerPort int32) {
 	By("get the IP:port needed to be checked")

--- a/pkg/validate/networking_linux.go
+++ b/pkg/validate/networking_linux.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validate
+
+import (
+	"context"
+
+	internalapi "k8s.io/cri-api/pkg/apis"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	"sigs.k8s.io/cri-tools/pkg/framework"
+)
+
+// createHostNetWebServerContainer creates a web server container using hostNetWebServerImage.
+func createHostNetWebServerContainer(ctx context.Context, rc internalapi.RuntimeService, ic internalapi.ImageManagerService, podID string, podConfig *runtimeapi.PodSandboxConfig, prefix string) string {
+	containerName := prefix + framework.NewUUID()
+	containerConfig := &runtimeapi.ContainerConfig{
+		Metadata: framework.BuildContainerMetadata(containerName, framework.DefaultAttempt),
+		Image:    &runtimeapi.ImageSpec{Image: hostNetWebServerImage},
+		Linux:    &runtimeapi.LinuxContainerConfig{},
+	}
+
+	return framework.CreateContainer(ctx, rc, ic, containerConfig, podID, podConfig)
+}

--- a/pkg/validate/streaming_linux.go
+++ b/pkg/validate/streaming_linux.go
@@ -73,7 +73,7 @@ var _ = framework.KubeDescribe("Streaming", func() {
 			req := createDefaultPortForward(ctx, rc, podID)
 
 			By("check the output of portforward")
-			checkPortForward(ctx, rc, req, webServerHostPortForHostNetPortFroward, webServerHostNetContainerPort)
+			checkPortForward(ctx, rc, req, webServerHostPortForHostNetPortForward, webServerHostNetContainerPort)
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Random clean up to remove warnings on build for "unused" things.

Also pre-compiled the regex in `verifyLogContentsRe ` so all logs are matched against precompiled version of it. If patter is wrong, the function will fail now.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
