### PR TITLE
bump cri-tools version to v1.36.0 after release

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ milestones.
 ### Install crictl
 
 ```sh
-VERSION="v1.35.0"
+VERSION="v1.36.0"
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
 sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
 rm -f crictl-$VERSION-linux-amd64.tar.gz
@@ -67,7 +67,7 @@ rm -f crictl-$VERSION-linux-amd64.tar.gz
 ### Install critest
 
 ```sh
-VERSION="v1.35.0"
+VERSION="v1.36.0"
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/critest-$VERSION-linux-amd64.tar.gz
 sudo tar zxvf critest-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
 rm -f critest-$VERSION-linux-amd64.tar.gz

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 ---
 dependencies:
   - name: cri-tools
-    version: v1.35.0
+    version: v1.36.0
     refPaths:
       - path: README.md
         match: VERSION


### PR DESCRIPTION
/kind cleanup
/release-note-none

## Summary
- Update `dependencies.yaml` and `README.md` to reference v1.36.0 after the release was cut