### PR TITLE
crictl: allow config to create a missing --config file

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -216,9 +216,8 @@ func run() error {
 
 		if config, err = common.GetServerConfigFromFile(context.String("config"), exePath); err != nil {
 			if context.IsSet("config") {
-				// `crictl config` can create a missing file; allow that path through.
-				// Other subcommands still require an existing --config path.
-				isConfigCmd := context.Args().Present() && context.Args().First() == "config"
+				// crictl config can create a missing file; let it through.
+				isConfigCmd := context.Args().First() == "config"
 				if !isConfigCmd || !errors.Is(err, os.ErrNotExist) {
 					return fmt.Errorf("get server config: %w", err)
 				}

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -215,7 +216,12 @@ func run() error {
 
 		if config, err = common.GetServerConfigFromFile(context.String("config"), exePath); err != nil {
 			if context.IsSet("config") {
-				return fmt.Errorf("get server config: %w", err)
+				// `crictl config` can create a missing file; allow that path through.
+				// Other subcommands still require an existing --config path.
+				isConfigCmd := context.Args().Present() && context.Args().First() == "config"
+				if !isConfigCmd || !errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("get server config: %w", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
`crictl --config /path/to/new.yaml config --set debug=true` used to die in `app.Before` with `get server config` when the file was not there yet. The config subcommand already knows how to create the file; this just lets that path through when the error is `ErrNotExist`.

Other commands still require an existing `--config` path.

Fixes #2143