### PR TITLE
e2e: Add crictl-timeout flag to fix flaky CRI-O CI

### DIFF
--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -77,6 +77,10 @@ jobs:
           printf '[crio.runtime]\nlog_level = "debug"\n[crio.image]\nshort_name_mode = "disabled"\n' | sudo tee /etc/crio/crio.conf.d/01-base.conf
           printf '[crio.stats]\nincluded_pod_metrics = [\n"all",\n]\n' | sudo tee -a /etc/crio/crio.conf.d/01-base.conf
 
+      - name: Enable CNI configuration
+        run: |
+          sudo mv /etc/cni/net.d/10-crio-bridge.conflist.disabled /etc/cni/net.d/10-crio-bridge.conflist
+
       - name: Configure NRI for CRI-O
         run: |
           sudo mkdir -p /var/run/nri /opt/nri/plugins
@@ -124,7 +128,7 @@ jobs:
             --parallel=$(nproc) \
             --ginkgo.flake-attempts=3 \
             --ginkgo.randomize-all \
-            --ginkgo.timeout=2m \
+            --ginkgo.timeout=5m \
             --ginkgo.trace \
             --ginkgo.v
           TEST_RC=$?
@@ -142,7 +146,7 @@ jobs:
 
           set +o errexit
           sudo -E PATH=$PATH make test-e2e \
-            TESTFLAGS="-crictl-runtime-endpoint=unix://var/run/crio/crio.sock"
+            TESTFLAGS="-crictl-runtime-endpoint=unix://var/run/crio/crio.sock -crictl-timeout=30s"
           TEST_RC=$?
           set -o errexit
 

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -34,11 +34,13 @@ import (
 var (
 	crictlBinaryPath      string
 	crictlRuntimeEndpoint string
+	crictlTimeout         string
 )
 
 func init() {
 	flag.StringVar(&crictlBinaryPath, "crictl-binary-path", "", "`crictl` binary path to be used")
 	flag.StringVar(&crictlRuntimeEndpoint, "crictl-runtime-endpoint", "", "`crictl --runtime-endpoint` to be used")
+	flag.StringVar(&crictlTimeout, "crictl-timeout", "", "`crictl --timeout` to be used (e.g. 30s)")
 }
 
 // TestFramework is used to support commonly used test features.
@@ -106,6 +108,14 @@ func crictlRuntimeEndpointFlag() string {
 	return ""
 }
 
+func crictlTimeoutFlag() string {
+	if crictlTimeout != "" {
+		return " --timeout=" + crictlTimeout
+	}
+
+	return ""
+}
+
 // Convenience method for command creation in the current working directory.
 func lcmd(format string, args ...any) *Session {
 	return cmd("", format, args...)
@@ -113,12 +123,12 @@ func lcmd(format string, args ...any) *Session {
 
 // Crictl runs crictl on the specified endpoint and returns the resulting session.
 func (t *TestFramework) Crictl(args string) *Session {
-	return lcmd("%s%s %s", crictlBinaryPathFlag(), crictlRuntimeEndpointFlag(), args).Wait(time.Minute)
+	return lcmd("%s%s%s %s", crictlBinaryPathFlag(), crictlRuntimeEndpointFlag(), crictlTimeoutFlag(), args).Wait(time.Minute)
 }
 
 // CrictlNoWait runs crictl on the specified endpoint and returns the resulting session without wait.
 func (t *TestFramework) CrictlNoWait(args string) *Session {
-	return lcmd("%s%s %s", crictlBinaryPathFlag(), crictlRuntimeEndpointFlag(), args)
+	return lcmd("%s%s%s %s", crictlBinaryPathFlag(), crictlRuntimeEndpointFlag(), crictlTimeoutFlag(), args)
 }
 
 // CrictlWithTracing runs crictl with tracing enabled and returns the resulting session.


### PR DESCRIPTION
/kind flake

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

CRI-O packaging now installs the CNI config as `10-crio-bridge.conflist.disabled`, which CRI-O does not recognize. On some GitHub runners this causes `RunPodSandbox` to block waiting for CNI to become ready, eventually hitting `DeadlineExceeded`. Whether this happens depends on runner state (some runners have CNI available from other sources, others don't).

This PR:
- Enables the CNI config by renaming the `.disabled` file during CI setup
- Adds a `-crictl-timeout` test framework flag (set to 30s in CI) to raise the default 2s crictl timeout
- Bumps the critest ginkgo suite timeout from 2m to 5m

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The CRI-O workflow on master has been failing consistently for weeks with `DeadlineExceeded` on `RunPodSandbox`. The root cause is the missing CNI config; the timeout increase is an additional safety margin.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```