### PR TITLE
crictl: extract shared helpers and fix ContainerStats context

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -428,29 +428,11 @@ var removeContainerCommand = &cli.Command{
 			return err
 		}
 
-		ids := ctx.Args().Slice()
-		if ctx.Bool("all") {
-			r, err := InterruptableRPC(ctx.Context, func(ctx context.Context) ([]*pb.Container, error) {
-				return runtimeClient.ListContainers(ctx, nil)
-			})
-			if err != nil {
-				return err
-			}
-
-			ids = nil
-			for _, ctr := range r {
-				ids = append(ids, ctr.GetId())
-			}
-		}
-
-		if len(ids) == 0 {
-			if ctx.Bool("all") {
-				logrus.Info("No containers to remove")
-
-				return nil
-			}
-
-			return cli.ShowSubcommandHelp(ctx)
+		ids, err := collectIDs(ctx.Context, ctx, func(ctx context.Context) ([]*pb.Container, error) {
+			return runtimeClient.ListContainers(ctx, nil)
+		}, "container")
+		if err != nil || len(ids) == 0 {
+			return err
 		}
 
 		funcs := []func() error{}
@@ -1482,22 +1464,5 @@ func getContainersList(ctx context.Context, imageClient internalapi.ImageManager
 		return cmp.Compare(b.GetCreatedAt(), a.GetCreatedAt()) // descending
 	})
 
-	n := len(filtered)
-	if opts.latest {
-		n = 1
-	}
-
-	if opts.last > 0 {
-		n = opts.last
-	}
-
-	n = func(a, b int) int {
-		if a < b {
-			return a
-		}
-
-		return b
-	}(n, len(filtered))
-
-	return filtered[:n], nil
+	return filtered[:truncateCount(len(filtered), opts.latest, opts.last)], nil
 }

--- a/cmd/crictl/container_stats.go
+++ b/cmd/crictl/container_stats.go
@@ -119,7 +119,7 @@ var statsCommand = &cli.Command{
 			return err
 		}
 
-		if err = ContainerStats(runtimeClient, opts); err != nil {
+		if err = ContainerStats(c.Context, runtimeClient, opts); err != nil {
 			return fmt.Errorf("get container stats: %w", err)
 		}
 
@@ -136,7 +136,7 @@ type containerStatsDisplayer struct {
 
 // ContainerStats sends a ListContainerStatsRequest to the server, and
 // parses the returned ListContainerStatsResponse.
-func ContainerStats(client internalapi.RuntimeService, opts *statsOptions) error {
+func ContainerStats(ctx context.Context, client internalapi.RuntimeService, opts *statsOptions) error {
 	d := containerStatsDisplayer{
 		opts: opts,
 		request: &pb.ListContainerStatsRequest{
@@ -149,7 +149,7 @@ func ContainerStats(client internalapi.RuntimeService, opts *statsOptions) error
 		display: newDefaultTableDisplay(),
 	}
 
-	return handleDisplay(context.TODO(), client, opts.watch, d.displayStats)
+	return handleDisplay(ctx, client, opts.watch, d.displayStats)
 }
 
 func (d containerStatsDisplayer) displayStats(ctx context.Context, client internalapi.RuntimeService) error {

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -140,29 +140,11 @@ var removePodCommand = &cli.Command{
 			return err
 		}
 
-		ids := ctx.Args().Slice()
-		if ctx.Bool("all") {
-			r, err := InterruptableRPC(ctx.Context, func(ctx context.Context) ([]*pb.PodSandbox, error) {
-				return runtimeClient.ListPodSandbox(ctx, nil)
-			})
-			if err != nil {
-				return err
-			}
-
-			ids = nil
-			for _, sb := range r {
-				ids = append(ids, sb.GetId())
-			}
-		}
-
-		if len(ids) == 0 {
-			if ctx.Bool("all") {
-				logrus.Info("No pods to remove")
-
-				return nil
-			}
-
-			return cli.ShowSubcommandHelp(ctx)
+		ids, err := collectIDs(ctx.Context, ctx, func(ctx context.Context) ([]*pb.PodSandbox, error) {
+			return runtimeClient.ListPodSandbox(ctx, nil)
+		}, "pod")
+		if err != nil || len(ids) == 0 {
+			return err
 		}
 
 		funcs := []func() error{}
@@ -770,22 +752,5 @@ func getSandboxesList(sandboxesList []*pb.PodSandbox, opts *listOptions) []*pb.P
 		return cmp.Compare(b.GetCreatedAt(), a.GetCreatedAt()) // descending
 	})
 
-	n := len(filtered)
-	if opts.latest {
-		n = 1
-	}
-
-	if opts.last > 0 {
-		n = opts.last
-	}
-
-	n = func(a, b int) int {
-		if a < b {
-			return a
-		}
-
-		return b
-	}(n, len(filtered))
-
-	return filtered[:n]
+	return filtered[:truncateCount(len(filtered), opts.latest, opts.last)]
 }

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/invopop/jsonschema"
 	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/protoadapt"
 	"google.golang.org/protobuf/runtime/protoiface"
@@ -667,4 +668,49 @@ func AggregateGoroutines(funcs ...func() error) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+func truncateCount(total int, latest bool, last int) int {
+	n := total
+	if latest {
+		n = 1
+	}
+
+	if last > 0 {
+		n = last
+	}
+
+	return min(n, total)
+}
+
+func collectIDs[T interface{ GetId() string }](
+	ctx context.Context,
+	cliCtx *cli.Context,
+	listFn func(ctx context.Context) ([]T, error),
+	typeName string,
+) ([]string, error) {
+	ids := cliCtx.Args().Slice()
+	if cliCtx.Bool("all") {
+		items, err := InterruptableRPC(ctx, listFn)
+		if err != nil {
+			return nil, err
+		}
+
+		ids = nil
+		for _, item := range items {
+			ids = append(ids, item.GetId())
+		}
+	}
+
+	if len(ids) == 0 {
+		if cliCtx.Bool("all") {
+			logrus.Infof("No %ss to remove", typeName)
+
+			return nil, nil
+		}
+
+		return nil, cli.ShowSubcommandHelp(cliCtx)
+	}
+
+	return ids, nil
 }

--- a/cmd/crictl/util_test.go
+++ b/cmd/crictl/util_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"errors"
+	"flag"
 	"io"
 	"os"
 	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/urfave/cli/v2"
 )
 
 func TestGetSortedKeys(t *testing.T) {
@@ -450,5 +454,147 @@ func TestLoadPodSandboxConfigNotFound(t *testing.T) {
 
 	if !strings.Contains(err.Error(), filename) {
 		t.Errorf("expected error message to contain %q, got %q", filename, err.Error())
+	}
+}
+
+func TestTruncateCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		total    int
+		latest   bool
+		last     int
+		expected int
+	}{
+		{"zero items", 0, false, 0, 0},
+		{"no truncation", 5, false, 0, 5},
+		{"latest", 5, true, 0, 1},
+		{"latest with empty", 0, true, 0, 0},
+		{"last 3", 5, false, 3, 3},
+		{"last exceeds total", 5, false, 10, 5},
+		{"last overrides latest", 5, true, 3, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := truncateCount(tt.total, tt.latest, tt.last)
+			if got != tt.expected {
+				t.Errorf("truncateCount(%d, %v, %d) = %d, want %d",
+					tt.total, tt.latest, tt.last, got, tt.expected)
+			}
+		})
+	}
+}
+
+type fakeItem struct{ id string }
+
+func (f fakeItem) GetId() string { return f.id } //nolint:staticcheck // matches protobuf GetId() interface
+
+func newCLIContext(args []string, all bool) *cli.Context {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Bool("all", false, "")
+
+	var setArgs []string
+	if all {
+		setArgs = append(setArgs, "--all")
+	}
+
+	setArgs = append(setArgs, args...)
+	_ = fs.Parse(setArgs)
+
+	app := &cli.App{Writer: io.Discard}
+
+	return cli.NewContext(app, fs, nil)
+}
+
+func TestCollectIDs(t *testing.T) {
+	t.Parallel()
+
+	errList := errors.New("list failed")
+
+	tests := []struct {
+		name        string
+		args        []string
+		all         bool
+		listFn      func(context.Context) ([]fakeItem, error)
+		expectedIDs []string
+		expectErr   bool
+	}{
+		{
+			name: "explicit args returned as-is",
+			args: []string{"id1", "id2"},
+			listFn: func(context.Context) ([]fakeItem, error) {
+				t.Fatal("listFn should not be called")
+
+				return nil, nil
+			},
+			expectedIDs: []string{"id1", "id2"},
+		},
+		{
+			name: "all flag collects IDs from listFn",
+			all:  true,
+			listFn: func(context.Context) ([]fakeItem, error) {
+				return []fakeItem{{id: "a"}, {id: "b"}, {id: "c"}}, nil
+			},
+			expectedIDs: []string{"a", "b", "c"},
+		},
+		{
+			name: "all flag with empty list returns nil",
+			all:  true,
+			listFn: func(context.Context) ([]fakeItem, error) {
+				return nil, nil
+			},
+		},
+		{
+			name: "all flag with list error",
+			all:  true,
+			listFn: func(context.Context) ([]fakeItem, error) {
+				return nil, errList
+			},
+			expectErr: true,
+		},
+		{
+			name: "no args and no all flag returns error",
+			listFn: func(context.Context) ([]fakeItem, error) {
+				t.Fatal("listFn should not be called")
+
+				return nil, nil
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cliCtx := newCLIContext(tt.args, tt.all)
+
+			ids, err := collectIDs(context.Background(), cliCtx, tt.listFn, "thing")
+			if tt.expectErr {
+				if err == nil && ids != nil {
+					t.Fatal("expected error or nil result, got ids")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(ids) != len(tt.expectedIDs) {
+				t.Fatalf("expected %d ids, got %d", len(tt.expectedIDs), len(ids))
+			}
+
+			for i, id := range ids {
+				if id != tt.expectedIDs[i] {
+					t.Errorf("ids[%d] = %q, want %q", i, id, tt.expectedIDs[i])
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind bug

#### What this PR does / why we need it:
- Fixes `ContainerStats` to propagate the CLI context instead of using `context.TODO()`, so cancellation and timeouts work correctly.
- Extracts `truncateCount` and `collectIDs[T]` helpers to deduplicate identical list-truncation and ID-collection logic in container and sandbox commands.
- Adds unit tests for both new helpers.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Image removal is intentionally left alone since it uses a different pattern (`map[string]bool` for prune filtering).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```