### PR TITLE
critest: fix image volume subpath test cleanup

### DIFF
--- a/pkg/validate/image_volume.go
+++ b/pkg/validate/image_volume.go
@@ -336,9 +336,10 @@ var _ = framework.KubeDescribe("Image Volume [Feature:ImageVolume]", func() {
 
 			podID, podConfig := framework.CreatePodSandboxForContainer(ctx, rc)
 
-			// Register pod sandbox cleanup before CreateContainer so that
-			// the sandbox is removed even when the test is skipped (e.g.
-			// containerd 1.7 does not support image volumes).
+			// Use best-effort cleanup because CRI-O cannot remove
+			// containers with read-only image volume subpath mounts.
+			// Placed before CreateContainer so it runs even when the
+			// test is skipped (e.g. containerd 1.7).
 			defer func() {
 				By("stop PodSandbox")
 				rc.StopPodSandbox(ctx, podID) //nolint:errcheck // best-effort cleanup
@@ -378,6 +379,8 @@ var _ = framework.KubeDescribe("Image Volume [Feature:ImageVolume]", func() {
 			// CRI-O cannot remove containers with read-only image volume
 			// subpath mounts (unlinkat fails on the read-only filesystem).
 			defer func() {
+				By("stop Container")
+				rc.StopContainer(ctx, containerID, defaultStopContainerTimeout) //nolint:errcheck // best-effort, CRI-O subpath bug
 				By("delete Container")
 				rc.RemoveContainer(ctx, containerID) //nolint:errcheck // best-effort, CRI-O subpath bug
 			}()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes two issues found during review of #2166:
- Adds `StopContainer` before `RemoveContainer` in the subpath test's container cleanup defer, matching the fix already applied to the "should correctly mount image and enforce read-only" test. Without this, `RemoveContainer` runs on a running container before `StopPodSandbox` has a chance to stop it.
- Clarifies the pod sandbox defer comment to describe what the code does (best-effort cleanup for CRI-O subpath bug) rather than implying the defer was relocated.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Follow-up to #2166.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```