### PR TITLE
crictl: extract generic resourceStatus to deduplicate status functions

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -1134,50 +1134,29 @@ func marshalContainerStatus(cs *pb.ContainerStatus) (string, error) {
 
 // containerStatus sends a ContainerStatusRequest to the server, and parses
 // the returned ContainerStatusResponse.
-//
-//nolint:dupl // pods and containers are similar, but still different
 func containerStatus(ctx context.Context, client internalapi.RuntimeService, ids []string, output, tmplStr string, quiet bool) error {
-	verbose := !(quiet)
+	return resourceStatus(
+		ctx, ids, output, tmplStr, quiet,
+		func(ctx context.Context, id string, verbose bool) (*pb.ContainerStatusResponse, error) {
+			r, err := InterruptableRPC(ctx, func(ctx context.Context) (*pb.ContainerStatusResponse, error) {
+				return client.ContainerStatus(ctx, id, verbose)
+			})
+			if err != nil {
+				return nil, fmt.Errorf("get container status: %w", err)
+			}
 
-	if output == "" { // default to json output
-		output = outputTypeJSON
-	}
+			return r, nil
+		},
+		func(r *pb.ContainerStatusResponse) (string, error) {
+			s, err := marshalContainerStatus(r.GetStatus())
+			if err != nil {
+				return "", fmt.Errorf("marshal container status: %w", err)
+			}
 
-	if len(ids) == 0 {
-		return errIDEmpty
-	}
-
-	statuses := []statusData{}
-
-	for _, id := range ids {
-		request := &pb.ContainerStatusRequest{
-			ContainerId: id,
-			Verbose:     verbose,
-		}
-		logrus.Debugf("ContainerStatusRequest: %v", request)
-
-		r, err := InterruptableRPC(ctx, func(ctx context.Context) (*pb.ContainerStatusResponse, error) {
-			return client.ContainerStatus(ctx, id, verbose)
-		})
-		logrus.Debugf("ContainerStatusResponse: %v", r)
-
-		if err != nil {
-			return fmt.Errorf("get container status: %w", err)
-		}
-
-		statusJSON, err := marshalContainerStatus(r.GetStatus())
-		if err != nil {
-			return fmt.Errorf("marshal container status: %w", err)
-		}
-
-		if output == outputTypeTable {
-			outputContainerStatusTable(r, verbose)
-		} else {
-			statuses = append(statuses, statusData{json: statusJSON, info: r.GetInfo()})
-		}
-	}
-
-	return outputStatusData(statuses, output, tmplStr)
+			return s, nil
+		},
+		outputContainerStatusTable,
+	)
 }
 
 func outputContainerStatusTable(r *pb.ContainerStatusResponse, verbose bool) {

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -456,51 +456,29 @@ func marshalPodSandboxStatus(ps *pb.PodSandboxStatus) (string, error) {
 
 // podSandboxStatus sends a PodSandboxStatusRequest to the server, and parses
 // the returned PodSandboxStatusResponse.
-//
-//nolint:dupl // pods and containers are similar, but still different
 func podSandboxStatus(ctx context.Context, client internalapi.RuntimeService, ids []string, output string, quiet bool, tmplStr string) error {
-	verbose := !(quiet)
+	return resourceStatus(
+		ctx, ids, output, tmplStr, quiet,
+		func(ctx context.Context, id string, verbose bool) (*pb.PodSandboxStatusResponse, error) {
+			r, err := InterruptableRPC(ctx, func(ctx context.Context) (*pb.PodSandboxStatusResponse, error) {
+				return client.PodSandboxStatus(ctx, id, verbose)
+			})
+			if err != nil {
+				return nil, fmt.Errorf("get pod sandbox status: %w", err)
+			}
 
-	if output == "" { // default to json output
-		output = outputTypeJSON
-	}
+			return r, nil
+		},
+		func(r *pb.PodSandboxStatusResponse) (string, error) {
+			s, err := marshalPodSandboxStatus(r.GetStatus())
+			if err != nil {
+				return "", fmt.Errorf("marshal pod sandbox status: %w", err)
+			}
 
-	if len(ids) == 0 {
-		return errIDEmpty
-	}
-
-	statuses := []statusData{}
-
-	for _, id := range ids {
-		request := &pb.PodSandboxStatusRequest{
-			PodSandboxId: id,
-			Verbose:      verbose,
-		}
-		logrus.Debugf("PodSandboxStatusRequest: %v", request)
-
-		r, err := InterruptableRPC(ctx, func(ctx context.Context) (*pb.PodSandboxStatusResponse, error) {
-			return client.PodSandboxStatus(ctx, id, verbose)
-		})
-
-		logrus.Debugf("PodSandboxStatusResponse: %v", r)
-
-		if err != nil {
-			return fmt.Errorf("get pod sandbox status: %w", err)
-		}
-
-		statusJSON, err := marshalPodSandboxStatus(r.GetStatus())
-		if err != nil {
-			return fmt.Errorf("marshal pod sandbox status: %w", err)
-		}
-
-		if output == outputTypeTable {
-			outputPodSandboxStatusTable(r, verbose)
-		} else {
-			statuses = append(statuses, statusData{json: statusJSON, info: r.GetInfo()})
-		}
-	}
-
-	return outputStatusData(statuses, output, tmplStr)
+			return s, nil
+		},
+		outputPodSandboxStatusTable,
+	)
 }
 
 func outputPodSandboxStatusTable(r *pb.PodSandboxStatusResponse, verbose bool) {

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -714,3 +714,49 @@ func collectIDs[T interface{ GetId() string }](
 
 	return ids, nil
 }
+
+type statusResult interface {
+	GetInfo() map[string]string
+}
+
+func resourceStatus[T statusResult](
+	ctx context.Context,
+	ids []string,
+	output, tmplStr string,
+	quiet bool,
+	fetch func(ctx context.Context, id string, verbose bool) (T, error),
+	marshal func(T) (string, error),
+	table func(T, bool),
+) error {
+	verbose := !quiet
+
+	if output == "" {
+		output = outputTypeJSON
+	}
+
+	if len(ids) == 0 {
+		return errIDEmpty
+	}
+
+	statuses := []statusData{}
+
+	for _, id := range ids {
+		r, err := fetch(ctx, id, verbose)
+		if err != nil {
+			return err
+		}
+
+		statusJSON, err := marshal(r)
+		if err != nil {
+			return err
+		}
+
+		if output == outputTypeTable {
+			table(r, verbose)
+		} else {
+			statuses = append(statuses, statusData{json: statusJSON, info: r.GetInfo()})
+		}
+	}
+
+	return outputStatusData(statuses, output, tmplStr)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Introduces a generic `resourceStatus[T]` helper that unifies the duplicated logic in `containerStatus` and `podSandboxStatus`. Both functions had identical control flow (validate IDs, loop, fetch, marshal, collect or print table) that was already flagged by the `dupl` linter via `nolint` comments.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```