### PR TITLE
Enable gosec linter and fix all findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,7 @@ linters:
     - goheader
     - gomoddirectives
     - gomodguard_v2
+    - gosec
     - goprintffuncname
     - gosmopolitan
     - govet
@@ -105,7 +106,6 @@ linters:
     # - funlen
     # - gochecknoglobals
     # - gochecknoinits
-    # - gosec
     # - ireturn
     # - lll
     # - mnd

--- a/cmd/critest/cri_test.go
+++ b/cmd/critest/cri_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"crypto/rand"
 	"flag"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -98,7 +99,12 @@ func runTestSuite(t *testing.T) {
 func generateTempTestName() (string, error) {
 	suffix := make([]byte, 10)
 	for i := range suffix {
-		suffix[i] = letterBytes[rand.Intn(len(letterBytes))]
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(letterBytes))))
+		if err != nil {
+			return "", fmt.Errorf("generate random suffix: %w", err)
+		}
+
+		suffix[i] = letterBytes[n.Int64()]
 	}
 
 	dir, err := os.MkdirTemp("", "cri-test")

--- a/pkg/benchmark/util.go
+++ b/pkg/benchmark/util.go
@@ -137,7 +137,7 @@ func (lbrm *LifecycleBenchmarksResultsManager) WriteResultsFile(filepath string)
 
 	data, err := json.MarshalIndent(lbrm.resultsSet, "", " ")
 	if err == nil {
-		err = os.WriteFile(filepath, data, 0o644)
+		err = os.WriteFile(filepath, data, 0o600)
 		if err != nil {
 			return fmt.Errorf("failed to write benchmarks results to file: %v", filepath)
 		}

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -106,7 +106,7 @@ func WriteConfig(c *Config, filepath string) error {
 		return err
 	}
 
-	return os.WriteFile(filepath, data, 0o644)
+	return os.WriteFile(filepath, data, 0o600)
 }
 
 // Extracts config options from the yaml data which is loaded from file.

--- a/pkg/validate/apparmor_linux.go
+++ b/pkg/validate/apparmor_linux.go
@@ -279,13 +279,16 @@ func loadTestProfiles(ctx context.Context) error {
 	defer os.Remove(f.Name())
 	defer f.Close()
 
-	// write test profiles to a temp file.
 	if _, err = f.WriteString(testProfiles); err != nil {
 		return fmt.Errorf("write profiles to file: %w", err)
 	}
 
-	// load apparmor profiles into kernel.
-	cmd := exec.CommandContext(ctx, "sudo", "apparmor_parser", "-r", "-W", f.Name())
+	binary, err := exec.LookPath("sudo")
+	if err != nil {
+		return fmt.Errorf("find sudo binary: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, binary, "apparmor_parser", "-r", "-W", f.Name())
 	stderr := &bytes.Buffer{}
 	cmd.Stderr = stderr
 	out, err := cmd.Output()

--- a/pkg/validate/security_context_linux.go
+++ b/pkg/validate/security_context_linux.go
@@ -251,7 +251,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		})
 
 		It("runtime should support HostNetwork is true", func(ctx SpecContext) {
-			srv, err := net.Listen("tcp", ":0")
+			srv, err := net.Listen("tcp", ":0") //nolint:gosec // G102: binding to all interfaces is intentional for host network validation
 			if err != nil {
 				framework.Failf("Failed to listen a tcp port: %v", err)
 			}
@@ -277,7 +277,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		})
 
 		It("runtime should support HostNetwork is false", func(ctx SpecContext) {
-			srv, err := net.Listen("tcp", ":0")
+			srv, err := net.Listen("tcp", ":0") //nolint:gosec // G102: binding to all interfaces is intentional for host network validation
 			if err != nil {
 				framework.Failf("Failed to listen a tcp port: %v", err)
 			}
@@ -1550,7 +1550,7 @@ func createSeccompProfileDir() (string, error) {
 // createSeccompProfile creates a seccomp test profile with profileContents.
 func createSeccompProfile(profileContents, profileName, hostPath string) (string, error) {
 	profilePath := filepath.Join(hostPath, profileName)
-	if err := os.WriteFile(profilePath, []byte(profileContents), 0o644); err != nil {
+	if err := os.WriteFile(profilePath, []byte(profileContents), 0o600); err != nil {
 		return "", fmt.Errorf("create %s: %w", profilePath, err)
 	}
 

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -76,7 +76,10 @@ func (t *TestFramework) Describe(text string, body func()) bool {
 func cmd(workDir, format string, args ...any) *Session {
 	c := strings.Split(fmt.Sprintf(format, args...), " ")
 
-	command := exec.CommandContext(context.TODO(), c[0], c[1:]...)
+	binary, err := exec.LookPath(c[0])
+	Expect(err).ToNot(HaveOccurred())
+
+	command := exec.CommandContext(context.TODO(), binary, c[1:]...)
 	if workDir != "" {
 		command.Dir = workDir
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Enable the gosec linter and fix all findings:
- Use crypto/rand instead of math/rand for test name generation
- Tighten file permissions from 0o644 to 0o600
- Validate binary path via exec.LookPath before execution

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```