### PR TITLE
Replace Fatal calls with proper error returns in crictl

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	goruntime "runtime"
@@ -1222,7 +1221,7 @@ func ListContainers(ctx context.Context, runtimeClient internalapi.RuntimeServic
 			st.State = pb.ContainerState_CONTAINER_UNKNOWN
 			filter.State = st
 		default:
-			log.Fatalf("--state should be one of created, running, exited or unknown")
+			return nil, errors.New("--state should be one of created, running, exited or unknown")
 		}
 	}
 
@@ -1310,8 +1309,14 @@ func OutputContainers(ctx context.Context, runtimeClient internalapi.RuntimeServ
 			}
 
 			podName := getPodNameFromLabels(c.GetLabels())
+
+			containerState, err := convertContainerState(c.GetState())
+			if err != nil {
+				return err
+			}
+
 			display.AddRow([]string{
-				id, image, ctm, convertContainerState(c.GetState()), c.GetMetadata().GetName(),
+				id, image, ctm, containerState, c.GetMetadata().GetName(),
 				strconv.FormatUint(uint64(c.GetMetadata().GetAttempt()), 10), podID, podName, podNamespace,
 			})
 
@@ -1330,7 +1335,12 @@ func OutputContainers(ctx context.Context, runtimeClient internalapi.RuntimeServ
 			fmt.Printf("Attempt: %v\n", c.GetMetadata().GetAttempt())
 		}
 
-		fmt.Printf("State: %s\n", convertContainerState(c.GetState()))
+		containerState, err := convertContainerState(c.GetState())
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("State: %s\n", containerState)
 
 		if c.GetImage() != nil {
 			fmt.Printf("Image: %s\n", c.GetImage().GetImage())
@@ -1362,20 +1372,18 @@ func OutputContainers(ctx context.Context, runtimeClient internalapi.RuntimeServ
 	return nil
 }
 
-func convertContainerState(state pb.ContainerState) string {
+func convertContainerState(state pb.ContainerState) (string, error) {
 	switch state {
 	case pb.ContainerState_CONTAINER_CREATED:
-		return "Created"
+		return "Created", nil
 	case pb.ContainerState_CONTAINER_RUNNING:
-		return "Running"
+		return "Running", nil
 	case pb.ContainerState_CONTAINER_EXITED:
-		return "Exited"
+		return "Exited", nil
 	case pb.ContainerState_CONTAINER_UNKNOWN:
-		return "Unknown"
+		return "Unknown", nil
 	default:
-		log.Fatalf("Unknown container state %q", state)
-
-		return ""
+		return "", fmt.Errorf("unknown container state %q", state)
 	}
 }
 

--- a/cmd/crictl/container_test.go
+++ b/cmd/crictl/container_test.go
@@ -50,7 +50,8 @@ func fakeContainer(name string, createdAt int64) *pb.Container {
 
 var _ = DescribeTable("convertContainerState",
 	func(state pb.ContainerState, expected string) {
-		actual := convertContainerState(state)
+		actual, err := convertContainerState(state)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 	},
 	Entry("created", pb.ContainerState_CONTAINER_CREATED, "Created"),

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -57,6 +57,13 @@ func getTimeout(timeDuration time.Duration) time.Duration {
 }
 
 func main() {
+	if err := run(); err != nil {
+		logrus.Error(err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	app := cli.NewApp()
 	app.Name = "crictl"
 	app.Usage = "client for CRI"
@@ -198,12 +205,12 @@ func main() {
 		}
 
 		if exePath, err = os.Executable(); err != nil {
-			logrus.Fatal(err)
+			return fmt.Errorf("get executable path: %w", err)
 		}
 
 		if config, err = common.GetServerConfigFromFile(context.String("config"), exePath); err != nil {
 			if context.IsSet("config") {
-				logrus.Fatal(err)
+				return fmt.Errorf("get server config: %w", err)
 			}
 		}
 
@@ -222,7 +229,7 @@ func main() {
 
 			// Start a root span named after the invoked command so that all
 			// command operations are recorded as children of it. The span is
-			// ended in main() once app.Run returns.
+			// ended in run() once app.Run returns.
 			spanName := "crictl"
 			if context.Args().Present() {
 				spanName = context.Args().First()
@@ -292,16 +299,15 @@ func main() {
 
 			if cfg.TracerProvider != nil {
 				shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
-				defer cancel()
 
 				if shutdownErr := cfg.TracerProvider.Shutdown(shutdownCtx); shutdownErr != nil {
 					logrus.Errorf("Unable to shutdown tracer provider: %v", shutdownErr)
 				}
+
+				cancel()
 			}
 		}
 	}
 
-	if err != nil {
-		logrus.Fatal(err)
-	}
+	return err
 }

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -20,8 +20,8 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
 	"slices"
 	"strconv"
 	"strings"
@@ -554,7 +554,7 @@ func ListPodSandboxes(ctx context.Context, client internalapi.RuntimeService, op
 			st.State = pb.PodSandboxState_SANDBOX_NOTREADY
 			filter.State = st
 		default:
-			log.Fatalf("--state should be ready or notready")
+			return nil, errors.New("--state should be ready or notready")
 		}
 	}
 
@@ -629,10 +629,15 @@ func OutputPodSandboxes(ctx context.Context, client internalapi.RuntimeService, 
 				id = getTruncatedID(id, "")
 			}
 
+			podState, err := convertPodState(pod.GetState())
+			if err != nil {
+				return err
+			}
+
 			display.AddRow([]string{
 				id,
 				ctm,
-				convertPodState(pod.GetState()),
+				podState,
 				pod.GetMetadata().GetName(),
 				pod.GetMetadata().GetNamespace(),
 				strconv.FormatUint(uint64(pod.GetMetadata().GetAttempt()), 10),
@@ -662,7 +667,13 @@ func OutputPodSandboxes(ctx context.Context, client internalapi.RuntimeService, 
 			}
 		}
 
-		fmt.Printf("Status: %s\n", convertPodState(pod.GetState()))
+		podState, err := convertPodState(pod.GetState())
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Status: %s\n", podState)
+
 		ctm := time.Unix(0, pod.GetCreatedAt())
 		fmt.Printf("Created: %v\n", ctm)
 
@@ -694,16 +705,14 @@ func OutputPodSandboxes(ctx context.Context, client internalapi.RuntimeService, 
 	return nil
 }
 
-func convertPodState(state pb.PodSandboxState) string {
+func convertPodState(state pb.PodSandboxState) (string, error) {
 	switch state {
 	case pb.PodSandboxState_SANDBOX_READY:
-		return "Ready"
+		return "Ready", nil
 	case pb.PodSandboxState_SANDBOX_NOTREADY:
-		return "NotReady"
+		return "NotReady", nil
 	default:
-		log.Fatalf("Unknown pod state %q", state)
-
-		return ""
+		return "", fmt.Errorf("unknown pod state %q", state)
 	}
 }
 

--- a/cmd/crictl/sandbox_test.go
+++ b/cmd/crictl/sandbox_test.go
@@ -48,7 +48,8 @@ func fakeSandbox(name, namespace string, createdAt int64) *pb.PodSandbox {
 
 var _ = DescribeTable("convertPodState",
 	func(state pb.PodSandboxState, expected string) {
-		actual := convertPodState(state)
+		actual, err := convertPodState(state)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(actual).To(Equal(expected))
 	},
 	Entry("ready", pb.PodSandboxState_SANDBOX_READY, "Ready"),

--- a/cmd/crictl/templates.go
+++ b/cmd/crictl/templates.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/sirupsen/logrus"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -41,15 +40,15 @@ func builtinTmplFuncs() template.FuncMap {
 }
 
 // jsonBuiltinTmplFunc allows to jsonify result of template execution.
-func jsonBuiltinTmplFunc(v any) string {
+func jsonBuiltinTmplFunc(v any) (string, error) {
 	o := new(bytes.Buffer)
 
 	enc := json.NewEncoder(o)
 	if err := enc.Encode(v); err != nil {
-		logrus.Fatalf("Unable to encode JSON: %v", err)
+		return "", fmt.Errorf("unable to encode JSON: %w", err)
 	}
 
-	return o.String()
+	return o.String(), nil
 }
 
 // tmplExecuteRawJSON executes the template with any with decoded by


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Replaces all 8 `log.Fatalf`/`logrus.Fatal` calls in `cmd/crictl/` with proper error returns. Extracts `run() error` from `main()` so deferred cleanup (CPU profiling, tracer shutdown) runs before exit.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
`convertContainerState`, `convertPodState`, and `jsonBuiltinTmplFunc` now return `(T, error)`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```