### PR TITLE
crictl: Fix CLI flag names in inspect fallback path

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -540,9 +540,9 @@ var containerStatusCommand = &cli.Command{
 
 		if len(ids) == 0 {
 			opts := &listOptions{
-				nameRegexp:         c.String("^name$"),
+				nameRegexp:         c.String("name"),
 				podID:              c.String("pod"),
-				podNamespaceRegexp: c.String("^namespace$"),
+				podNamespaceRegexp: c.String("namespace"),
 				image:              c.String("image"),
 				state:              c.String("state"),
 				latest:             c.Bool("latest"),


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The inspect command's fallback to container listing used `c.String("^name$")` and `c.String("^namespace$")`, which look up non-existent CLI flags instead of the defined `name` and `namespace` flags. This caused the name and namespace filters to always be empty in the inspect code path.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The correct flag lookups (`c.String("name")` / `c.String("namespace")`) are already used in `containerStatusAction` at line 685/691. This fix aligns the inspect fallback path with the rest of the code.

#### Does this PR introduce a user-facing change?
```release-note
crictl: Fix inspect command's name and namespace filters being silently ignored.
```