### PR TITLE
Extract pod sandbox cleanup into framework helpers

### DIFF
--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -189,6 +189,21 @@ func ExpectNoError(err error, explain ...any) {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), explain...)
 }
 
+// CleanupPodSandbox stops and removes a PodSandbox.
+func CleanupPodSandbox(ctx context.Context, rc internalapi.RuntimeService, podID string) {
+	By("stop PodSandbox")
+	ExpectNoError(rc.StopPodSandbox(ctx, podID), "failed to stop PodSandbox")
+	By("delete PodSandbox")
+	ExpectNoError(rc.RemovePodSandbox(ctx, podID), "failed to remove PodSandbox")
+}
+
+// CleanupPodSandboxAndLogDir stops and removes a PodSandbox and its log directory.
+func CleanupPodSandboxAndLogDir(ctx context.Context, rc internalapi.RuntimeService, podID, logDir string) {
+	CleanupPodSandbox(ctx, rc, podID)
+	By("cleanup log directory")
+	ExpectNoError(os.RemoveAll(logDir), "failed to remove log directory")
+}
+
 // NewUUID creates a new UUID string.
 func NewUUID() string {
 	return uuid.New().String()

--- a/pkg/validate/apparmor_linux.go
+++ b/pkg/validate/apparmor_linux.go
@@ -97,10 +97,7 @@ var _ = framework.KubeDescribe("AppArmor", func() {
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, sandboxID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, sandboxID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, sandboxID)
 		})
 
 		It("should fail with an unloaded apparmor_profile", func(ctx SpecContext) {
@@ -139,10 +136,7 @@ var _ = framework.KubeDescribe("AppArmor", func() {
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, sandboxID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, sandboxID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, sandboxID)
 		})
 
 		It("should fail with an unloaded apparmor_profile", func(ctx SpecContext) {
@@ -190,10 +184,7 @@ var _ = framework.KubeDescribe("AppArmor", func() {
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, sandboxID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, sandboxID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, sandboxID)
 		})
 
 		It("should fail with an unloaded apparmor_profile", func(ctx SpecContext) {

--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -76,10 +76,7 @@ var _ = framework.KubeDescribe("Container", func() {
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, podID)
 		})
 
 		It("runtime should support creating container [Conformance]", func(ctx SpecContext) {
@@ -338,10 +335,7 @@ var _ = framework.KubeDescribe("Container", func() {
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, podID)
 		})
 
 		It("runtime should support starting container with volume [Conformance]", func(ctx SpecContext) {
@@ -403,12 +397,7 @@ var _ = framework.KubeDescribe("Container", func() {
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("clean up the TempDir")
-			os.RemoveAll(hostPath)
+			framework.CleanupPodSandboxAndLogDir(ctx, rc, podID, hostPath)
 		})
 
 		It("runtime should support starting container with log [Conformance]", func(ctx SpecContext) {

--- a/pkg/validate/container_linux.go
+++ b/pkg/validate/container_linux.go
@@ -57,10 +57,7 @@ var _ = framework.KubeDescribe("Container Mount Propagation", func() {
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, podID)
 		})
 
 		testMountPropagation := func(ctx context.Context, propagation runtimeapi.MountPropagation) {
@@ -153,10 +150,7 @@ var _ = framework.KubeDescribe("Container OOM", func() {
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, podID)
 		})
 
 		It("should terminate with exitCode 137 and reason OOMKilled", func(ctx SpecContext) {
@@ -356,10 +350,7 @@ var _ = framework.KubeDescribe("Container Mount Readonly", func() {
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, podID)
 		})
 
 		testRRO := func(ctx context.Context, rc internalapi.RuntimeService, ic internalapi.ImageManagerService, rro bool) {

--- a/pkg/validate/multi_container_linux.go
+++ b/pkg/validate/multi_container_linux.go
@@ -76,12 +76,7 @@ var _ = framework.KubeDescribe("Multiple Containers [Conformance]", func() {
 		})
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).To(Succeed())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).To(Succeed())
-			By("cleanup log path")
-			Expect(os.RemoveAll(logDir)).To(Succeed())
+			framework.CleanupPodSandboxAndLogDir(ctx, rc, podID, logDir)
 		})
 
 		It("should support network", func(ctx SpecContext) {

--- a/pkg/validate/networking.go
+++ b/pkg/validate/networking.go
@@ -49,10 +49,7 @@ var _ = framework.KubeDescribe("Networking", func() {
 		var podID string
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, podID)
 		})
 
 		It("runtime should support DNS config [Conformance]", func(ctx SpecContext) {

--- a/pkg/validate/pod.go
+++ b/pkg/validate/pod.go
@@ -45,10 +45,7 @@ var _ = framework.KubeDescribe("PodSandbox", func() {
 
 		AfterEach(func(ctx SpecContext) {
 			if podID != "" {
-				By("stop PodSandbox")
-				Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-				By("delete PodSandbox")
-				Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+				framework.CleanupPodSandbox(ctx, rc, podID)
 			}
 		})
 

--- a/pkg/validate/pod_linux.go
+++ b/pkg/validate/pod_linux.go
@@ -50,10 +50,7 @@ var _ = framework.KubeDescribe("PodSandbox", func() {
 		)
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, podID)
 		})
 
 		It("should support safe sysctls", func(ctx SpecContext) {

--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -65,10 +65,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 
 	AfterEach(func(ctx SpecContext) {
 		if podID != "" {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, podID)
 		}
 
 		if podLogDir != "" {

--- a/pkg/validate/selinux_linux.go
+++ b/pkg/validate/selinux_linux.go
@@ -117,7 +117,7 @@ var _ = framework.KubeDescribe("SELinux", func() {
 				})
 
 				AfterEach(func(ctx SpecContext) {
-					cleanupSandbox(ctx, rc, sandboxID)
+					framework.CleanupPodSandbox(ctx, rc, sandboxID)
 				})
 
 				sandboxTests(false)
@@ -129,7 +129,7 @@ var _ = framework.KubeDescribe("SELinux", func() {
 				})
 
 				AfterEach(func(ctx SpecContext) {
-					cleanupSandbox(ctx, rc, sandboxID)
+					framework.CleanupPodSandbox(ctx, rc, sandboxID)
 				})
 
 				sandboxTests(true)
@@ -147,8 +147,8 @@ var _ = framework.KubeDescribe("SELinux", func() {
 				})
 
 				AfterEach(func(ctx SpecContext) {
-					cleanupSandbox(ctx, rc, sandboxID)
-					cleanupSandbox(ctx, rc, sandboxID2)
+					framework.CleanupPodSandbox(ctx, rc, sandboxID)
+					framework.CleanupPodSandbox(ctx, rc, sandboxID2)
 				})
 
 				It("should create containers with different process labels", func(ctx SpecContext) {
@@ -223,13 +223,6 @@ func checkContainerSelinux(ctx context.Context, rc internalapi.RuntimeService, c
 	stdout, stderr, err := rc.ExecSync(ctx, containerID, cmd, time.Duration(defaultExecSyncTimeout)*time.Second)
 	msg := fmt.Sprintf("cmd %v, stdout %q, stderr %q", cmd, stdout, stderr)
 	Expect(err).NotTo(HaveOccurred(), msg)
-}
-
-func cleanupSandbox(ctx context.Context, rc internalapi.RuntimeService, sandboxID string) {
-	By("stop PodSandbox")
-	Expect(rc.StopPodSandbox(ctx, sandboxID)).NotTo(HaveOccurred())
-	By("delete PodSandbox")
-	Expect(rc.RemovePodSandbox(ctx, sandboxID)).NotTo(HaveOccurred())
 }
 
 func checkMountLabelRoleType(ctx context.Context, rc internalapi.RuntimeService, containerID string) {

--- a/pkg/validate/streaming.go
+++ b/pkg/validate/streaming.go
@@ -60,10 +60,7 @@ var _ = framework.KubeDescribe("Streaming", func() {
 		)
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, podID)
 		})
 
 		It("runtime should support exec with tty=false and stdin=false [Conformance]", func(ctx SpecContext) {

--- a/pkg/validate/streaming_linux.go
+++ b/pkg/validate/streaming_linux.go
@@ -18,7 +18,6 @@ package validate
 
 import (
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 
@@ -42,10 +41,7 @@ var _ = framework.KubeDescribe("Streaming", func() {
 		var podID string
 
 		AfterEach(func(ctx SpecContext) {
-			By("stop PodSandbox")
-			Expect(rc.StopPodSandbox(ctx, podID)).NotTo(HaveOccurred())
-			By("delete PodSandbox")
-			Expect(rc.RemovePodSandbox(ctx, podID)).NotTo(HaveOccurred())
+			framework.CleanupPodSandbox(ctx, rc, podID)
 		})
 
 		It("runtime should support portforward in host network", func(ctx SpecContext) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Extracts the repeated stop/remove pod sandbox cleanup pattern (18 occurrences across 11 files) into `CleanupPodSandbox` and `CleanupPodSandboxAndLogDir` helpers in `pkg/framework/util.go`.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The helpers use `ExpectNoError` consistently. One call site in `container.go` previously ignored the `os.RemoveAll` error; the helper now checks it.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```