### PR TITLE
Remove accidentally committed crictl binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Session.vim
 /build
 release-notes.md
 test/e2e/e2e.test
+/crictl
 
 CLAUDE.md
 /docs/plans


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Removes the `crictl` binary (Mach-O arm64 executable) that was accidentally committed in 924b3f91 and adds `/crictl` to `.gitignore` to prevent it from happening again.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```