### PR TITLE
crictl: deduplicate pull-related CLI flags

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -84,32 +84,6 @@ type pullOptions struct {
 	timeout time.Duration
 }
 
-var pullFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:  "creds",
-		Usage: "Use `USERNAME[:PASSWORD]` for accessing the registry",
-	},
-	&cli.StringFlag{
-		Name:  "auth",
-		Usage: "Use `AUTH_STRING` for accessing the registry. AUTH_STRING is a base64 encoded 'USERNAME[:PASSWORD]'",
-	},
-	&cli.StringFlag{
-		Name:  "username",
-		Usage: "Use `USERNAME` for accessing the registry. The password will be requested on the command line",
-	},
-	&cli.DurationFlag{
-		Name:    "cancel-timeout",
-		Aliases: []string{"T"},
-		Usage:   "Seconds to wait for the request to complete before cancelling",
-	},
-	&cli.DurationFlag{
-		Name:    "pull-timeout",
-		Aliases: []string{"pt"},
-		Usage:   "Maximum time to be used for pulling the image, disabled if set to 0s",
-		EnvVars: []string{"CRICTL_PULL_TIMEOUT"},
-	},
-}
-
 var createPullFlags = append([]cli.Flag{
 	&cli.BoolFlag{
 		Name:  "no-pull",
@@ -119,6 +93,7 @@ var createPullFlags = append([]cli.Flag{
 		Name:  "with-pull",
 		Usage: "Pull the image on container creation (overrides pull-image-on-create=false in config)",
 	},
+	cancelTimeoutFlag,
 }, pullFlags...)
 
 var runPullFlags = append([]cli.Flag{
@@ -135,6 +110,7 @@ var runPullFlags = append([]cli.Flag{
 		Aliases: []string{"r"},
 		Usage:   "Runtime handler to use. Available options are defined by the container runtime.",
 	},
+	cancelTimeoutFlag,
 }, pullFlags...)
 
 var subcommands = []*cli.Command{{

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -36,26 +36,41 @@ import (
 	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
+var pullFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "creds",
+		Usage:   "Use `USERNAME[:PASSWORD]` for accessing the registry",
+		EnvVars: []string{"CRICTL_CREDS"},
+	},
+	&cli.StringFlag{
+		Name:    "auth",
+		Usage:   "Use `AUTH_STRING` for accessing the registry. AUTH_STRING is a base64 encoded 'USERNAME[:PASSWORD]'",
+		EnvVars: []string{"CRICTL_AUTH"},
+	},
+	&cli.StringFlag{
+		Name:    "username",
+		Aliases: []string{"u"},
+		Usage:   "Use `USERNAME` for accessing the registry. The password will be requested on the command line",
+	},
+	&cli.DurationFlag{
+		Name:    "pull-timeout",
+		Aliases: []string{"pt"},
+		Usage:   "Maximum time to be used for pulling the image, disabled if set to 0s",
+		EnvVars: []string{"CRICTL_PULL_TIMEOUT"},
+	},
+}
+
+var cancelTimeoutFlag = &cli.DurationFlag{
+	Name:    "cancel-timeout",
+	Aliases: []string{"T"},
+	Usage:   "Seconds to wait for the request to complete before cancelling",
+}
+
 var pullImageCommand = &cli.Command{
 	Name:                   "pull",
 	Usage:                  "Pull an image from a registry",
 	UseShortOptionHandling: true,
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "creds",
-			Usage:   "Use `USERNAME[:PASSWORD]` for accessing the registry",
-			EnvVars: []string{"CRICTL_CREDS"},
-		},
-		&cli.StringFlag{
-			Name:    "auth",
-			Usage:   "Use `AUTH_STRING` for accessing the registry. AUTH_STRING is a base64 encoded 'USERNAME[:PASSWORD]'",
-			EnvVars: []string{"CRICTL_AUTH"},
-		},
-		&cli.StringFlag{
-			Name:    "username",
-			Aliases: []string{"u"},
-			Usage:   "Use `USERNAME` for accessing the registry. The password will be requested on the command line",
-		},
+	Flags: append([]cli.Flag{
 		&cli.StringFlag{
 			Name:      "pod-config",
 			Usage:     "Use `pod-config.[json|yaml]` to override the pull c",
@@ -66,13 +81,7 @@ var pullImageCommand = &cli.Command{
 			Aliases: []string{"a"},
 			Usage:   "Annotation to be set on the pulled image",
 		},
-		&cli.DurationFlag{
-			Name:    "pull-timeout",
-			Aliases: []string{"pt"},
-			Usage:   "Maximum time to be used for pulling the image, disabled if set to 0s",
-			EnvVars: []string{"CRICTL_PULL_TIMEOUT"},
-		},
-	},
+	}, pullFlags...),
 	Subcommands: []*cli.Command{{
 		Name:      "jsonschema",
 		Aliases:   []string{"js"},


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Consolidates duplicate pull-related flag definitions (`creds`, `auth`, `username`, `pull-timeout`) that existed separately in `container.go` and `image.go`. The shared `pullFlags` now lives in `image.go` alongside `getAuth` and the pull logic, and is reused by `pullImageCommand`, `createPullFlags`, and `runPullFlags`.

This also fixes inconsistencies where `crictl create` and `crictl run` were missing the `CRICTL_CREDS`/`CRICTL_AUTH` env vars and the `-u` alias for `--username` that `crictl pull` already had.

The `cancel-timeout` flag is extracted into its own `cancelTimeoutFlag` variable since it only applies to `create`/`run`, not `pull`.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The `create` and `run` commands now also honor `CRICTL_CREDS` and `CRICTL_AUTH` environment variables (previously only `pull` did). This is intentional to align behavior across all pull-capable commands.

#### Does this PR introduce a user-facing change?

```release-note
crictl: The `create` and `run` commands now support `CRICTL_CREDS`/`CRICTL_AUTH` environment variables and the `-u` alias for `--username`, aligning them with `pull`.
```