### PR TITLE
fix typo: intead -> instead

### DIFF
--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -58,7 +58,7 @@ jobs:
           sudo mkdir -p /etc/crio/crio.conf.d
           printf '[crio.runtime]\nlog_level = "debug"\n[crio.image]\nshort_name_mode = "disabled"\n' | sudo tee /etc/crio/crio.conf.d/01-log-level.conf
 
-      - name: Configure CRI-O to use conmon-rs intead of the default conmon
+      - name: Configure CRI-O to use conmon-rs instead of the default conmon
         if: ${{matrix.monitor == 'conmon-rs'}}
         run: |
           sudo sed -i -E 's;(monitor_path = ).*;\1"/usr/libexec/crio/conmonrs"\nruntime_type = "pod";g' /etc/crio/crio.conf.d/10-crio.conf


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Otherwise typo job fails: https://github.com/kubernetes-sigs/cri-tools/pull/2043

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
