### PR TITLE
crictl: encapsulate global config and add client injection for testability

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -81,7 +81,7 @@ var runtimeAttachCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -217,11 +217,12 @@ var createContainerCommand = &cli.Command{
 			return errors.New("conflict: no-pull and with-pull are both set")
 		}
 
-		withPull := (!c.Bool("no-pull") && PullImageOnCreate) || c.Bool("with-pull")
+		cfg := configFromContext(c)
+		withPull := (!c.Bool("no-pull") && cfg.PullImageOnCreate) || c.Bool("with-pull")
 
 		var imageClient internalapi.ImageManagerService
 		if withPull {
-			imageClient, err = getImageService(c)
+			imageClient, err = cfg.GetImageService(c.Context)
 			if err != nil {
 				return err
 			}
@@ -243,7 +244,7 @@ var createContainerCommand = &cli.Command{
 			},
 		}
 
-		runtimeClient, err := getRuntimeService(c, opts.timeout)
+		runtimeClient, err := cfg.GetRuntimeService(c.Context, opts.timeout)
 		if err != nil {
 			return err
 		}
@@ -268,7 +269,7 @@ var startContainerCommand = &cli.Command{
 			return errors.New("ID cannot be empty")
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}
@@ -331,7 +332,7 @@ var updateContainerCommand = &cli.Command{
 			return errors.New("ID cannot be empty")
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}
@@ -377,7 +378,7 @@ var stopContainerCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}
@@ -449,7 +450,7 @@ var removeContainerCommand = &cli.Command{
 		},
 	},
 	Action: func(ctx *cli.Context) error {
-		runtimeClient, err := getRuntimeService(ctx, 0)
+		runtimeClient, err := configFromContext(ctx).GetRuntimeService(ctx.Context, 0)
 		if err != nil {
 			return err
 		}
@@ -591,12 +592,14 @@ var containerStatusCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		runtimeClient, err := getRuntimeService(c, 0)
+		cfg := configFromContext(c)
+
+		runtimeClient, err := cfg.GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}
 
-		imageClient, err := getImageService(c)
+		imageClient, err := cfg.GetImageService(c.Context)
 		if err != nil {
 			return err
 		}
@@ -732,12 +735,14 @@ var listContainersCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		cfg := configFromContext(c)
+
+		runtimeClient, err := cfg.GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}
 
-		imageClient, err := getImageService(c)
+		imageClient, err := cfg.GetImageService(c.Context)
 		if err != nil {
 			return err
 		}
@@ -787,11 +792,12 @@ var runContainerCommand = &cli.Command{
 			return errors.New("conflict: no-pull and with-pull are both set")
 		}
 
-		withPull := (!DisablePullOnRun && !c.Bool("no-pull")) || c.Bool("with-pull")
+		cfg := configFromContext(c)
+		withPull := (!cfg.DisablePullOnRun && !c.Bool("no-pull")) || c.Bool("with-pull")
 
 		var imageClient internalapi.ImageManagerService
 		if withPull {
-			imageClient, err = getImageService(c)
+			imageClient, err = cfg.GetImageService(c.Context)
 			if err != nil {
 				return err
 			}
@@ -810,7 +816,7 @@ var runContainerCommand = &cli.Command{
 			timeout: c.Duration("cancel-timeout"),
 		}
 
-		runtimeClient, err := getRuntimeService(c, opts.timeout)
+		runtimeClient, err := cfg.GetRuntimeService(c.Context, opts.timeout)
 		if err != nil {
 			return err
 		}
@@ -847,7 +853,7 @@ var checkpointContainerCommand = &cli.Command{
 			)
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/container_stats.go
+++ b/cmd/crictl/container_stats.go
@@ -94,7 +94,7 @@ var statsCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/crictl_config.go
+++ b/cmd/crictl/crictl_config.go
@@ -1,0 +1,246 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	internalapi "k8s.io/cri-api/pkg/apis"
+	remote "k8s.io/cri-client/pkg"
+
+	"sigs.k8s.io/cri-tools/pkg/common"
+)
+
+const configKey = "crictl-config"
+
+func newCrictlConfig(ctx *cli.Context, config *common.ServerConfiguration) *CrictlConfig {
+	cfg := &CrictlConfig{}
+
+	if config == nil {
+		cfg.RuntimeEndpoint = ctx.String("runtime-endpoint")
+
+		if ctx.IsSet("runtime-endpoint") {
+			cfg.RuntimeEndpointIsSet = true
+		}
+
+		cfg.ImageEndpoint = ctx.String("image-endpoint")
+
+		if ctx.IsSet("image-endpoint") {
+			cfg.ImageEndpointIsSet = true
+		}
+
+		if ctx.IsSet("timeout") {
+			cfg.Timeout = getTimeout(ctx.Duration("timeout"))
+		} else {
+			cfg.Timeout = ctx.Duration("timeout")
+		}
+
+		cfg.Debug = ctx.Bool("debug")
+		cfg.DisablePullOnRun = false
+	} else {
+		// Command line flags overrides config file.
+		if ctx.IsSet("runtime-endpoint") { //nolint:gocritic
+			cfg.RuntimeEndpoint = ctx.String("runtime-endpoint")
+			cfg.RuntimeEndpointIsSet = true
+		} else if config.RuntimeEndpoint != "" {
+			cfg.RuntimeEndpoint = config.RuntimeEndpoint
+			cfg.RuntimeEndpointIsSet = true
+		} else {
+			cfg.RuntimeEndpoint = ctx.String("runtime-endpoint")
+		}
+
+		if ctx.IsSet("image-endpoint") { //nolint:gocritic
+			cfg.ImageEndpoint = ctx.String("image-endpoint")
+			cfg.ImageEndpointIsSet = true
+		} else if config.ImageEndpoint != "" {
+			cfg.ImageEndpoint = config.ImageEndpoint
+			cfg.ImageEndpointIsSet = true
+		} else {
+			cfg.ImageEndpoint = ctx.String("image-endpoint")
+		}
+
+		if ctx.IsSet("timeout") { //nolint:gocritic
+			cfg.Timeout = getTimeout(ctx.Duration("timeout"))
+		} else if config.Timeout > 0 { // 0/neg value set to default timeout
+			cfg.Timeout = config.Timeout
+		} else {
+			cfg.Timeout = ctx.Duration("timeout")
+		}
+
+		if ctx.IsSet("debug") {
+			cfg.Debug = ctx.Bool("debug")
+		} else {
+			cfg.Debug = config.Debug
+		}
+
+		cfg.PullImageOnCreate = config.PullImageOnCreate
+		cfg.DisablePullOnRun = config.DisablePullOnRun
+	}
+
+	if cfg.Debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	return cfg
+}
+
+// CrictlConfig holds all resolved runtime configuration for a crictl session.
+type CrictlConfig struct {
+	RuntimeEndpoint      string
+	RuntimeEndpointIsSet bool
+	ImageEndpoint        string
+	ImageEndpointIsSet   bool
+	Timeout              time.Duration
+	Debug                bool
+	PullImageOnCreate    bool
+	DisablePullOnRun     bool
+	TracerProvider       *sdktrace.TracerProvider
+
+	runtimeServiceOverride internalapi.RuntimeService
+	imageServiceOverride   internalapi.ImageManagerService
+}
+
+func configFromContext(ctx *cli.Context) *CrictlConfig {
+	cfg, _ := ctx.App.Metadata[configKey].(*CrictlConfig)
+
+	return cfg
+}
+
+// GetRuntimeService returns the runtime service client. If an override is set
+// (for testing), it is returned directly. Otherwise a new gRPC connection is
+// created using the configured endpoint and timeout.
+func (cfg *CrictlConfig) GetRuntimeService(ctx context.Context, timeout time.Duration) (internalapi.RuntimeService, error) {
+	if cfg.runtimeServiceOverride != nil {
+		return cfg.runtimeServiceOverride, nil
+	}
+
+	if cfg.RuntimeEndpointIsSet && cfg.RuntimeEndpoint == "" {
+		return nil, errors.New("--runtime-endpoint is not set")
+	}
+
+	logrus.Debug("Get runtime connection")
+
+	t := cfg.Timeout
+	if timeout != 0 {
+		t = timeout
+	}
+
+	logrus.Debugf("Using runtime connection timeout: %v", t)
+
+	var tp trace.TracerProvider = noop.NewTracerProvider()
+	if cfg.TracerProvider != nil {
+		tp = cfg.TracerProvider
+	}
+
+	if !cfg.RuntimeEndpointIsSet {
+		logrus.Warningf("runtime connect using default endpoints: %v. "+
+			"As the default settings are now deprecated, you should set the "+
+			"endpoint instead.", defaultRuntimeEndpoints)
+		logrus.Debug("Note that performance maybe affected as each default " +
+			"connection attempt takes n-seconds to complete before timing out " +
+			"and going to the next in sequence.")
+
+		var (
+			res internalapi.RuntimeService
+			err error
+		)
+
+		for _, endPoint := range defaultRuntimeEndpoints {
+			logrus.Debugf("Connect using endpoint %q with %q timeout", endPoint, t)
+
+			res, err = remote.NewRemoteRuntimeService(ctx, endPoint, t, tp, false)
+			if err != nil {
+				logrus.Error(err)
+
+				continue
+			}
+
+			logrus.Debugf("Connected successfully using endpoint: %s", endPoint)
+
+			break
+		}
+
+		return res, err
+	}
+
+	return remote.NewRemoteRuntimeService(ctx, cfg.RuntimeEndpoint, t, tp, false)
+}
+
+// GetImageService returns the image service client. If an override is set
+// (for testing), it is returned directly. Otherwise a new gRPC connection is
+// created using the configured endpoint and timeout.
+func (cfg *CrictlConfig) GetImageService(ctx context.Context) (internalapi.ImageManagerService, error) {
+	if cfg.imageServiceOverride != nil {
+		return cfg.imageServiceOverride, nil
+	}
+
+	if cfg.ImageEndpoint == "" {
+		if cfg.RuntimeEndpointIsSet && cfg.RuntimeEndpoint == "" {
+			return nil, errors.New("--image-endpoint is not set")
+		}
+
+		cfg.ImageEndpoint = cfg.RuntimeEndpoint
+		cfg.ImageEndpointIsSet = cfg.RuntimeEndpointIsSet
+	}
+
+	logrus.Debug("Get image connection")
+
+	var tp trace.TracerProvider = noop.NewTracerProvider()
+	if cfg.TracerProvider != nil {
+		tp = cfg.TracerProvider
+	}
+
+	if !cfg.ImageEndpointIsSet {
+		logrus.Warningf("Image connect using default endpoints: %v. "+
+			"As the default settings are now deprecated, you should set the "+
+			"endpoint instead.", defaultRuntimeEndpoints)
+		logrus.Debug("Note that performance maybe affected as each default " +
+			"connection attempt takes n-seconds to complete before timing out " +
+			"and going to the next in sequence.")
+
+		var (
+			res internalapi.ImageManagerService
+			err error
+		)
+
+		for _, endPoint := range defaultRuntimeEndpoints {
+			logrus.Debugf("Connect using endpoint %q with %q timeout", endPoint, cfg.Timeout)
+
+			res, err = remote.NewRemoteImageService(ctx, endPoint, cfg.Timeout, tp, false)
+			if err != nil {
+				logrus.Error(err)
+
+				continue
+			}
+
+			logrus.Debugf("Connected successfully using endpoint: %s", endPoint)
+
+			break
+		}
+
+		return res, err
+	}
+
+	return remote.NewRemoteImageService(ctx, cfg.ImageEndpoint, cfg.Timeout, tp, false)
+}

--- a/cmd/crictl/events.go
+++ b/cmd/crictl/events.go
@@ -63,7 +63,7 @@ var eventsCommand = &cli.Command{
 			return fmt.Errorf("don't support %q format", format)
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -148,12 +148,14 @@ var runtimeExecCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		cfg := configFromContext(c)
+
+		runtimeClient, err := cfg.GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}
 
-		imageClient, err := getImageService(c)
+		imageClient, err := cfg.GetImageService(c.Context)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/fake_test.go
+++ b/cmd/crictl/fake_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	internalapi "k8s.io/cri-api/pkg/apis"
+)
+
+func TestConfigOverride(t *testing.T) {
+	t.Parallel()
+
+	cfg := &CrictlConfig{
+		Timeout:                2 * time.Second,
+		runtimeServiceOverride: fakeRuntimeSvc{},
+		imageServiceOverride:   fakeImageSvc{},
+	}
+
+	rs, err := cfg.GetRuntimeService(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := rs.(fakeRuntimeSvc); !ok {
+		t.Fatal("expected fake runtime service override to be returned")
+	}
+
+	is, err := cfg.GetImageService(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := is.(fakeImageSvc); !ok {
+		t.Fatal("expected fake image service override to be returned")
+	}
+}
+
+type fakeRuntimeSvc struct {
+	internalapi.RuntimeService
+}
+
+type fakeImageSvc struct {
+	internalapi.ImageManagerService
+}

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -109,7 +109,7 @@ var pullImageCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		imageClient, err := getImageService(c)
+		imageClient, err := configFromContext(c).GetImageService(c.Context)
 		if err != nil {
 			return err
 		}
@@ -196,7 +196,7 @@ var listImageCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		imageClient, err := getImageService(c)
+		imageClient, err := configFromContext(c).GetImageService(c.Context)
 		if err != nil {
 			return err
 		}
@@ -336,7 +336,7 @@ var imageStatusCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		imageClient, err := getImageService(c)
+		imageClient, err := configFromContext(c).GetImageService(c.Context)
 		if err != nil {
 			return err
 		}
@@ -442,7 +442,9 @@ the specified tag. To remove only a specific tag, use the container runtime's na
 		},
 	},
 	Action: func(cliCtx *cli.Context) error {
-		imageClient, err := getImageService(cliCtx)
+		cfg := configFromContext(cliCtx)
+
+		imageClient, err := cfg.GetImageService(cliCtx.Context)
 		if err != nil {
 			return err
 		}
@@ -481,7 +483,7 @@ the specified tag. To remove only a specific tag, use the container runtime's na
 
 		// On prune, remove images which are in use from the ID selector
 		if prune {
-			runtimeClient, err := getRuntimeService(cliCtx, 0)
+			runtimeClient, err := cfg.GetRuntimeService(cliCtx.Context, 0)
 			if err != nil {
 				return err
 			}
@@ -603,7 +605,7 @@ var imageFsInfoCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		imageClient, err := getImageService(c)
+		imageClient, err := configFromContext(c).GetImageService(c.Context)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -54,7 +54,7 @@ var runtimeStatusCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -117,7 +117,7 @@ var logsCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		runtimeService, err := getRuntimeService(c, 0)
+		runtimeService, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,11 +30,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/trace"
-	"go.opentelemetry.io/otel/trace/noop"
-	internalapi "k8s.io/cri-api/pkg/apis"
-	remote "k8s.io/cri-client/pkg"
 
 	"sigs.k8s.io/cri-tools/pkg/common"
 	"sigs.k8s.io/cri-tools/pkg/framework"
@@ -47,128 +41,6 @@ const (
 	defaultTimeout        = 2 * time.Second
 	defaultTimeoutWindows = 200 * time.Second
 )
-
-var (
-	// RuntimeEndpoint is CRI server runtime endpoint.
-	RuntimeEndpoint string
-	// RuntimeEndpointIsSet is true when RuntimeEndpoint is configured.
-	RuntimeEndpointIsSet bool
-	// ImageEndpoint is CRI server image endpoint, default same as runtime endpoint.
-	ImageEndpoint string
-	// ImageEndpointIsSet is true when ImageEndpoint is configured.
-	ImageEndpointIsSet bool
-	// Timeout  of connecting to server (default: 2s on Linux, 200s on Windows).
-	Timeout time.Duration
-	// Debug enable debug output.
-	Debug bool
-	// PullImageOnCreate enables pulling image on create requests.
-	PullImageOnCreate bool
-	// DisablePullOnRun disable pulling image on run requests.
-	DisablePullOnRun bool
-	// tracerProvider is the global OpenTelemetry tracing instance.
-	tracerProvider *sdktrace.TracerProvider
-)
-
-func getRuntimeService(_ *cli.Context, timeout time.Duration) (res internalapi.RuntimeService, err error) {
-	if RuntimeEndpointIsSet && RuntimeEndpoint == "" {
-		return nil, errors.New("--runtime-endpoint is not set")
-	}
-
-	logrus.Debug("Get runtime connection")
-
-	// Check if a custom timeout is provided.
-	t := Timeout
-	if timeout != 0 {
-		t = timeout
-	}
-
-	logrus.Debugf("Using runtime connection timeout: %v", t)
-
-	// Use the noop tracer provider and not tracerProvider directly, otherwise
-	// we'll panic in the unary call interceptor
-	var tp trace.TracerProvider = noop.NewTracerProvider()
-	if tracerProvider != nil {
-		tp = tracerProvider
-	}
-
-	// If no EP set then use the default endpoint types
-	if !RuntimeEndpointIsSet {
-		logrus.Warningf("runtime connect using default endpoints: %v. "+
-			"As the default settings are now deprecated, you should set the "+
-			"endpoint instead.", defaultRuntimeEndpoints)
-		logrus.Debug("Note that performance maybe affected as each default " +
-			"connection attempt takes n-seconds to complete before timing out " +
-			"and going to the next in sequence.")
-
-		for _, endPoint := range defaultRuntimeEndpoints {
-			logrus.Debugf("Connect using endpoint %q with %q timeout", endPoint, t)
-
-			res, err = remote.NewRemoteRuntimeService(context.Background(), endPoint, t, tp, false)
-			if err != nil {
-				logrus.Error(err)
-
-				continue
-			}
-
-			logrus.Debugf("Connected successfully using endpoint: %s", endPoint)
-
-			break
-		}
-
-		return res, err
-	}
-
-	return remote.NewRemoteRuntimeService(context.Background(), RuntimeEndpoint, t, tp, false)
-}
-
-func getImageService(*cli.Context) (res internalapi.ImageManagerService, err error) {
-	if ImageEndpoint == "" {
-		if RuntimeEndpointIsSet && RuntimeEndpoint == "" {
-			return nil, errors.New("--image-endpoint is not set")
-		}
-
-		ImageEndpoint = RuntimeEndpoint
-		ImageEndpointIsSet = RuntimeEndpointIsSet
-	}
-
-	logrus.Debug("Get image connection")
-
-	// Use the noop tracer provider and not tracerProvider directly, otherwise
-	// we'll panic in the unary call interceptor
-	var tp trace.TracerProvider = noop.NewTracerProvider()
-	if tracerProvider != nil {
-		tp = tracerProvider
-	}
-
-	// If no EP set then use the default endpoint types
-	if !ImageEndpointIsSet {
-		logrus.Warningf("Image connect using default endpoints: %v. "+
-			"As the default settings are now deprecated, you should set the "+
-			"endpoint instead.", defaultRuntimeEndpoints)
-		logrus.Debug("Note that performance maybe affected as each default " +
-			"connection attempt takes n-seconds to complete before timing out " +
-			"and going to the next in sequence.")
-
-		for _, endPoint := range defaultRuntimeEndpoints {
-			logrus.Debugf("Connect using endpoint %q with %q timeout", endPoint, Timeout)
-
-			res, err = remote.NewRemoteImageService(context.Background(), endPoint, Timeout, tp, false)
-			if err != nil {
-				logrus.Error(err)
-
-				continue
-			}
-
-			logrus.Debugf("Connected successfully using endpoint: %s", endPoint)
-
-			break
-		}
-
-		return res, err
-	}
-
-	return remote.NewRemoteImageService(context.Background(), ImageEndpoint, Timeout, tp, false)
-}
 
 func getTimeout(timeDuration time.Duration) time.Duration {
 	if timeDuration.Seconds() > 0 {
@@ -187,6 +59,7 @@ func main() {
 	app.Name = "crictl"
 	app.Usage = "client for CRI"
 	app.Version = version.Version
+	app.Metadata = map[string]any{}
 
 	app.Commands = []*cli.Command{
 		runtimeAttachCommand,
@@ -332,74 +205,11 @@ func main() {
 			}
 		}
 
-		if config == nil {
-			RuntimeEndpoint = context.String("runtime-endpoint")
-
-			if context.IsSet("runtime-endpoint") {
-				RuntimeEndpointIsSet = true
-			}
-
-			ImageEndpoint = context.String("image-endpoint")
-
-			if context.IsSet("image-endpoint") {
-				ImageEndpointIsSet = true
-			}
-
-			if context.IsSet("timeout") {
-				Timeout = getTimeout(context.Duration("timeout"))
-			} else {
-				Timeout = context.Duration("timeout")
-			}
-
-			Debug = context.Bool("debug")
-			DisablePullOnRun = false
-		} else {
-			// Command line flags overrides config file.
-			if context.IsSet("runtime-endpoint") { //nolint:gocritic
-				RuntimeEndpoint = context.String("runtime-endpoint")
-				RuntimeEndpointIsSet = true
-			} else if config.RuntimeEndpoint != "" {
-				RuntimeEndpoint = config.RuntimeEndpoint
-				RuntimeEndpointIsSet = true
-			} else {
-				RuntimeEndpoint = context.String("runtime-endpoint")
-			}
-
-			if context.IsSet("image-endpoint") { //nolint:gocritic
-				ImageEndpoint = context.String("image-endpoint")
-				ImageEndpointIsSet = true
-			} else if config.ImageEndpoint != "" {
-				ImageEndpoint = config.ImageEndpoint
-				ImageEndpointIsSet = true
-			} else {
-				ImageEndpoint = context.String("image-endpoint")
-			}
-
-			if context.IsSet("timeout") { //nolint:gocritic
-				Timeout = getTimeout(context.Duration("timeout"))
-			} else if config.Timeout > 0 { // 0/neg value set to default timeout
-				Timeout = config.Timeout
-			} else {
-				Timeout = context.Duration("timeout")
-			}
-
-			if context.IsSet("debug") {
-				Debug = context.Bool("debug")
-			} else {
-				Debug = config.Debug
-			}
-
-			PullImageOnCreate = config.PullImageOnCreate
-			DisablePullOnRun = config.DisablePullOnRun
-		}
-
-		if Debug {
-			logrus.SetLevel(logrus.DebugLevel)
-		}
+		cfg := newCrictlConfig(context, config)
 
 		// Configure tracing if enabled
 		if context.IsSet("enable-tracing") {
-			tracerProvider, err = tracing.Init(
+			cfg.TracerProvider, err = tracing.Init(
 				context.Context,
 				context.String("tracing-endpoint"),
 				context.Int("tracing-sampling-rate-per-million"),
@@ -408,6 +218,8 @@ func main() {
 				return fmt.Errorf("init tracing: %w", err)
 			}
 		}
+
+		context.App.Metadata[configKey] = cfg
 
 		return nil
 	}
@@ -451,12 +263,15 @@ func main() {
 	}
 
 	// Ensure that all spans are processed.
-	if tracerProvider != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), Timeout)
-		defer cancel()
+	if v, ok := app.Metadata[configKey]; ok {
+		cfg, _ := v.(*CrictlConfig)
+		if cfg.TracerProvider != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
+			defer cancel()
 
-		if err := tracerProvider.Shutdown(ctx); err != nil {
-			logrus.Errorf("Unable to shutdown tracer provider: %v", err)
+			if err := cfg.TracerProvider.Shutdown(ctx); err != nil {
+				logrus.Errorf("Unable to shutdown tracer provider: %v", err)
+			}
 		}
 	}
 }

--- a/cmd/crictl/metric_descs.go
+++ b/cmd/crictl/metric_descs.go
@@ -47,7 +47,7 @@ var metricDescriptorsCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		client, err := getRuntimeService(c, 0)
+		client, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return fmt.Errorf("get runtime service: %w", err)
 		}

--- a/cmd/crictl/pod_metrics.go
+++ b/cmd/crictl/pod_metrics.go
@@ -55,7 +55,7 @@ var podMetricsCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		client, err := getRuntimeService(c, 0)
+		client, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return fmt.Errorf("get runtime service: %w", err)
 		}

--- a/cmd/crictl/pod_stats.go
+++ b/cmd/crictl/pod_stats.go
@@ -88,7 +88,7 @@ var podStatsCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		client, err := getRuntimeService(c, 0)
+		client, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return fmt.Errorf("get runtime service: %w", err)
 		}

--- a/cmd/crictl/portforward.go
+++ b/cmd/crictl/portforward.go
@@ -67,7 +67,7 @@ var runtimePortForwardCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/runtime_config.go
+++ b/cmd/crictl/runtime_config.go
@@ -30,7 +30,7 @@ var runtimeConfigCommand = &cli.Command{
 	Usage:                  "Retrieve the container runtime configuration",
 	UseShortOptionHandling: true,
 	Action: func(c *cli.Context) error {
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return fmt.Errorf("get runtime client: %w", err)
 		}

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -76,7 +76,7 @@ var runPodCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		runtimeClient, err := getRuntimeService(c, c.Duration("cancel-timeout"))
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, c.Duration("cancel-timeout"))
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,7 @@ var stopPodCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}
@@ -143,7 +143,7 @@ var removePodCommand = &cli.Command{
 		},
 	},
 	Action: func(ctx *cli.Context) error {
-		runtimeClient, err := getRuntimeService(ctx, 0)
+		runtimeClient, err := configFromContext(ctx).GetRuntimeService(ctx.Context, 0)
 		if err != nil {
 			return err
 		}
@@ -255,7 +255,7 @@ var podStatusCommand = &cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}
@@ -367,7 +367,7 @@ var listPodCommand = &cli.Command{
 	Action: func(c *cli.Context) error {
 		var err error
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/sandbox_test.go
+++ b/cmd/crictl/sandbox_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func fakeSandboxesWithCreatedAtDesc(names ...string) []*pb.PodSandbox {
+	sandboxes := make([]*pb.PodSandbox, len(names))
+	creationTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	for i, name := range names {
+		sandboxes[i] = fakeSandbox(name, "", creationTime.UnixNano())
+		creationTime = creationTime.Truncate(time.Hour)
+	}
+
+	return sandboxes
+}
+
+func fakeSandbox(name, namespace string, createdAt int64) *pb.PodSandbox {
+	return &pb.PodSandbox{
+		Metadata: &pb.PodSandboxMetadata{
+			Name:      name,
+			Namespace: namespace,
+		},
+		CreatedAt: createdAt,
+	}
+}
+
+var _ = DescribeTable("getSandboxesList",
+	func(input []*pb.PodSandbox, options *listOptions, indexes []int) {
+		actual := getSandboxesList(input, options)
+
+		expected := make([]*pb.PodSandbox, 0, len(indexes))
+		for _, i := range indexes {
+			expected = append(expected, input[i])
+		}
+
+		Expect(actual).To(HaveExactElements(expected))
+	},
+	Entry("returns sandboxes in order by createdAt desc",
+		[]*pb.PodSandbox{
+			fakeSandbox("test0", "ns", time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC).UnixNano()),
+			fakeSandbox("test1", "ns", time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano()),
+			fakeSandbox("test2", "ns", time.Date(2023, 1, 3, 12, 0, 0, 0, time.UTC).UnixNano()),
+		},
+		&listOptions{},
+		[]int{2, 0, 1},
+	),
+	Entry("returns sandboxes filtered by name regexp",
+		fakeSandboxesWithCreatedAtDesc("Test0", "Dev1", "Test2", "Dev3"),
+		&listOptions{nameRegexp: "Test.*"},
+		[]int{0, 2},
+	),
+	Entry("returns no sandboxes when regexp matches nothing",
+		fakeSandboxesWithCreatedAtDesc("Test0", "Dev1"),
+		&listOptions{nameRegexp: "Prod.*"},
+		[]int{},
+	),
+	Entry("returns sandboxes filtered by namespace regexp",
+		[]*pb.PodSandbox{
+			fakeSandbox("a", "kube-system", time.Date(2023, 1, 3, 12, 0, 0, 0, time.UTC).UnixNano()),
+			fakeSandbox("b", "default", time.Date(2023, 1, 2, 12, 0, 0, 0, time.UTC).UnixNano()),
+			fakeSandbox("c", "kube-public", time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano()),
+		},
+		&listOptions{podNamespaceRegexp: "kube-.*"},
+		[]int{0, 2},
+	),
+	Entry("returns the most recent sandbox with latest option",
+		fakeSandboxesWithCreatedAtDesc("v0", "v1", "v2"),
+		&listOptions{latest: true},
+		[]int{0},
+	),
+	Entry("returns last n sandboxes with the last option",
+		fakeSandboxesWithCreatedAtDesc("v0", "v1", "v2"),
+		&listOptions{last: 2},
+		[]int{0, 1},
+	),
+	Entry("returns all sandboxes when last exceeds length",
+		fakeSandboxesWithCreatedAtDesc("v0", "v1"),
+		&listOptions{last: 5},
+		[]int{0, 1},
+	),
+	Entry("returns nothing when last is set and list is empty",
+		fakeSandboxesWithCreatedAtDesc(),
+		&listOptions{last: 2},
+		[]int{},
+	),
+)

--- a/cmd/crictl/update_runtime_config.go
+++ b/cmd/crictl/update_runtime_config.go
@@ -50,7 +50,7 @@ var updateRuntimeConfigCommand = &cli.Command{
 			runtimeConfig.NetworkConfig = &pb.NetworkConfig{PodCidr: c.String(podCIDRFlag)}
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/crictl/version.go
+++ b/cmd/crictl/version.go
@@ -35,7 +35,7 @@ var runtimeVersionCommand = &cli.Command{
 			return cli.ShowSubcommandHelp(c)
 		}
 
-		runtimeClient, err := getRuntimeService(c, 0)
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Replaces package-level global variables with a `CrictlConfig` struct stored in `cli.App.Metadata`. Moves gRPC client creation into methods on `CrictlConfig` with unexported override fields for test injection. Propagates `context.Context` through `GetRuntimeService` and `GetImageService` instead of using `context.Background`.
Adds unit tests for sandbox listing and config override paths.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The command files are touched with a mechanical replacement of `getRuntimeService(c, X)` / `getImageService(c)` to `configFromContext(c).GetRuntimeService(c.Context, X)` / `configFromContext(c).GetImageService(c.Context)`. Action funcs with multiple calls extract `cfg := configFromContext(c)` once.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```