### PR TITLE
crictl: replace sort.Sort types with slices.SortFunc

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -25,7 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	goruntime "runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -40,14 +41,6 @@ import (
 
 	"sigs.k8s.io/cri-tools/pkg/framework"
 )
-
-type containerByCreated []*pb.Container
-
-func (a containerByCreated) Len() int      { return len(a) }
-func (a containerByCreated) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a containerByCreated) Less(i, j int) bool {
-	return a[i].GetCreatedAt() > a[j].GetCreatedAt()
-}
 
 type createOptions struct {
 	// the config and pod options
@@ -1485,7 +1478,9 @@ func getContainersList(ctx context.Context, imageClient internalapi.ImageManager
 		}
 	}
 
-	sort.Sort(containerByCreated(filtered))
+	slices.SortFunc(filtered, func(a, b *pb.Container) int {
+		return cmp.Compare(b.GetCreatedAt(), a.GetCreatedAt()) // descending
+	})
 
 	n := len(filtered)
 	if opts.latest {

--- a/cmd/crictl/container_stats.go
+++ b/cmd/crictl/container_stats.go
@@ -17,10 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"time"
 
@@ -124,14 +125,6 @@ var statsCommand = &cli.Command{
 
 		return nil
 	},
-}
-
-type containerStatsByID []*pb.ContainerStats
-
-func (c containerStatsByID) Len() int      { return len(c) }
-func (c containerStatsByID) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-func (c containerStatsByID) Less(i, j int) bool {
-	return c[i].GetAttributes().GetId() < c[j].GetAttributes().GetId()
 }
 
 type containerStatsDisplayer struct {
@@ -251,7 +244,9 @@ func getContainerStats(ctx context.Context, client internalapi.RuntimeService, r
 		return nil, err
 	}
 
-	sort.Sort(containerStatsByID(r))
+	slices.SortFunc(r, func(a, b *pb.ContainerStats) int {
+		return cmp.Compare(a.GetAttributes().GetId(), b.GetAttributes().GetId())
+	})
 
 	return &pb.ListContainerStatsResponse{Stats: r}, nil
 }

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -17,13 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"regexp"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -35,22 +35,6 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
-
-type imageByRef []*pb.Image
-
-func (a imageByRef) Len() int      { return len(a) }
-func (a imageByRef) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a imageByRef) Less(i, j int) bool {
-	if len(a[i].GetRepoTags()) > 0 && len(a[j].GetRepoTags()) > 0 {
-		return a[i].GetRepoTags()[0] < a[j].GetRepoTags()[0]
-	}
-
-	if len(a[i].GetRepoDigests()) > 0 && len(a[j].GetRepoDigests()) > 0 {
-		return a[i].GetRepoDigests()[0] < a[j].GetRepoDigests()[0]
-	}
-
-	return a[i].GetId() < a[j].GetId()
-}
 
 var pullImageCommand = &cli.Command{
 	Name:                   "pull",
@@ -813,7 +797,17 @@ func ListImages(ctx context.Context, client internalapi.ImageManagerService, nam
 	resp := &pb.ListImagesResponse{Images: res}
 	logrus.Debugf("ListImagesResponse: %v", resp)
 
-	sort.Sort(imageByRef(resp.GetImages()))
+	slices.SortFunc(resp.GetImages(), func(a, b *pb.Image) int {
+		if len(a.GetRepoTags()) > 0 && len(b.GetRepoTags()) > 0 {
+			return cmp.Compare(a.GetRepoTags()[0], b.GetRepoTags()[0])
+		}
+
+		if len(a.GetRepoDigests()) > 0 && len(b.GetRepoDigests()) > 0 {
+			return cmp.Compare(a.GetRepoDigests()[0], b.GetRepoDigests()[0])
+		}
+
+		return cmp.Compare(a.GetId(), b.GetId())
+	})
 
 	if len(conditionFilters) > 0 && len(resp.GetImages()) > 0 {
 		resp.Images, err = filterImagesList(resp.GetImages(), conditionFilters)

--- a/cmd/crictl/pod_stats.go
+++ b/cmd/crictl/pod_stats.go
@@ -17,10 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/docker/go-units"
@@ -111,14 +112,6 @@ var podStatsCommand = &cli.Command{
 
 		return nil
 	},
-}
-
-type podStatsByID []*pb.PodSandboxStats
-
-func (c podStatsByID) Len() int      { return len(c) }
-func (c podStatsByID) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
-func (c podStatsByID) Less(i, j int) bool {
-	return c[i].GetAttributes().GetId() < c[j].GetAttributes().GetId()
 }
 
 type podStatsDisplayer struct {
@@ -285,7 +278,9 @@ func getPodSandboxStats(
 
 	logrus.Debugf("Stats: %v", stats)
 
-	sort.Sort(podStatsByID(stats))
+	slices.SortFunc(stats, func(a, b *pb.PodSandboxStats) int {
+		return cmp.Compare(a.GetAttributes().GetId(), b.GetAttributes().GetId())
+	})
 
 	return stats, nil
 }

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -17,11 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -34,14 +35,6 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
-
-type sandboxByCreated []*pb.PodSandbox
-
-func (a sandboxByCreated) Len() int      { return len(a) }
-func (a sandboxByCreated) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a sandboxByCreated) Less(i, j int) bool {
-	return a[i].GetCreatedAt() > a[j].GetCreatedAt()
-}
 
 var runPodCommand = &cli.Command{
 	Name:      "runp",
@@ -773,7 +766,9 @@ func getSandboxesList(sandboxesList []*pb.PodSandbox, opts *listOptions) []*pb.P
 		}
 	}
 
-	sort.Sort(sandboxByCreated(filtered))
+	slices.SortFunc(filtered, func(a, b *pb.PodSandbox) int {
+		return cmp.Compare(b.GetCreatedAt(), a.GetCreatedAt()) // descending
+	})
 
 	n := len(filtered)
 	if opts.latest {


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Replace five custom `sort.Interface` implementations (`containerByCreated`, `sandboxByCreated`, `imageByRef`, `containerStatsByID`, `podStatsByID`) with inline `slices.SortFunc` + `cmp.Compare` comparators.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
All sort orders are preserved. The image sort retains its multi-key fallback (repoTags, repoDigests, ID).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```