### PR TITLE
Add --max-retries flag for connection retry with backoff

### DIFF
--- a/cmd/crictl/config.go
+++ b/cmd/crictl/config.go
@@ -52,7 +52,8 @@ CRICTL OPTIONS:
 	 timeout:	Timeout of connecting to server (default: 2)
 	 debug:	Enable debug output (default: false)
 	 pull-image-on-create:	Enable pulling image on create requests (default: false)
-	 disable-pull-on-run:	Disable pulling image on run requests (default: false)`,
+	 disable-pull-on-run:	Disable pulling image on run requests (default: false)
+	 max-retries:	Max retries for connecting to an explicitly set endpoint (default: 3, 0 to disable, negative for infinite)`,
 	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
@@ -96,6 +97,8 @@ CRICTL OPTIONS:
 				fmt.Println(config.PullImageOnCreate)
 			case common.DisablePullOnRun:
 				fmt.Println(config.DisablePullOnRun)
+			case common.MaxRetries:
+				fmt.Println(config.MaxRetries)
 			default:
 				return fmt.Errorf("no configuration option named %s", get)
 			}
@@ -130,6 +133,7 @@ CRICTL OPTIONS:
 			display.AddRow([]string{common.Debug, strconv.FormatBool(config.Debug)})
 			display.AddRow([]string{common.PullImageOnCreate, strconv.FormatBool(config.PullImageOnCreate)})
 			display.AddRow([]string{common.DisablePullOnRun, strconv.FormatBool(config.DisablePullOnRun)})
+			display.AddRow([]string{common.MaxRetries, strconv.Itoa(config.MaxRetries)})
 			display.ClearScreen()
 			display.Flush()
 
@@ -187,6 +191,13 @@ func setValue(key, value string, config *common.Config) error {
 		}
 
 		config.DisablePullOnRun = pi
+	case common.MaxRetries:
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("parse max-retries value '%s': %w", value, err)
+		}
+
+		config.MaxRetries = n
 	default:
 		return fmt.Errorf("no configuration option named %s", key)
 	}

--- a/cmd/crictl/crictl_config.go
+++ b/cmd/crictl/crictl_config.go
@@ -35,72 +35,95 @@ import (
 const configKey = "crictl-config"
 
 func newCrictlConfig(ctx *cli.Context, config *common.ServerConfiguration) *CrictlConfig {
-	cfg := &CrictlConfig{}
+	var cfg *CrictlConfig
 
 	if config == nil {
-		cfg.RuntimeEndpoint = ctx.String("runtime-endpoint")
-
-		if ctx.IsSet("runtime-endpoint") {
-			cfg.RuntimeEndpointIsSet = true
-		}
-
-		cfg.ImageEndpoint = ctx.String("image-endpoint")
-
-		if ctx.IsSet("image-endpoint") {
-			cfg.ImageEndpointIsSet = true
-		}
-
-		if ctx.IsSet("timeout") {
-			cfg.Timeout = getTimeout(ctx.Duration("timeout"))
-		} else {
-			cfg.Timeout = ctx.Duration("timeout")
-		}
-
-		cfg.Debug = ctx.Bool("debug")
-		cfg.DisablePullOnRun = false
+		cfg = newCrictlConfigFromFlags(ctx)
 	} else {
-		// Command line flags overrides config file.
-		if ctx.IsSet("runtime-endpoint") { //nolint:gocritic
-			cfg.RuntimeEndpoint = ctx.String("runtime-endpoint")
-			cfg.RuntimeEndpointIsSet = true
-		} else if config.RuntimeEndpoint != "" {
-			cfg.RuntimeEndpoint = config.RuntimeEndpoint
-			cfg.RuntimeEndpointIsSet = true
-		} else {
-			cfg.RuntimeEndpoint = ctx.String("runtime-endpoint")
-		}
-
-		if ctx.IsSet("image-endpoint") { //nolint:gocritic
-			cfg.ImageEndpoint = ctx.String("image-endpoint")
-			cfg.ImageEndpointIsSet = true
-		} else if config.ImageEndpoint != "" {
-			cfg.ImageEndpoint = config.ImageEndpoint
-			cfg.ImageEndpointIsSet = true
-		} else {
-			cfg.ImageEndpoint = ctx.String("image-endpoint")
-		}
-
-		if ctx.IsSet("timeout") { //nolint:gocritic
-			cfg.Timeout = getTimeout(ctx.Duration("timeout"))
-		} else if config.Timeout > 0 { // 0/neg value set to default timeout
-			cfg.Timeout = config.Timeout
-		} else {
-			cfg.Timeout = ctx.Duration("timeout")
-		}
-
-		if ctx.IsSet("debug") {
-			cfg.Debug = ctx.Bool("debug")
-		} else {
-			cfg.Debug = config.Debug
-		}
-
-		cfg.PullImageOnCreate = config.PullImageOnCreate
-		cfg.DisablePullOnRun = config.DisablePullOnRun
+		cfg = newCrictlConfigFromFile(ctx, config)
 	}
 
 	if cfg.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+
+	return cfg
+}
+
+func newCrictlConfigFromFlags(ctx *cli.Context) *CrictlConfig {
+	cfg := &CrictlConfig{}
+
+	cfg.RuntimeEndpoint = ctx.String("runtime-endpoint")
+
+	if ctx.IsSet("runtime-endpoint") {
+		cfg.RuntimeEndpointIsSet = true
+	}
+
+	cfg.ImageEndpoint = ctx.String("image-endpoint")
+
+	if ctx.IsSet("image-endpoint") {
+		cfg.ImageEndpointIsSet = true
+	}
+
+	if ctx.IsSet("timeout") {
+		cfg.Timeout = getTimeout(ctx.Duration("timeout"))
+	} else {
+		cfg.Timeout = ctx.Duration("timeout")
+	}
+
+	cfg.Debug = ctx.Bool("debug")
+	cfg.MaxRetries = ctx.Int("max-retries")
+	cfg.DisablePullOnRun = false
+
+	return cfg
+}
+
+func newCrictlConfigFromFile(ctx *cli.Context, config *common.ServerConfiguration) *CrictlConfig {
+	cfg := &CrictlConfig{}
+
+	// Command line flags overrides config file.
+	if ctx.IsSet("runtime-endpoint") { //nolint:gocritic
+		cfg.RuntimeEndpoint = ctx.String("runtime-endpoint")
+		cfg.RuntimeEndpointIsSet = true
+	} else if config.RuntimeEndpoint != "" {
+		cfg.RuntimeEndpoint = config.RuntimeEndpoint
+		cfg.RuntimeEndpointIsSet = true
+	} else {
+		cfg.RuntimeEndpoint = ctx.String("runtime-endpoint")
+	}
+
+	if ctx.IsSet("image-endpoint") { //nolint:gocritic
+		cfg.ImageEndpoint = ctx.String("image-endpoint")
+		cfg.ImageEndpointIsSet = true
+	} else if config.ImageEndpoint != "" {
+		cfg.ImageEndpoint = config.ImageEndpoint
+		cfg.ImageEndpointIsSet = true
+	} else {
+		cfg.ImageEndpoint = ctx.String("image-endpoint")
+	}
+
+	if ctx.IsSet("timeout") { //nolint:gocritic
+		cfg.Timeout = getTimeout(ctx.Duration("timeout"))
+	} else if config.Timeout > 0 { // 0/neg value set to default timeout
+		cfg.Timeout = config.Timeout
+	} else {
+		cfg.Timeout = ctx.Duration("timeout")
+	}
+
+	if ctx.IsSet("debug") {
+		cfg.Debug = ctx.Bool("debug")
+	} else {
+		cfg.Debug = config.Debug
+	}
+
+	if ctx.IsSet("max-retries") {
+		cfg.MaxRetries = ctx.Int("max-retries")
+	} else {
+		cfg.MaxRetries = config.MaxRetries
+	}
+
+	cfg.PullImageOnCreate = config.PullImageOnCreate
+	cfg.DisablePullOnRun = config.DisablePullOnRun
 
 	return cfg
 }
@@ -115,6 +138,7 @@ type CrictlConfig struct {
 	Debug                bool
 	PullImageOnCreate    bool
 	DisablePullOnRun     bool
+	MaxRetries           int
 	TracerProvider       *sdktrace.TracerProvider
 	// RootSpan is the root OpenTelemetry span for the command.
 	RootSpan trace.Span
@@ -186,7 +210,9 @@ func (cfg *CrictlConfig) GetRuntimeService(ctx context.Context, timeout time.Dur
 		return res, err
 	}
 
-	return remote.NewRemoteRuntimeService(ctx, cfg.RuntimeEndpoint, t, tp, false)
+	return connectWithRetry(ctx, cfg.MaxRetries, func() (internalapi.RuntimeService, error) {
+		return remote.NewRemoteRuntimeService(ctx, cfg.RuntimeEndpoint, t, tp, false)
+	})
 }
 
 // GetImageService returns the image service client. If an override is set
@@ -244,5 +270,44 @@ func (cfg *CrictlConfig) GetImageService(ctx context.Context) (internalapi.Image
 		return res, err
 	}
 
-	return remote.NewRemoteImageService(ctx, cfg.ImageEndpoint, cfg.Timeout, tp, false)
+	return connectWithRetry(ctx, cfg.MaxRetries, func() (internalapi.ImageManagerService, error) {
+		return remote.NewRemoteImageService(ctx, cfg.ImageEndpoint, cfg.Timeout, tp, false)
+	})
+}
+
+func connectWithRetry[T any](
+	ctx context.Context,
+	maxRetries int,
+	connect func() (T, error),
+) (T, error) {
+	result, err := connect()
+	if err == nil || maxRetries == 0 {
+		return result, err
+	}
+
+	delay := 500 * time.Millisecond
+	maxDelay := 5 * time.Second
+
+	for attempt := 0; maxRetries < 0 || attempt < maxRetries; attempt++ {
+		if maxRetries > 0 {
+			logrus.Debugf("Connection attempt %d/%d failed: %v, retrying in %v", attempt+1, maxRetries, err, delay)
+		} else {
+			logrus.Debugf("Connection attempt %d failed: %v, retrying in %v", attempt+1, err, delay)
+		}
+
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		case <-time.After(delay):
+		}
+
+		result, err = connect()
+		if err == nil {
+			return result, nil
+		}
+
+		delay = min(delay*2, maxDelay)
+	}
+
+	return result, err
 }

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -147,6 +147,11 @@ func run() error {
 			Aliases: []string{"D"},
 			Usage:   "Enable debug mode",
 		},
+		&cli.IntFlag{
+			Name:  "max-retries",
+			Value: 3,
+			Usage: "Max retries for connecting to an explicitly set endpoint with exponential backoff (0 to disable, negative for infinite)",
+		},
 		&cli.BoolFlag{
 			Name:  "enable-tracing",
 			Usage: "Enable OpenTelemetry tracing.",

--- a/docs/crictl.1
+++ b/docs/crictl.1
@@ -187,6 +187,7 @@ image-endpoint: unix:///run/containerd/containerd.sock
 timeout: 2
 debug: true
 pull-image-on-create: false
+max-retries: 3
 .EE
 
 .PP
@@ -199,6 +200,7 @@ image-endpoint: npipe:////./pipe/containerd-containerd
 timeout: 2
 debug: true
 pull-image-on-create: false
+max-retries: 3
 .EE
 
 .SS Connection troubleshooting
@@ -231,6 +233,8 @@ option for no timeout value set and the smallest supported timeout is \fB1s\fR
 \fB--tracing-endpoint\fR: Address to which the gRPC tracing collector will send spans to (default: \fB127.0.0.1:4317\fR)
 .IP \(bu 2
 \fB--tracing-sampling-rate-per-million\fR: Number of samples to collect per million OpenTelemetry spans. Set to 1000000 or -1 to always sample (default: \fB-1\fR)
+.IP \(bu 2
+\fB--max-retries\fR: Max retries for connecting to an explicitly set endpoint with exponential backoff (default: \fB3\fR, \fB0\fR to disable, negative for infinite)
 .IP \(bu 2
 \fB--profile-cpu\fR: Write a pprof CPU profile to the provided path
 .IP \(bu 2
@@ -275,6 +279,8 @@ COMMAND OPTIONS:
 \fBpull-image-on-create\fR: Enable pulling image on create requests (default: \fBfalse\fR)
 .IP \(bu 2
 \fBdisable-pull-on-run\fR: Disable pulling image on run requests (default: \fBfalse\fR)
+.IP \(bu 2
+\fBmax-retries\fR: Max retries for connecting to an explicitly set endpoint (default: \fB3\fR, \fB0\fR to disable, negative for infinite)
 
 .PP
 .RS

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -116,6 +116,7 @@ image-endpoint: unix:///run/containerd/containerd.sock
 timeout: 2
 debug: true
 pull-image-on-create: false
+max-retries: 3
 ```
 
 Windows:
@@ -127,6 +128,7 @@ image-endpoint: npipe:////./pipe/containerd-containerd
 timeout: 2
 debug: true
 pull-image-on-create: false
+max-retries: 3
 ```
 
 ### Connection troubleshooting
@@ -151,6 +153,7 @@ via sudo (`sudo -E crictl ...`).
 - `--enable-tracing`: Enable OpenTelemetry tracing (default: `false`)
 - `--tracing-endpoint`: Address to which the gRPC tracing collector will send spans to (default: `127.0.0.1:4317`)
 - `--tracing-sampling-rate-per-million`: Number of samples to collect per million OpenTelemetry spans. Set to 1000000 or -1 to always sample (default: `-1`)
+- `--max-retries`: Max retries for connecting to an explicitly set endpoint with exponential backoff (default: `3`, `0` to disable, negative for infinite)
 - `--profile-cpu`: Write a pprof CPU profile to the provided path
 - `--profile-mem`: Write a pprof memory profile to the provided path
 
@@ -182,6 +185,7 @@ COMMAND OPTIONS:
 - `debug`: Enable debug output (default: `false`)
 - `pull-image-on-create`: Enable pulling image on create requests (default: `false`)
 - `disable-pull-on-run`: Disable pulling image on run requests (default: `false`)
+- `max-retries`: Max retries for connecting to an explicitly set endpoint (default: `3`, `0` to disable, negative for infinite)
 
 > When enabled `pull-image-on-create` modifies the create container command to first pull the container's image.
 > This feature is used as a helper to make creating containers easier and faster.

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -40,6 +40,8 @@ type ServerConfiguration struct {
 	PullImageOnCreate bool
 	// DisablePullOnRun disables pulling an image for run requests
 	DisablePullOnRun bool
+	// MaxRetries is the number of retries for connecting to the server
+	MaxRetries int
 }
 
 // GetServerConfigFromFile returns the CRI server configuration from file.
@@ -76,6 +78,7 @@ func GetServerConfigFromFile(configFileName, currentDir string) (*ServerConfigur
 	serverConfig.Debug = config.Debug
 	serverConfig.PullImageOnCreate = config.PullImageOnCreate
 	serverConfig.DisablePullOnRun = config.DisablePullOnRun
+	serverConfig.MaxRetries = config.MaxRetries
 
 	return &serverConfig, nil
 }

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -34,6 +34,7 @@ type Config struct {
 	Debug             bool
 	PullImageOnCreate bool
 	DisablePullOnRun  bool
+	MaxRetries        int
 	yamlData          *yaml.Node // YAML representation of config
 }
 
@@ -55,6 +56,9 @@ const (
 
 	// DisablePullOnRun is the YAML key for the disable pull on run config option.
 	DisablePullOnRun = "disable-pull-on-run"
+
+	// MaxRetries is the YAML key for the max retries config option.
+	MaxRetries = "max-retries"
 )
 
 // ReadConfig reads from a file with the given name and returns a config or
@@ -152,6 +156,11 @@ func getConfigOptions(yamlData *yaml.Node) (*Config, error) {
 			if err != nil {
 				return nil, fmt.Errorf("parsing config option '%s': %w", name, err)
 			}
+		case MaxRetries:
+			config.MaxRetries, err = strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("parsing config option '%s': %w", name, err)
+			}
 		default:
 			return nil, fmt.Errorf("Config option '%s' is not valid", name)
 		}
@@ -170,6 +179,7 @@ func setConfigOptions(config *Config) {
 	setConfigOption(Debug, strconv.FormatBool(config.Debug), config.yamlData)
 	setConfigOption(PullImageOnCreate, strconv.FormatBool(config.PullImageOnCreate), config.yamlData)
 	setConfigOption(DisablePullOnRun, strconv.FormatBool(config.DisablePullOnRun), config.yamlData)
+	setConfigOption(MaxRetries, strconv.Itoa(config.MaxRetries), config.yamlData)
 }
 
 // Set config option on yaml.
@@ -224,7 +234,7 @@ func setConfigOption(configName, configValue string, yamlData *yaml.Node) {
 		var tagType string
 
 		switch configName {
-		case Timeout:
+		case Timeout, MaxRetries:
 			tagType = tagInt
 		case Debug:
 			tagType = tagBool

--- a/pkg/common/file_test.go
+++ b/pkg/common/file_test.go
@@ -50,6 +50,7 @@ var _ = DescribeTable("ReadConfig",
 		Expect(readConfig.Debug).To(Equal(expectedConfig.Debug))
 		Expect(readConfig.PullImageOnCreate).To(Equal(expectedConfig.PullImageOnCreate))
 		Expect(readConfig.DisablePullOnRun).To(Equal(expectedConfig.DisablePullOnRun))
+		Expect(readConfig.MaxRetries).To(Equal(expectedConfig.MaxRetries))
 	},
 
 	Entry("should succeed with valid config", `
@@ -59,6 +60,7 @@ timeout: 10
 debug: true
 pull-image-on-create: true
 disable-pull-on-run: true
+max-retries: 3
 `, &common.Config{
 		RuntimeEndpoint:   "foo",
 		ImageEndpoint:     "bar",
@@ -66,6 +68,7 @@ disable-pull-on-run: true
 		Debug:             true,
 		PullImageOnCreate: true,
 		DisablePullOnRun:  true,
+		MaxRetries:        3,
 	}, false),
 
 	Entry("should succeed with comments", `
@@ -126,6 +129,7 @@ timeout: 20
 	Entry("should fail with invalid 'debug' value", `debug: "foo"`, nil, true),
 	Entry("should fail with invalid 'pull-image-on-create' value", `pull-image-on-create: "foo"`, nil, true),
 	Entry("should fail with invalid 'disable-pull-on-run' value", `disable-pull-on-run: "foo"`, nil, true),
+	Entry("should fail with invalid 'max-retries' value", `max-retries: "foo"`, nil, true),
 )
 
 var _ = DescribeTable("WriteConfig",
@@ -151,6 +155,7 @@ var _ = DescribeTable("WriteConfig",
 		Expect(readConfig.Debug).To(Equal(config.Debug))
 		Expect(readConfig.PullImageOnCreate).To(Equal(config.PullImageOnCreate))
 		Expect(readConfig.DisablePullOnRun).To(Equal(config.DisablePullOnRun))
+		Expect(readConfig.MaxRetries).To(Equal(config.MaxRetries))
 	},
 
 	Entry("should succeed with config", &common.Config{
@@ -160,6 +165,7 @@ var _ = DescribeTable("WriteConfig",
 		Debug:             true,
 		PullImageOnCreate: true,
 		DisablePullOnRun:  true,
+		MaxRetries:        5,
 	}),
 
 	Entry("should succeed with nil config", nil),

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -53,6 +53,7 @@ var _ = t.Describe("config", func() {
 		Expect(cfg).To(MatchRegexp("debug .* false"))
 		Expect(cfg).To(MatchRegexp("pull-image-on-create .* false"))
 		Expect(cfg).To(MatchRegexp("disable-pull-on-run .* false"))
+		Expect(cfg).To(MatchRegexp("max-retries .* 0"))
 	})
 
 	It("should succeed to set config values", func() {
@@ -87,6 +88,7 @@ timeout: 10
 debug: false
 pull-image-on-create: false
 disable-pull-on-run: false
+max-retries: 0
 `))
 	})
 
@@ -123,6 +125,7 @@ image-endpoint: ""
 debug: false
 pull-image-on-create: false
 disable-pull-on-run: false
+max-retries: 0
 `))
 
 		t.CrictlExpectSuccess("--config "+configFile.Name()+" config --get timeout", "30")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Adds `--max-retries` flag (default: 3) with exponential backoff (500ms-5s) for crictl connections to explicitly configured endpoints. Also available via config file and `crictl config`. Set to 0 to disable retries.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Retry only applies to explicit endpoints, not the deprecated default-endpoint fallback. The `newCrictlConfig` refactor into two functions satisfies the nestif linter.

#### Does this PR introduce a user-facing change?
```release-note
Add --max-retries flag for crictl connection retry with exponential backoff (default: 3).
```