### PR TITLE
Fix various correctness issues and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,8 @@ ifeq ($(GOOS),windows)
 	BIN_EXT := .exe
 endif
 
-# test for go module support
-ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
-export GO_BUILD=GO111MODULE=on GOARCH=$(GOARCH) GOOS=$(GOOS) $(GO) build -mod=vendor
-export GO_TEST=GO111MODULE=on GOARCH=$(GOARCH) GOOS=$(GOOS) $(GO) test -mod=vendor
-else
-export GO_BUILD=GOARCH=$(GOARCH) GOOS=$(GOOS) $(GO) build
-export GO_TEST=GOARCH=$(GOARCH) GOOS=$(GOOS) $(GO) test
-endif
+export GO_BUILD=GOARCH=$(GOARCH) GOOS=$(GOOS) $(GO) build -mod=vendor
+export GO_TEST=GOARCH=$(GOARCH) GOOS=$(GOOS) $(GO) test -mod=vendor
 
 PROJECT := sigs.k8s.io/cri-tools
 BINDIR ?= /usr/local/bin
@@ -77,7 +71,7 @@ COLOR:=\\033[36m
 NOCOLOR:=\\033[0m
 WIDTH:=30
 
-.PHONY: helpIn
+.PHONY: help
 help: ## Display this help.
 	@awk \
 		-v "col=${COLOR}" -v "nocol=${NOCOLOR}" \
@@ -359,7 +353,7 @@ $(GOLANGCI_LINT):
 
 .PHONY: vendor
 vendor: ## Update vendored golang modules.
-	export GO111MODULE=on GOSUMDB= && \
+	export GOSUMDB= && \
 		$(GO) mod tidy && \
 		$(GO) mod vendor && \
 		$(GO) mod verify

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -272,7 +272,7 @@ var updateContainerCommand = &cli.Command{
 			Name:  "cpuset-mems",
 			Usage: "Memory node(s) to use",
 		},
-		&cli.StringFlag{
+		&cli.Int64Flag{
 			Name:  "oom-score-adj",
 			Usage: "OOM Killer score to use",
 		},
@@ -889,7 +889,7 @@ func CreateContainer(
 		// Add possible OCI volume mounts
 		for _, m := range config.GetMounts() {
 			if m.GetImage() != nil && m.GetImage().GetImage() != "" {
-				logrus.Infof("Pulling image %s to be mounted to container path: %s", image, m.GetContainerPath())
+				logrus.Infof("Pulling image %s to be mounted to container path: %s", m.GetImage().GetImage(), m.GetContainerPath())
 				images = append(images, m.GetImage().GetImage())
 			}
 		}
@@ -1039,7 +1039,7 @@ func CheckpointContainer(
 	}
 	logrus.Debugf("CheckpointContainerRequest: %v", request)
 
-	_, err := InterruptableRPC(ctx, func(ctx context.Context) (*pb.ImageFsInfoResponse, error) {
+	_, err := InterruptableRPC(ctx, func(ctx context.Context) (any, error) {
 		return nil, rClient.CheckpointContainer(ctx, request)
 	})
 	if err != nil {
@@ -1105,8 +1105,7 @@ func marshalContainerStatus(cs *pb.ContainerStatus) (string, error) {
 	jsonMap["startedAt"] = startedAt.Format(time.RFC3339Nano)
 	jsonMap["finishedAt"] = finishedAt.Format(time.RFC3339Nano)
 
-	//nolint:govet // copying the lock is not harmful in this place
-	return marshalMapInOrder(jsonMap, *cs)
+	return marshalMapInOrder(jsonMap, cs)
 }
 
 // containerStatus sends a ContainerStatusRequest to the server, and parses

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -301,8 +301,8 @@ func tlsConfigFromFlags(ctx *cli.Context) (*rest.TLSClientConfig, error) {
 
 	if cfg.CertFile == "" || cfg.KeyFile == "" {
 		return nil, fmt.Errorf(
-			"all two flags --%s and --%s are required for TLS streaming, only --%s is optional",
-			flagTLSCA, flagTLSCert, flagTLSKey,
+			"both flags --%s and --%s are required for TLS streaming, only --%s is optional",
+			flagTLSCert, flagTLSKey, flagTLSCA,
 		)
 	}
 

--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -174,8 +174,14 @@ var logsCommand = &cli.Command{
 				return fmt.Errorf("previous terminated container %s not found", status.GetStatus().GetMetadata().GetName())
 			}
 
-			logPath = fmt.Sprintf("%s%s%s", logPath[:strings.LastIndex(logPath, "/")+1], strconv.FormatUint(uint64(containerAttempt-1), 10),
-				logPath[strings.LastIndex(logPath, "."):])
+			dotIdx := strings.LastIndex(logPath, ".")
+
+			ext := ""
+			if dotIdx != -1 {
+				ext = logPath[dotIdx:]
+			}
+
+			logPath = fmt.Sprintf("%s%s%s", logPath[:strings.LastIndex(logPath, "/")+1], strconv.FormatUint(uint64(containerAttempt-1), 10), ext)
 		}
 		// build a WithCancel context based on cli.context
 		readLogCtx, cancelFn := context.WithCancel(c.Context)

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -450,8 +450,7 @@ func marshalPodSandboxStatus(ps *pb.PodSandboxStatus) (string, error) {
 
 	jsonMap["createdAt"] = time.Unix(0, ps.GetCreatedAt()).Format(time.RFC3339Nano)
 
-	//nolint:govet // copying the lock is not harmful in this place
-	return marshalMapInOrder(jsonMap, *ps)
+	return marshalMapInOrder(jsonMap, ps)
 }
 
 // podSandboxStatus sends a PodSandboxStatusRequest to the server, and parses
@@ -503,7 +502,7 @@ func outputPodSandboxStatusTable(r *pb.PodSandboxStatusResponse, verbose bool) {
 
 	fmt.Printf("Status: %s\n", r.GetStatus().GetState())
 	ctm := time.Unix(0, r.GetStatus().GetCreatedAt())
-	fmt.Printf("Created: %v\n", ctm)
+	fmt.Printf("Created: %v\n", units.HumanDuration(time.Now().UTC().Sub(ctm))+" ago")
 
 	if r.GetStatus().GetNetwork() != nil {
 		fmt.Printf("IP Addresses: %v\n", r.GetStatus().GetNetwork().GetIp())

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -497,7 +497,7 @@ func marshalMapInOrder(m map[string]any, t any) (string, error) {
 	var sb strings.Builder
 	sb.WriteString("{")
 
-	v := reflect.ValueOf(t)
+	v := reflect.Indirect(reflect.ValueOf(t))
 	numFields := v.Type().NumField()
 	fieldCount := 0
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Fixes several correctness bugs, go vet warnings, and dead code across crictl:

- Fix `--oom-score-adj` flag type from `StringFlag` to `Int64Flag` (value was silently discarded)
- Fix panic in `logs --previous` with extensionless log paths
- Fix TLS error message naming wrong required/optional flags
- Fix wrong image name in volume mount pull log message
- Fix go vet mutex copy warnings by passing pointers to `marshalMapInOrder` and using `reflect.Indirect` to handle them
- Fix `CheckpointContainer` `InterruptableRPC` type parameter
- Use consistent `HumanDuration` time format in sandbox status output
- Fix Makefile `.PHONY` typo and remove dead `GO111MODULE` check

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The `marshalMapInOrder` change in `util.go` uses `reflect.Indirect` to dereference pointers, which is necessary because the callers in `container.go` and `sandbox.go` now pass pointers instead of copying the protobuf structs by value.

#### Does this PR introduce a user-facing change?

```release-note
Fix `crictl update --oom-score-adj` flag being silently ignored, fix panic in `crictl logs --previous` with extensionless log paths, and fix misleading TLS streaming error message.
```