### PR TITLE
Add pod checkpoint/restore commands

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -103,6 +103,8 @@ func run() error {
 		metricDescriptorsCommand,
 		completionCommand,
 		checkpointContainerCommand,
+		checkpointPodCommand,
+		restorePodCommand,
 		runtimeConfigCommand,
 		eventsCommand,
 		updateRuntimeConfigCommand,

--- a/cmd/crictl/pod_checkpoint.go
+++ b/cmd/crictl/pod_checkpoint.go
@@ -1,0 +1,185 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+var checkpointPodCommand = &cli.Command{
+	Name:                   "checkpointp",
+	Usage:                  "Checkpoint a running pod sandbox",
+	ArgsUsage:              "POD-ID",
+	UseShortOptionHandling: true,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "path",
+			Aliases: []string{"p"},
+			Usage:   "Path to the directory where the checkpoint will be stored",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		if c.NArg() == 0 {
+			return errors.New("POD-ID cannot be empty")
+		}
+
+		if c.NArg() > 1 {
+			return errors.New("only one pod sandbox can be checkpointed at a time")
+		}
+
+		path := c.String("path")
+		if path == "" {
+			return errors.New(
+				"cannot checkpoint a pod without specifying the checkpoint path. " +
+					"Use --path=/path/to/checkpoint/dir",
+			)
+		}
+
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
+		if err != nil {
+			return err
+		}
+
+		podID := c.Args().First()
+
+		containers, err := runtimeClient.ListContainers(c.Context, &pb.ContainerFilter{
+			PodSandboxId: podID,
+			State: &pb.ContainerStateValue{
+				State: pb.ContainerState_CONTAINER_RUNNING,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("listing running containers for pod %q failed: %w", podID, err)
+		}
+
+		if len(containers) == 0 {
+			return fmt.Errorf("pod %q has no running containers to checkpoint", podID)
+		}
+
+		containerIDs := make([]string, 0, len(containers))
+		for _, container := range containers {
+			containerIDs = append(containerIDs, container.GetId())
+		}
+
+		request := &pb.CheckpointPodRequest{
+			PodSandboxId: podID,
+			OutputPath:   path,
+			ContainerIds: containerIDs,
+		}
+		logrus.Debugf("CheckpointPodRequest: %v", request)
+
+		_, err = InterruptableRPC(c.Context, func(
+			ctx context.Context,
+		) (*pb.CheckpointPodResponse, error) {
+			return nil, runtimeClient.CheckpointPod(ctx, request)
+		})
+		if err != nil {
+			return fmt.Errorf("checkpointing pod %q failed: %w", podID, err)
+		}
+
+		fmt.Printf("Pod %s checkpointed to %s\n", podID, path)
+
+		return nil
+	},
+}
+
+var restorePodCommand = &cli.Command{
+	Name:                   "restorep",
+	Usage:                  "Restore a pod sandbox from a checkpoint",
+	ArgsUsage:              "CHECKPOINT-PATH",
+	UseShortOptionHandling: true,
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "pod-config",
+			Aliases: []string{"c"},
+			Usage:   "Path to the PodSandboxConfig JSON or YAML file for the restored pod",
+		},
+		&cli.StringSliceFlag{
+			Name:    "container-config",
+			Aliases: []string{"C"},
+			Usage:   "Path to a ContainerConfig JSON or YAML file; specify once per restored container",
+		},
+		&cli.StringFlag{
+			Name:    "runtime",
+			Aliases: []string{"r"},
+			Usage:   "Runtime handler to use for restore",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		if c.NArg() == 0 {
+			return errors.New("CHECKPOINT-PATH cannot be empty")
+		}
+
+		if c.NArg() > 1 {
+			return errors.New("only one checkpoint path can be restored at a time")
+		}
+
+		if c.String("pod-config") == "" {
+			return errors.New("--pod-config is required")
+		}
+
+		if len(c.StringSlice("container-config")) == 0 {
+			return errors.New("at least one --container-config is required")
+		}
+
+		runtimeClient, err := configFromContext(c).GetRuntimeService(c.Context, 0)
+		if err != nil {
+			return err
+		}
+
+		checkpointPath := c.Args().First()
+		request := &pb.RestorePodRequest{
+			CheckpointPath: checkpointPath,
+			RuntimeHandler: c.String("runtime"),
+		}
+
+		request.Config, err = loadPodSandboxConfig(c.String("pod-config"))
+		if err != nil {
+			return fmt.Errorf("failed to load pod sandbox config: %w", err)
+		}
+
+		for _, configPath := range c.StringSlice("container-config") {
+			config, err := loadContainerConfig(configPath)
+			if err != nil {
+				return fmt.Errorf("failed to load container config %q: %w", configPath, err)
+			}
+
+			request.ContainerConfigs = append(request.ContainerConfigs, config)
+		}
+
+		logrus.Debugf("RestorePodRequest: %v", request)
+
+		response, err := InterruptableRPC(c.Context, func(
+			ctx context.Context,
+		) (*pb.RestorePodResponse, error) {
+			return runtimeClient.RestorePod(ctx, request)
+		})
+		if err != nil {
+			return fmt.Errorf("restoring pod from %q failed: %w", checkpointPath, err)
+		}
+
+		fmt.Printf("Pod restored: %s\n", response.GetPodSandboxId())
+
+		return nil
+	},
+}

--- a/test/e2e/checkpoint_pod_test.go
+++ b/test/e2e/checkpoint_pod_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+const checkpointTestImage = "registry.k8s.io/busybox:1.36.1"
+
+func writeCheckpointConfig(pattern, contents string) string {
+	file, err := os.CreateTemp("", pattern)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = fmt.Fprint(file, contents)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(file.Close()).To(Succeed())
+
+	return file.Name()
+}
+
+func checkpointPodConfigs(name, uid, namespace string) (podConfig, containerConfig string) {
+	podConfig = writeCheckpointConfig("pod-config-", fmt.Sprintf(`{
+		"metadata": {"name": %q, "uid": %q, "namespace": %q},
+		"linux": {"security_context": {"namespace_options": {"network": 2}}}
+	}`, name, uid, namespace))
+	containerConfig = writeCheckpointConfig("container-config-", fmt.Sprintf(`{
+		"metadata": {"name": "checkpoint-container"},
+		"image": {"image": %q},
+		"command": ["sh"],
+		"args": ["-c", "sleep 300"]
+	}`, checkpointTestImage))
+
+	return podConfig, containerConfig
+}
+
+func createCheckpointPod(name, uid, namespace string) (podID, podConfig, containerConfig string) {
+	podConfig, containerConfig = checkpointPodConfigs(name, uid, namespace)
+	Expect(t.Crictl(fmt.Sprintf("run --with-pull %s %s", containerConfig, podConfig))).To(Exit(0))
+	result := t.Crictl("pods --name " + name + " -q")
+	Expect(result).To(Exit(0))
+	podID = string(bytes.TrimSpace(result.Out.Contents()))
+	Expect(podID).NotTo(BeEmpty())
+
+	return podID, podConfig, containerConfig
+}
+
+func cleanupCheckpointPod(podID, podConfig, containerConfig string) {
+	if podID != "" {
+		Expect(t.Crictl("rmp -f " + podID)).To(Exit(0))
+	}
+
+	Expect(os.Remove(podConfig)).To(Succeed())
+	Expect(os.Remove(containerConfig)).To(Succeed())
+	t.CrictlRemovePauseImages()
+}
+
+var _ = t.Describe("checkpointp", func() {
+	It("should validate its arguments", func() {
+		t.CrictlExpectFailure("checkpointp", "", "POD-ID cannot be empty")
+		t.CrictlExpectFailure("checkpointp pod-id", "", "without specifying the checkpoint path")
+		t.CrictlExpectFailure("checkpointp --path /tmp/checkpoint pod1 pod2", "",
+			"only one pod sandbox can be checkpointed at a time")
+	})
+
+	It("should reject a pod without running containers", func() {
+		podConfig, containerConfig := checkpointPodConfigs(
+			"checkpoint-empty", "checkpoint-empty", "default",
+		)
+		defer os.Remove(podConfig)
+		defer os.Remove(containerConfig)
+
+		result := t.Crictl("runp " + podConfig)
+		Expect(result).To(Exit(0))
+
+		podID := string(bytes.TrimSpace(result.Out.Contents()))
+		defer func() { Expect(t.Crictl("rmp -f " + podID)).To(Exit(0)) }()
+
+		checkpointPath, err := os.MkdirTemp("", "checkpoint-")
+		Expect(err).NotTo(HaveOccurred())
+
+		defer os.RemoveAll(checkpointPath)
+
+		t.CrictlExpectFailure(fmt.Sprintf("checkpointp --path %s %s", checkpointPath, podID), "",
+			"has no running containers to checkpoint")
+	})
+
+	It("should checkpoint and restore a pod", func() {
+		podID, podConfig, containerConfig := createCheckpointPod(
+			"checkpoint-roundtrip", "checkpoint-roundtrip", "default")
+		defer func() { cleanupCheckpointPod(podID, podConfig, containerConfig) }()
+
+		checkpointPath, err := os.MkdirTemp("", "checkpoint-")
+		Expect(err).NotTo(HaveOccurred())
+
+		defer os.RemoveAll(checkpointPath)
+
+		result := t.Crictl(fmt.Sprintf("checkpointp --path %s %s", checkpointPath, podID))
+		Expect(result).To(Exit(0))
+		Expect(result.Out.Contents()).To(ContainSubstring("checkpointed"))
+
+		entries, err := os.ReadDir(checkpointPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).NotTo(BeEmpty(), "the runtime should write checkpoint data")
+
+		Expect(t.Crictl("rmp -f " + podID)).To(Exit(0))
+		podID = ""
+		result = t.Crictl(fmt.Sprintf(
+			"restorep --pod-config %s --container-config %s %s",
+			podConfig, containerConfig, checkpointPath,
+		))
+		Expect(result).To(Exit(0))
+		fields := bytes.Fields(result.Out.Contents())
+		Expect(fields).NotTo(BeEmpty())
+		podID = string(fields[len(fields)-1])
+		Expect(podID).NotTo(BeEmpty())
+		Expect(t.Crictl("inspectp " + podID)).To(Exit(0))
+	})
+})
+
+var _ = t.Describe("restorep", func() {
+	It("should validate its arguments and required configs", func() {
+		t.CrictlExpectFailure("restorep", "", "CHECKPOINT-PATH cannot be empty")
+		t.CrictlExpectFailure("restorep /path1 /path2", "",
+			"only one checkpoint path can be restored at a time")
+		t.CrictlExpectFailure("restorep /checkpoint", "", "--pod-config is required")
+
+		podConfig, containerConfig := checkpointPodConfigs(
+			"restore-validation", "restore-validation", "default",
+		)
+		defer os.Remove(podConfig)
+		defer os.Remove(containerConfig)
+
+		t.CrictlExpectFailure("restorep --pod-config "+podConfig+" /checkpoint", "",
+			"at least one --container-config is required")
+		t.CrictlExpectFailure(fmt.Sprintf(
+			"restorep --pod-config %s --container-config %s %s",
+			podConfig, containerConfig, filepath.Join(os.TempDir(), "missing-checkpoint"),
+		), "", "restoring pod")
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://github.com/kubernetes-sigs/cri-tools/blob/master/CONTRIBUTING.md
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Adds pod-level checkpoint and restore support to `crictl` for [KEP-5823](https://github.com/kubernetes/enhancements/issues/5823).

This introduces two commands: `crictl checkpointp` and `crictl restorep`. The commands use the new CRI `CheckpointPod` and `RestorePod` RPCs.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is a dependent PR for KEP-5823 and should remain a draft until its API dependencies are available upstream.

Dependencies:
- Kubernetes CRI API change adding `CheckpointPod` and `RestorePod`: https://github.com/kubernetes/kubernetes/pull/140366
- Containerd implementation: https://github.com/containerd/containerd/pull/13822

#### Does this PR introduce a user-facing change?

```release-note
Add `crictl checkpointp` and `crictl restorep` commands for pod-level checkpoint and restore.
```
