### PR TITLE
Improve agent docs and fix zeitgeist for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ CLAUDE.md
 .*/
 # Except:
 !.github/
+!.skills/
 

--- a/.skills/after-release.md
+++ b/.skills/after-release.md
@@ -1,0 +1,62 @@
+## After release branch updates
+
+You are the release manager who needs to update the master branch after release was created.
+
+If asked to update the branch after release, follow the instructions and produce the release report.
+
+### 1. Identify the release
+
+- [ ] Ensure the working tree is clean (no uncommitted changes), switch to master branch, fetch all, and reset to `upstream/master`
+- [ ] Identify the latest release by finding the latest tag like `vX.XX.0`
+- [ ] Confirm with the user if this is the release that branch needs to be updated for
+
+### 2. Make the branch consistent
+
+- [ ] Create a working branch: `git checkout -b release-1.XX-after-release master`
+- [ ] `dependencies.yaml`: update `cri-tools` version to the release version
+- [ ] `README.md`: update `VERSION="vX.XX.0"` in install examples (both crictl and critest sections)
+- [ ] Validate that the corresponding binary is available for download: `gh release view vX.XX.0 --repo kubernetes-sigs/cri-tools --json assets`
+- [ ] Run `make verify` to check for issues
+
+### 3. Create PR and fix CI failures
+
+- [ ] Push the branch to origin
+- [ ] Create a PR against `master` using `gh pr create` with `/kind cleanup` and `/release-note-none` tags in the body
+- [ ] Wait for CI runs
+- [ ] Review CI results and fix if needed
+
+### 4. Create PR for Kubernetes repository
+
+This step updates the cri-tools version in the main Kubernetes repository (similar to https://github.com/kubernetes/kubernetes/pull/138613).
+
+Prerequisites: You need a fork of `kubernetes/kubernetes` or push access to create a branch.
+
+- [ ] Clone or navigate to your fork of `kubernetes/kubernetes`
+- [ ] Ensure the working tree is clean (no uncommitted changes), then create a branch: `git checkout -b cri-tools-1.XX upstream/master`
+- [ ] Read `build/dependencies.yaml` and find the `crictl` entry — its `refPaths` list all files and match patterns that need updating
+- [ ] Update `build/dependencies.yaml`: set `crictl` version to `1.XX.0`
+- [ ] Update all files referenced in `refPaths` for the `crictl` dependency, updating version strings and sha512 hashes as needed
+- [ ] Get sha512 hashes from the release checksum files (e.g., `crictl-vX.XX.0-linux-amd64.tar.gz.sha512`) available as release assets
+- [ ] Push the branch and create a PR:
+
+  ```
+  gh pr create --repo kubernetes/kubernetes --base master \
+    --title "Update cri-tools to vX.XX.0" \
+    --body "#### What type of PR is this?
+  /kind feature
+
+  #### What this PR does / why we need it:
+  Update cri-tools (crictl) to vX.XX.0.
+
+  #### Which issue(s) this PR is related to:
+  N/A
+
+  #### Special notes for your reviewer:
+
+  #### Does this PR introduce a user-facing change?
+  \`\`\`release-note
+  Updated cri-tools to vX.XX.0.
+  \`\`\`"
+  ```
+
+- [ ] Wait for CI and address reviewer feedback

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,7 @@ The project uses `make` for building and running tests.
 
 ### Validation
 
-Before completing any task, agents **must** verify their changes by running the following commands:
-
-1. **Linter**: `make verify-lint`
-2. **Formatting**: `make verify-prettier`
-3. **Tests**: Ensure relevant tests pass (see the [Testing](#testing) section).
+Before completing any task, agents **must** verify their changes by running `make verify` and ensuring relevant tests pass (see the [Testing](#testing) section).
 
 Failure to run these checks may result in CI failures.
 
@@ -126,3 +122,7 @@ The project's CI/CD pipeline is defined in the `.github/workflows` directory. Th
 ### Containerd Workflow
 
 The `containerd.yml` workflow runs tests against different versions of `containerd` on both Linux and Windows. It also tests against different runtimes and CNI configurations.
+
+## Skills
+
+- [After Release](.skills/after-release.md) — Update the master branch after a release is created

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ verify-dependencies: $(BUILD_BIN_PATH)/zeitgeist ## Verify third party dependenc
 	$(ZEITGEIST) validate --local-only --base-path . --config dependencies.yaml
 
 $(ZEITGEIST): $(BUILD_BIN_PATH)
-	$(call curl_to,https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes-sigs/zeitgeist/$(ZEITGEIST_VERSION)/zeitgeist-amd64-linux,$(ZEITGEIST))
+	$(call curl_to,https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes-sigs/zeitgeist/$(ZEITGEIST_VERSION)/zeitgeist-$(GOARCH)-$(GOOS),$(ZEITGEIST))
 
 .PHONY: verify-go-modules
 verify-go-modules: ## Verify vendored golang modules.


### PR DESCRIPTION
Continue experimenting with AI tools. The https://github.com/kubernetes-sigs/cri-tools/pull/2060 was made by this skill. And the same time it documents what needs to happen after release

/kind cleanup
/release-note-none

## Summary
- Simplify AGENTS.md validation instructions to just `make verify`
- Add after-release skill with step-by-step checklist for updating master after a release
- Allow `.skills/` directory in `.gitignore`
- Fix `make verify-dependencies` to download platform-specific zeitgeist binary instead of hardcoded `zeitgeist-amd64-linux`
