### PR TITLE
Fix crictl logs --previous panic on a log path with no extension

### DIFF
--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -174,8 +174,7 @@ var logsCommand = &cli.Command{
 				return fmt.Errorf("previous terminated container %s not found", status.GetStatus().GetMetadata().GetName())
 			}
 
-			logPath = fmt.Sprintf("%s%s%s", logPath[:strings.LastIndex(logPath, "/")+1], strconv.FormatUint(uint64(containerAttempt-1), 10),
-				logPath[strings.LastIndex(logPath, "."):])
+			logPath = previousLogPath(logPath, containerAttempt-1)
 		}
 		// build a WithCancel context based on cli.context
 		readLogCtx, cancelFn := context.WithCancel(c.Context)
@@ -233,4 +232,21 @@ func parseTimestamp(value string) (time.Time, error) {
 	}
 
 	return time.Unix(s, ns), nil
+}
+
+// previousLogPath returns the log path of an earlier attempt of the same
+// container, by swapping the attempt number in the file name. The runtime
+// reports the log path, and nothing guarantees it carries an extension, so a
+// name without a dot keeps whatever suffix it has rather than being sliced at
+// a negative index.
+func previousLogPath(logPath string, attempt uint32) string {
+	dir := logPath[:strings.LastIndex(logPath, "/")+1]
+	name := logPath[len(dir):]
+
+	extension := ""
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		extension = name[i:]
+	}
+
+	return dir + strconv.FormatUint(uint64(attempt), 10) + extension
 }

--- a/cmd/crictl/logs_test.go
+++ b/cmd/crictl/logs_test.go
@@ -174,3 +174,52 @@ func TestParseTimestamp(t *testing.T) {
 		})
 	}
 }
+
+func TestPreviousLogPath(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		logPath  string
+		attempt  uint32
+		expected string
+	}{
+		{
+			name:     "kubelet style path",
+			logPath:  "/var/log/pods/ns_pod_uid/container/1.log",
+			attempt:  0,
+			expected: "/var/log/pods/ns_pod_uid/container/0.log",
+		},
+		{
+			name:     "no extension",
+			logPath:  "/tmp/logs/1",
+			attempt:  0,
+			expected: "/tmp/logs/0",
+		},
+		{
+			name:     "no directory and no extension",
+			logPath:  "1",
+			attempt:  0,
+			expected: "0",
+		},
+		{
+			name:     "dot in a directory name only",
+			logPath:  "/var/log/my.logs/2",
+			attempt:  1,
+			expected: "/var/log/my.logs/1",
+		},
+		{
+			name:     "double extension keeps the last one",
+			logPath:  "/var/log/pods/ns_pod_uid/container/3.log.txt",
+			attempt:  2,
+			expected: "/var/log/pods/ns_pod_uid/container/2.txt",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			g := NewWithT(t)
+			g.Expect(previousLogPath(tc.logPath, tc.attempt)).To(Equal(tc.expected))
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`crictl logs --previous` builds the earlier attempt's path like this:

```go
logPath = fmt.Sprintf("%s%s%s", logPath[:strings.LastIndex(logPath, "/")+1],
    strconv.FormatUint(uint64(containerAttempt-1), 10),
    logPath[strings.LastIndex(logPath, "."):])
```

`strings.LastIndex` returns -1 when there is no dot, so `logPath[-1:]` panics:

```
panic: runtime error: slice bounds out of range [-1:]
```

`logPath` is whatever the runtime reports for the container. Kubelet-created containers get `/var/log/pods/<ns>_<pod>_<uid>/<container>/0.log`, which always has the extension, but a container created directly with `crictl create` carries whatever `log_path` was in its config, and nothing requires an extension there. So `crictl logs --previous` on a container someone made with crictl itself can die with a stack trace rather than an error message.

The path computation moves into a `previousLogPath` helper that keeps the extension when there is one and leaves the name alone otherwise. Behavior for kubelet-style paths is unchanged.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The helper exists mostly so the case is testable, the surrounding function needs a runtime service to reach. Table test covers the kubelet path, a path with no extension, a bare name with neither directory nor extension, a dot that appears only in a directory name, and a double extension. The no-extension cases panic with the previous expression, which I confirmed by running it directly before removing it.

#### Does this PR introduce a user-facing change?

```release-note
Fix a panic in `crictl logs --previous` when the container log path has no file extension.
```
