### PR TITLE
ci: cancel in-progress workflow runs on new push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 permissions:
   contents: read
 

--- a/.github/workflows/containerd.yml
+++ b/.github/workflows/containerd.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 permissions:
   contents: read
 

--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 permissions:
   contents: read
 


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Add concurrency groups with `cancel-in-progress: true` to the build, containerd, and crio workflows. This cancels already-running CI jobs when a new commit is pushed to the same PR, avoiding wasted runner time.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The `release.yml` workflow only triggers on tags and doesn't need this.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```