### PR TITLE
crictl: use sentinel error for empty ID validation

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 
@@ -74,7 +73,7 @@ var runtimeAttachCommand = &cli.Command{
 	Action: func(c *cli.Context) error {
 		id := c.Args().First()
 		if id == "" {
-			return errors.New("ID cannot be empty")
+			return errIDEmpty
 		}
 
 		if c.NArg() != 1 {
@@ -112,7 +111,7 @@ var runtimeAttachCommand = &cli.Command{
 // Attach sends an AttachRequest to server, and parses the returned AttachResponse.
 func Attach(ctx context.Context, client internalapi.RuntimeService, opts attachOptions) error {
 	if opts.id == "" {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	request := &pb.AttachRequest{

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -265,7 +265,7 @@ var startContainerCommand = &cli.Command{
 	ArgsUsage: "CONTAINER-ID [CONTAINER-ID...]",
 	Action: func(c *cli.Context) error {
 		if c.NArg() == 0 {
-			return errors.New("ID cannot be empty")
+			return errIDEmpty
 		}
 
 		runtimeClient, err := getRuntimeService(c, 0)
@@ -328,7 +328,7 @@ var updateContainerCommand = &cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		if c.NArg() == 0 {
-			return errors.New("ID cannot be empty")
+			return errIDEmpty
 		}
 
 		runtimeClient, err := getRuntimeService(c, 0)
@@ -837,7 +837,7 @@ var checkpointContainerCommand = &cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		if c.NArg() == 0 {
-			return errors.New("ID cannot be empty")
+			return errIDEmpty
 		}
 
 		if c.String("export") == "" {
@@ -986,7 +986,7 @@ func CreateContainer(
 // the returned StartContainerResponse.
 func StartContainer(ctx context.Context, client internalapi.RuntimeService, id string) error {
 	if id == "" {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	if _, err := InterruptableRPC(ctx, func(ctx context.Context) (any, error) {
@@ -1025,7 +1025,7 @@ type updateOptions struct {
 // the returned UpdateContainerResourcesResponse.
 func UpdateContainerResources(ctx context.Context, client internalapi.RuntimeService, id string, opts *updateOptions) error {
 	if id == "" {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	request := &pb.UpdateContainerResourcesRequest{
@@ -1068,7 +1068,7 @@ func UpdateContainerResources(ctx context.Context, client internalapi.RuntimeSer
 // the returned StopContainerResponse.
 func StopContainer(ctx context.Context, client internalapi.RuntimeService, id string, timeout int64) error {
 	if id == "" {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	logrus.Debugf("Stopping container: %s (timeout = %v)", id, timeout)
@@ -1092,7 +1092,7 @@ func CheckpointContainer(
 	export string,
 ) error {
 	if id == "" {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	request := &pb.CheckpointContainerRequest{
@@ -1117,7 +1117,7 @@ func CheckpointContainer(
 // the returned RemoveContainerResponse.
 func RemoveContainer(ctx context.Context, client internalapi.RuntimeService, id string) error {
 	if id == "" {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	logrus.Debugf("Removing container: %s", id)
@@ -1183,7 +1183,7 @@ func containerStatus(ctx context.Context, client internalapi.RuntimeService, ids
 	}
 
 	if len(ids) == 0 {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	statuses := []statusData{}

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -949,7 +949,7 @@ func ImageStatus(ctx context.Context, client internalapi.ImageManagerService, im
 // the returned RemoveImageResponse.
 func RemoveImage(ctx context.Context, client internalapi.ImageManagerService, image string) error {
 	if image == "" {
-		return errors.New("ImageID cannot be empty")
+		return errIDEmpty
 	}
 
 	request := &pb.RemoveImageRequest{Image: &pb.ImageSpec{Image: image}}

--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -110,7 +110,7 @@ var logsCommand = &cli.Command{
 	Action: func(c *cli.Context) (retErr error) {
 		containerID := c.Args().First()
 		if containerID == "" {
-			return errors.New("ID cannot be empty")
+			return errIDEmpty
 		}
 
 		if c.NArg() > 1 {

--- a/cmd/crictl/portforward.go
+++ b/cmd/crictl/portforward.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -94,7 +93,7 @@ var runtimePortForwardCommand = &cli.Command{
 // PortForward sends an PortForwardRequest to server, and parses the returned PortForwardResponse.
 func PortForward(ctx context.Context, client internalapi.RuntimeService, opts portforwardOptions) error {
 	if opts.id == "" {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	request := &pb.PortForwardRequest{

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -423,7 +422,7 @@ func RunPodSandbox(ctx context.Context, client internalapi.RuntimeService, confi
 // the returned StopPodSandboxResponse.
 func StopPodSandbox(ctx context.Context, client internalapi.RuntimeService, id string) error {
 	if id == "" {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	logrus.Debugf("Stopping pod sandbox: %s", id)
@@ -443,7 +442,7 @@ func StopPodSandbox(ctx context.Context, client internalapi.RuntimeService, id s
 // the returned RemovePodSandboxResponse.
 func RemovePodSandbox(ctx context.Context, client internalapi.RuntimeService, id string) error {
 	if id == "" {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	logrus.Debugf("Removing pod sandbox: %s", id)
@@ -492,7 +491,7 @@ func podSandboxStatus(ctx context.Context, client internalapi.RuntimeService, id
 	}
 
 	if len(ids) == 0 {
-		return errors.New("ID cannot be empty")
+		return errIDEmpty
 	}
 
 	statuses := []statusData{}

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -52,6 +52,8 @@ const (
 	outputTypeGoTemplate = "go-template"
 )
 
+var errIDEmpty = errors.New("ID cannot be empty")
+
 var (
 	// The global stopCh for monitoring Interrupt signal.
 	// DO NOT use it directly. Use SetupInterruptSignalHandler() to get it.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Introduces a package-level `errIDEmpty` sentinel error to replace 16 scattered `errors.New("ID cannot be empty")` calls across files. This makes the error consistent, testable with `errors.Is`, and removes unused `errors` imports from attach.go, portforward.go, and sandbox.go.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The `ImageID cannot be empty` variant in image.go was also unified to use the same sentinel.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```