### PR TITLE
crictl: Do not advertise base64 env values in JSON schema

### DIFF
--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -235,8 +235,29 @@ func loadContainerConfig(path string) (*pb.ContainerConfig, error) {
 	return &config, nil
 }
 
+// stripKeyValueContentEncoding removes the base64 content encoding from the
+// reflected pb.KeyValue schema.
+//
+// pb.KeyValue stores the value as []byte, which reflection renders as a base64
+// encoded string. The CRI API implements custom JSON marshaling for
+// pb.KeyValue to keep encoding the value as a plain string, which is what the
+// config parsers in this package accept as well. Advertising base64 in the
+// schema would point users and code generators to an encoding crictl does not
+// understand.
+func stripKeyValueContentEncoding(schema *jsonschema.Schema) {
+	definition, ok := schema.Definitions[reflect.TypeFor[pb.KeyValue]().Name()]
+	if !ok || definition.Properties == nil {
+		return
+	}
+
+	if value, ok := definition.Properties.Get("value"); ok {
+		value.ContentEncoding = ""
+	}
+}
+
 func printJSONSchema(value any) error {
 	schema := jsonschema.Reflect(value)
+	stripKeyValueContentEncoding(schema)
 
 	data, err := json.MarshalIndent(schema, "", "  ")
 	if err != nil {

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -236,14 +236,8 @@ func loadContainerConfig(path string) (*pb.ContainerConfig, error) {
 }
 
 // stripKeyValueContentEncoding removes the base64 content encoding from the
-// reflected pb.KeyValue schema.
-//
-// pb.KeyValue stores the value as []byte, which reflection renders as a base64
-// encoded string. The CRI API implements custom JSON marshaling for
-// pb.KeyValue to keep encoding the value as a plain string, which is what the
-// config parsers in this package accept as well. Advertising base64 in the
-// schema would point users and code generators to an encoding crictl does not
-// understand.
+// reflected pb.KeyValue schema so it matches the custom JSON marshaling that
+// keeps values as plain strings.
 func stripKeyValueContentEncoding(schema *jsonschema.Schema) {
 	definition, ok := schema.Definitions[reflect.TypeFor[pb.KeyValue]().Name()]
 	if !ok || definition.Properties == nil {

--- a/cmd/crictl/util_test.go
+++ b/cmd/crictl/util_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -27,6 +28,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/urfave/cli/v2"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func TestGetSortedKeys(t *testing.T) {
@@ -401,6 +403,55 @@ func TestLoadContainerConfigNotFound(t *testing.T) {
 
 	if !strings.Contains(err.Error(), filename) {
 		t.Errorf("expected error message to contain %q, got %q", filename, err.Error())
+	}
+}
+
+//nolint:paralleltest // replaces os.Stdout
+func TestPrintJSONSchemaEnvValueIsPlainString(t *testing.T) {
+	tmpfile, err := os.CreateTemp(t.TempDir(), "jsonschema-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer tmpfile.Close()
+
+	old := os.Stdout
+	os.Stdout = tmpfile
+
+	defer func() { os.Stdout = old }()
+
+	if err := printJSONSchema(&pb.ContainerConfig{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out, err := os.ReadFile(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var schema struct {
+		Defs map[string]struct {
+			Properties map[string]struct {
+				Type            string `json:"type"`
+				ContentEncoding string `json:"contentEncoding"`
+			} `json:"properties"`
+		} `json:"$defs"`
+	}
+
+	if err := json.Unmarshal(out, &schema); err != nil {
+		t.Fatalf("unmarshal JSON schema: %v", err)
+	}
+
+	value := schema.Defs["KeyValue"].Properties["value"]
+
+	if value.Type != "string" {
+		t.Errorf("expected KeyValue value type %q, got %q", "string", value.Type)
+	}
+
+	// The CRI API encodes KeyValue values as plain strings, which is also what
+	// loadContainerConfig accepts. The schema must not advertise base64.
+	if value.ContentEncoding != "" {
+		t.Errorf("expected empty content encoding for KeyValue value, got %q", value.ContentEncoding)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`crictl create jsonschema --container` and `crictl run jsonschema --container` publish a machine readable schema that contradicts crictl's own config parser: the schema says `envs[].value` is base64, the parser accepts plain text.

**Evidence 1 — what the schema says on `master`:**

```console
$ go build -o ./crictl ./cmd/crictl
$ ./crictl create jsonschema --container | grep -A4 '"value"'
      "value": {
        "type": "string",
        "contentEncoding": "base64"
      }
    },
```

**Evidence 2 — what the parser actually does on `master`** (`loadContainerConfig` on a config with a single env var):

```
config value: "hello"      ->  parsed env value: "hello"
config value: "aGVsbG8="   ->  parsed env value: "aGVsbG8="     # expected "hello"
```

Base64 is not rejected, it is taken literally. So a user or a code generator that trusts the published schema and encodes the value gets a container whose env var contains the base64 text, with no error — which is exactly the bad path #2127 complains about.

Root cause: `KeyValue` regained a plain string `value` encoding through the custom `MarshalJSON`/`UnmarshalJSON` added upstream in kubernetes/kubernetes#139964, which landed here with the `k8s.io/cri-api` v0.36.3 bump in 895f236b (#2152). Those methods only affect the `encoding/json` path used by `sigs.k8s.io/yaml` when parsing configs. `printJSONSchema` goes through `github.com/invopop/jsonschema`, which reflects over the Go struct and still renders the underlying `[]byte` as `contentEncoding: base64`. The parser side was fixed, the reflection side was missed.

This PR removes `contentEncoding` from the reflected `KeyValue` definition, so the schema again matches what the parser accepts. The rest of the schema is untouched — the only diff in `crictl create jsonschema --container` output is:

```diff
       "value": {
-        "type": "string",
-        "contentEncoding": "base64"
+        "type": "string"
       }
```

#### Which issue(s) this PR fixes:

Fixes #2153
Relates to #2127

#### Special notes for your reviewer:

**Scope.** Only the reflection based `jsonschema` output is changed. There is a second base64 producing path in `protobufObjectToJSON` (`protojson`), but `KeyValue` is input-only for crictl — it appears solely in `ContainerConfig.envs`, which crictl never `protojson`-marshals — so that path has no user visible problem here and is deliberately left alone.

**Implementation choice.** `invopop/jsonschema` offers `Reflector.Mapper` for type specific overrides, but a `Mapper` hit returns before the type is registered, which inlines `KeyValue` at its use site and drops the `#/$defs/KeyValue` entry — a needless, larger change to a published artifact that code generators consume. Clearing `ContentEncoding` on the reflected definition (all public API: `Schema.Definitions`, `Properties.Get`, `Schema.ContentEncoding`) keeps `$defs` intact and reduces the output diff to the two lines above. Happy to switch to `Mapper` if you prefer that even with the `$defs` change.

**Release impact.** The mismatch is not in v1.36.0, which pins cri-api v0.36.0 where the parser and the schema agree on base64. It only exists on `master` since 895f236b, so this lands before it can ship.

**Testing.**

- New `TestPrintJSONSchemaEnvValueIsPlainString` in `cmd/crictl/util_test.go` asserts the printed schema describes `KeyValue.value` as a plain string with no `contentEncoding`. It fails on `master` and passes with this change:

  ```console
  # before (fix reverted)
  --- FAIL: TestPrintJSONSchemaEnvValueIsPlainString (0.00s)
      util_test.go:454: expected empty content encoding for KeyValue value, got "base64"

  # after
  --- PASS: TestPrintJSONSchemaEnvValueIsPlainString (0.04s)
  ```

- `go test ./cmd/crictl/... -count=1`, `go build ./...`, `gofmt`, and `golangci-lint run ./cmd/crictl/...` (for both the host GOOS and `GOOS=linux`) are clean.
- `critest` and the `crictl` e2e suites were not run locally: they need a live containerd/CRI-O, which this change does not touch.

/cc @SergeyKanzhelev @bitoku

#### Does this PR introduce a user-facing change?

```release-note
crictl now describes container environment variable values as plain strings in the output of `crictl create jsonschema --container` and `crictl run jsonschema --container`, instead of incorrectly advertising them as base64 encoded.
```
