### PR TITLE
crictl: add unit tests for utility functions

### DIFF
--- a/cmd/crictl/container_test.go
+++ b/cmd/crictl/container_test.go
@@ -48,6 +48,17 @@ func fakeContainer(name string, createdAt int64) *pb.Container {
 	}
 }
 
+var _ = DescribeTable("convertContainerState",
+	func(state pb.ContainerState, expected string) {
+		actual := convertContainerState(state)
+		Expect(actual).To(Equal(expected))
+	},
+	Entry("created", pb.ContainerState_CONTAINER_CREATED, "Created"),
+	Entry("running", pb.ContainerState_CONTAINER_RUNNING, "Running"),
+	Entry("exited", pb.ContainerState_CONTAINER_EXITED, "Exited"),
+	Entry("unknown", pb.ContainerState_CONTAINER_UNKNOWN, "Unknown"),
+)
+
 var _ = DescribeTable("getContainersList",
 	func(input []*pb.Container, options *listOptions, indexes []int) {
 		actual, err := getContainersList(context.Background(), nil, input, options)

--- a/cmd/crictl/image_test.go
+++ b/cmd/crictl/image_test.go
@@ -37,6 +37,119 @@ func assert(input []*pb.Image, options, images []string) {
 	Expect(images).To(Equal(expected))
 }
 
+var _ = DescribeTable("parseCreds",
+	func(input, expectedUser, expectedPass string, expectErr bool) {
+		user, pass, err := parseCreds(input)
+		if expectErr {
+			Expect(err).To(HaveOccurred())
+
+			return
+		}
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(user).To(Equal(expectedUser))
+		Expect(pass).To(Equal(expectedPass))
+	},
+	Entry("user:password", "alice:secret", "alice", "secret", false),
+	Entry("user only (no colon)", "alice", "alice", "", false),
+	Entry("user with empty password", "alice:", "alice", "", false),
+	Entry("password containing colons", "alice:p:a:ss", "alice", "p:a:ss", false),
+	Entry("empty string", "", "", "", true),
+	Entry("empty username", ":secret", "", "", true),
+)
+
+var _ = DescribeTable("getAuth",
+	func(creds, auth string, expectedUser, expectedPass, expectedAuth string, expectNil, expectErr bool) {
+		cfg, err := getAuth(creds, auth, "")
+		if expectErr {
+			Expect(err).To(HaveOccurred())
+
+			return
+		}
+
+		Expect(err).NotTo(HaveOccurred())
+
+		if expectNil {
+			Expect(cfg).To(BeNil())
+
+			return
+		}
+
+		Expect(cfg.GetUsername()).To(Equal(expectedUser))
+		Expect(cfg.GetPassword()).To(Equal(expectedPass))
+		Expect(cfg.GetAuth()).To(Equal(expectedAuth))
+	},
+	Entry("creds only", "alice:secret", "", "alice", "secret", "", false, false),
+	Entry("auth only", "", "dG9rZW4=", "", "", "dG9rZW4=", false, false),
+	Entry("both creds and auth", "alice:secret", "dG9rZW4=", "", "", "", false, true),
+	Entry("neither creds nor auth", "", "", "", "", "", true, false),
+)
+
+var _ = DescribeTable("normalizeRepoTagPair",
+	func(repoTags []string, imageName string, expected [][]string) {
+		actual := normalizeRepoTagPair(repoTags, imageName)
+		Expect(actual).To(Equal(expected))
+	},
+	Entry("standard image:tag",
+		[]string{"docker.io/library/nginx:latest"},
+		"nginx",
+		[][]string{{"docker.io/library/nginx", "latest"}},
+	),
+	Entry("multiple tags",
+		[]string{"nginx:latest", "nginx:1.25"},
+		"nginx",
+		[][]string{{"nginx", "latest"}, {"nginx", "1.25"}},
+	),
+	Entry("empty repoTags uses imageName with <none> tag",
+		[]string{},
+		"docker.io/library/nginx",
+		[][]string{{"docker.io/library/nginx", "<none>"}},
+	),
+	Entry("nil repoTags uses imageName with <none> tag",
+		nil,
+		"docker.io/library/nginx",
+		[][]string{{"docker.io/library/nginx", "<none>"}},
+	),
+	Entry("<none> name replaced by imageName",
+		[]string{"<none>:latest"},
+		"myimage",
+		[][]string{{"myimage", "latest"}},
+	),
+	Entry("tag without colon yields error pair",
+		[]string{"malformed"},
+		"img",
+		[][]string{{"errorRepoTag", "errorRepoTag"}},
+	),
+)
+
+var _ = DescribeTable("normalizeRepoDigest",
+	func(repoDigests []string, expectedRepo, expectedDigest string) {
+		repo, digest := normalizeRepoDigest(repoDigests)
+		Expect(repo).To(Equal(expectedRepo))
+		Expect(digest).To(Equal(expectedDigest))
+	},
+	Entry("standard digest",
+		[]string{"docker.io/library/nginx@sha256:abc123"},
+		"docker.io/library/nginx", "sha256:abc123",
+	),
+	Entry("empty list",
+		[]string{},
+		"<none>", "<none>",
+	),
+	Entry("nil list",
+		nil,
+		"<none>", "<none>",
+	),
+	Entry("malformed digest (no @)",
+		[]string{"docker.io/library/nginx"},
+		"errorName", "errorRepoDigest",
+	),
+	Entry("multiple digests uses first",
+		[]string{"docker.io/library/nginx@sha256:abc", "docker.io/library/nginx@sha256:def"},
+		"docker.io/library/nginx", "sha256:abc",
+	),
+)
+
 var _ = DescribeTable("filterImagesListByDangling", assert,
 	Entry("returns filtered images with dangling --filter=dangling=true",
 		[]*pb.Image{

--- a/cmd/crictl/logs_test.go
+++ b/cmd/crictl/logs_test.go
@@ -23,6 +23,92 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func TestNewLogOptions(t *testing.T) {
+	t.Parallel()
+
+	g := NewWithT(t)
+
+	t.Run("defaults", func(t *testing.T) {
+		t.Parallel()
+
+		opts := NewLogOptions(false, false, time.Time{}, nil, nil)
+		g := NewWithT(t)
+		g.Expect(opts.Follow).To(BeFalse())
+		g.Expect(opts.Timestamp).To(BeFalse())
+		g.Expect(opts.Since).To(Equal(time.Time{}))
+		g.Expect(opts.TailLines).To(BeNil())
+		g.Expect(opts.LimitBytes).To(BeNil())
+	})
+
+	t.Run("follow and timestamps enabled", func(t *testing.T) {
+		t.Parallel()
+
+		opts := NewLogOptions(true, true, time.Time{}, nil, nil)
+		g := NewWithT(t)
+		g.Expect(opts.Follow).To(BeTrue())
+		g.Expect(opts.Timestamp).To(BeTrue())
+	})
+
+	t.Run("since is set when non-zero", func(t *testing.T) {
+		t.Parallel()
+
+		since := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		opts := NewLogOptions(false, false, since, nil, nil)
+		g := NewWithT(t)
+		g.Expect(opts.Since).To(Equal(since))
+	})
+
+	t.Run("positive tail lines", func(t *testing.T) {
+		t.Parallel()
+
+		var lines int64 = 100
+
+		opts := NewLogOptions(false, false, time.Time{}, &lines, nil)
+		g = NewWithT(t)
+		g.Expect(opts.TailLines).To(Equal(&lines))
+	})
+
+	t.Run("negative tail lines are ignored", func(t *testing.T) {
+		t.Parallel()
+
+		var lines int64 = -1
+
+		opts := NewLogOptions(false, false, time.Time{}, &lines, nil)
+		g := NewWithT(t)
+		g.Expect(opts.TailLines).To(BeNil())
+	})
+
+	t.Run("positive limit bytes", func(t *testing.T) {
+		t.Parallel()
+
+		var limit int64 = 1024
+
+		opts := NewLogOptions(false, false, time.Time{}, nil, &limit)
+		g := NewWithT(t)
+		g.Expect(opts.LimitBytes).To(Equal(&limit))
+	})
+
+	t.Run("negative limit bytes are ignored", func(t *testing.T) {
+		t.Parallel()
+
+		var limit int64 = -1
+
+		opts := NewLogOptions(false, false, time.Time{}, nil, &limit)
+		g := NewWithT(t)
+		g.Expect(opts.LimitBytes).To(BeNil())
+	})
+
+	t.Run("zero tail lines are accepted", func(t *testing.T) {
+		t.Parallel()
+
+		var lines int64
+
+		opts := NewLogOptions(false, false, time.Time{}, &lines, nil)
+		g := NewWithT(t)
+		g.Expect(opts.TailLines).To(Equal(&lines))
+	})
+}
+
 func TestParseTimestamp(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/crictl/sandbox_test.go
+++ b/cmd/crictl/sandbox_test.go
@@ -46,6 +46,26 @@ func fakeSandbox(name, namespace string, createdAt int64) *pb.PodSandbox {
 	}
 }
 
+var _ = DescribeTable("convertPodState",
+	func(state pb.PodSandboxState, expected string) {
+		actual := convertPodState(state)
+		Expect(actual).To(Equal(expected))
+	},
+	Entry("ready", pb.PodSandboxState_SANDBOX_READY, "Ready"),
+	Entry("not ready", pb.PodSandboxState_SANDBOX_NOTREADY, "NotReady"),
+)
+
+var _ = DescribeTable("getSandboxesRuntimeHandler",
+	func(handler string, expected string) {
+		sandbox := &pb.PodSandbox{RuntimeHandler: handler}
+		actual := getSandboxesRuntimeHandler(sandbox)
+		Expect(actual).To(Equal(expected))
+	},
+	Entry("empty handler returns default", "", "(default)"),
+	Entry("custom handler", "runc", "runc"),
+	Entry("another handler", "kata", "kata"),
+)
+
 var _ = DescribeTable("getSandboxesList",
 	func(input []*pb.PodSandbox, options *listOptions, indexes []int) {
 		actual := getSandboxesList(input, options)

--- a/cmd/crictl/util_test.go
+++ b/cmd/crictl/util_test.go
@@ -25,6 +25,49 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func TestGetSortedKeys(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		desc     string
+		input    map[string]string
+		expected []string
+	}{
+		{
+			desc:     "returns keys in alphabetical order",
+			input:    map[string]string{"c": "3", "a": "1", "b": "2"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			desc:     "empty map returns empty slice",
+			input:    map[string]string{},
+			expected: []string{},
+		},
+		{
+			desc:     "single key",
+			input:    map[string]string{"only": "value"},
+			expected: []string{"only"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			result := getSortedKeys(tc.input)
+			if len(result) != len(tc.expected) {
+				t.Fatalf("expected %d keys, got %d", len(tc.expected), len(result))
+			}
+
+			for i, k := range tc.expected {
+				if result[i] != k {
+					t.Errorf("expected key[%d]=%q, got %q", i, k, result[i])
+				}
+			}
+		})
+	}
+}
+
 func TestNameFilterByRegex(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Adds unit tests for several utility functions that were previously
untested:
- `convertContainerState`
- `parseCreds`, `getAuth`
- `normalizeRepoTagPair`, `normalizeRepoDigest`
- `NewLogOptions`
- `convertPodState`, `getSandboxesRuntimeHandler`
- `getSortedKeys`

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Test-only change, no modifications to existing code.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```