### PR TITLE
fix: touch zizmor binary after extraction to prevent repeated downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,8 @@ $(ZIZMOR): $(BUILD_BIN_PATH)
 		-o "$$tmp"; \
 	mkdir -p $(ZIZMOR_DIR); \
 	tar -xzf "$$tmp" -C $(ZIZMOR_DIR) zizmor; \
-	chmod +x $(ZIZMOR)
+	chmod +x $(ZIZMOR); \
+	touch $(ZIZMOR)
 
 .PHONY: verify-go-modules
 verify-go-modules: ## Verify vendored golang modules.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

tar preserves the archive's original timestamp, which can be older than the prerequisite directory. Without touch, Make considers the target out-of-date on every invocation and re-downloads it.

```release-note
NONE
```
