### PR TITLE
ci: declare contents: read across the 4 remaining workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   images:
     runs-on: ubuntu-latest

--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   #
   # Run CRI tests against containerd

--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ on:
   push:
     tags:
       - "*"
+# `make release-notes release` and ncipollo/release-action authenticate via
+# secrets.GH_TOKEN; the default GITHUB_TOKEN only needs read access.
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: release


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only on the four workflows still inheriting org defaults:

- `build.yml` — image build + linter matrix.
- `containerd.yml` — runs the CRI test suite against containerd shims.
- `crio.yml` — runs e2e + critest against CRI-O.
- `release.yml` — `make release-notes release` and `ncipollo/release-action` authenticate via `secrets.GH_TOKEN` (a dedicated PAT), so the default `GITHUB_TOKEN` only needs read.

YAML validated locally.