### PR TITLE
crictl: Pre-compile regex patterns for name and namespace filters

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -1407,6 +1407,16 @@ func getFromLabels(labels map[string]string, label string) string {
 }
 
 func getContainersList(ctx context.Context, imageClient internalapi.ImageManagerService, containersList []*pb.Container, opts *listOptions) ([]*pb.Container, error) {
+	nameRe, err := compileRegex(opts.nameRegexp)
+	if err != nil {
+		return nil, err
+	}
+
+	nsRe, err := compileRegex(opts.podNamespaceRegexp)
+	if err != nil {
+		return nil, err
+	}
+
 	filtered := []*pb.Container{}
 
 	for _, c := range containersList {
@@ -1419,8 +1429,8 @@ func getContainersList(ctx context.Context, imageClient internalapi.ImageManager
 		podNamespace := getPodNamespaceFromLabels(c.GetLabels())
 		// Filter by pod name/namespace regular expressions.
 		if c.GetMetadata() != nil &&
-			matchesRegex(opts.nameRegexp, c.GetMetadata().GetName()) &&
-			matchesRegex(opts.podNamespaceRegexp, podNamespace) {
+			matchesRegex(nameRe, c.GetMetadata().GetName()) &&
+			matchesRegex(nsRe, podNamespace) {
 			filtered = append(filtered, c)
 		}
 	}

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -576,7 +576,7 @@ func ListPodSandboxes(ctx context.Context, client internalapi.RuntimeService, op
 		return nil, fmt.Errorf("call list sandboxes RPC: %w", err)
 	}
 
-	return getSandboxesList(r, opts), nil
+	return getSandboxesList(r, opts)
 }
 
 // OutputPodSandboxes sends a ListPodSandboxRequest to the server, and parses
@@ -724,13 +724,23 @@ func getSandboxesRuntimeHandler(sandbox *pb.PodSandbox) string {
 	return sandbox.GetRuntimeHandler()
 }
 
-func getSandboxesList(sandboxesList []*pb.PodSandbox, opts *listOptions) []*pb.PodSandbox {
+func getSandboxesList(sandboxesList []*pb.PodSandbox, opts *listOptions) ([]*pb.PodSandbox, error) {
+	nameRe, err := compileRegex(opts.nameRegexp)
+	if err != nil {
+		return nil, err
+	}
+
+	nsRe, err := compileRegex(opts.podNamespaceRegexp)
+	if err != nil {
+		return nil, err
+	}
+
 	filtered := []*pb.PodSandbox{}
 
 	for _, p := range sandboxesList {
 		// Filter by pod name/namespace regular expressions.
-		if p.GetMetadata() != nil && matchesRegex(opts.nameRegexp, p.GetMetadata().GetName()) &&
-			matchesRegex(opts.podNamespaceRegexp, p.GetMetadata().GetNamespace()) {
+		if p.GetMetadata() != nil && matchesRegex(nameRe, p.GetMetadata().GetName()) &&
+			matchesRegex(nsRe, p.GetMetadata().GetNamespace()) {
 			filtered = append(filtered, p)
 		}
 	}
@@ -739,5 +749,5 @@ func getSandboxesList(sandboxesList []*pb.PodSandbox, opts *listOptions) []*pb.P
 		return cmp.Compare(b.GetCreatedAt(), a.GetCreatedAt()) // descending
 	})
 
-	return filtered[:truncateCount(len(filtered), opts.latest, opts.last)]
+	return filtered[:truncateCount(len(filtered), opts.latest, opts.last)], nil
 }

--- a/cmd/crictl/sandbox_test.go
+++ b/cmd/crictl/sandbox_test.go
@@ -69,7 +69,8 @@ var _ = DescribeTable("getSandboxesRuntimeHandler",
 
 var _ = DescribeTable("getSandboxesList",
 	func(input []*pb.PodSandbox, options *listOptions, indexes []int) {
-		actual := getSandboxesList(input, options)
+		actual, err := getSandboxesList(input, options)
+		Expect(err).NotTo(HaveOccurred())
 
 		expected := make([]*pb.PodSandbox, 0, len(indexes))
 		for _, i := range indexes {

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -557,18 +557,25 @@ func getTruncatedID(id, prefix string) string {
 	return id
 }
 
-func matchesRegex(pattern, target string) bool {
+func compileRegex(pattern string) (*regexp.Regexp, error) {
 	if pattern == "" {
+		return nil, nil
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regular expression %q: %w", pattern, err)
+	}
+
+	return re, nil
+}
+
+func matchesRegex(re *regexp.Regexp, target string) bool {
+	if re == nil {
 		return true
 	}
 
-	matched, err := regexp.MatchString(pattern, target)
-	if err != nil {
-		// Assume it's not a match if an error occurs.
-		return false
-	}
-
-	return matched
+	return re.MatchString(target)
 }
 
 func matchesImage(ctx context.Context, imageClient internalapi.ImageManagerService, image, containerImage string) (bool, error) {

--- a/cmd/crictl/util_test.go
+++ b/cmd/crictl/util_test.go
@@ -72,6 +72,49 @@ func TestGetSortedKeys(t *testing.T) {
 	}
 }
 
+func TestCompileRegex(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty pattern returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		re, err := compileRegex("")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if re != nil {
+			t.Errorf("expected nil regexp for empty pattern, got %v", re)
+		}
+	})
+
+	t.Run("valid pattern compiles", func(t *testing.T) {
+		t.Parallel()
+
+		re, err := compileRegex("iner$")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if re == nil {
+			t.Error("expected non-nil regexp")
+		}
+	})
+
+	t.Run("invalid pattern returns error", func(t *testing.T) {
+		t.Parallel()
+
+		re, err := compileRegex("[invalid")
+		if err == nil {
+			t.Error("expected error for invalid regex")
+		}
+
+		if re != nil {
+			t.Errorf("expected nil regexp for invalid pattern, got %v", re)
+		}
+	})
+}
+
 func TestNameFilterByRegex(t *testing.T) {
 	t.Parallel()
 
@@ -116,7 +159,12 @@ func TestNameFilterByRegex(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			r := matchesRegex(tc.pattern, tc.name)
+			re, err := compileRegex(tc.pattern)
+			if err != nil {
+				t.Fatalf("unexpected compile error: %v", err)
+			}
+
+			r := matchesRegex(re, tc.name)
 			if r != tc.isMatch {
 				t.Errorf("expected matched to be %v; actual result is %v", tc.isMatch, r)
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Compile user-supplied regular expressions once before filtering instead of re-compiling on every item in the list. This surfaces invalid regex errors to the user immediately rather than silently treating them as non-matches.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The `compileRegex` helper returns a `*regexp.Regexp` (or nil for empty patterns), and `matchesRegex` takes the compiled result. Both `getContainersList` and `getSandboxesList` now compile upfront and return errors for invalid patterns. `getSandboxesList` gains an error return value accordingly.

#### Does this PR introduce a user-facing change?
```release-note
crictl: Invalid regex patterns for name and namespace filters now return a clear error instead of silently matching nothing.
```