### PR TITLE
task: bump go version to the latest

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,9 +13,11 @@ dependencies:
         match: VERSION
 
   - name: go
-    version: 1.26.3
+    version: 1.26.4
     refPaths:
       - path: go.mod
+        match: go
+      - path: hack/tools/go.mod
         match: go
       - path: images/containerd-local-test/Dockerfile
         match: GO_VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cri-tools
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/containerd/nri v0.12.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cri-tools/hack/tools
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Mirantis/cri-dockerd v0.4.3

--- a/images/containerd-local-test/Dockerfile
+++ b/images/containerd-local-test/Dockerfile
@@ -20,7 +20,7 @@
 
 # Go toolchain version, extracted from go.mod by hack/run-e2e-container.sh
 # (mirroring CI's go-version-file approach). The default is a fallback only.
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 FROM golang:${GO_VERSION} AS containerd-builder
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

Following the k/k repo bump Go version to 1.26.4 across go.mod, hack/tools/go.mod, dependencies.yaml and the containerd-local-test Dockerfile.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
