### PR TITLE
docs: update version references to v1.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ milestones.
 ### Install crictl
 
 ```sh
-VERSION="v1.36.0"
+VERSION="v1.37.0"
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
 sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
 rm -f crictl-$VERSION-linux-amd64.tar.gz
@@ -67,7 +67,7 @@ rm -f crictl-$VERSION-linux-amd64.tar.gz
 ### Install critest
 
 ```sh
-VERSION="v1.36.0"
+VERSION="v1.37.0"
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/critest-$VERSION-linux-amd64.tar.gz
 sudo tar zxvf critest-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
 rm -f critest-$VERSION-linux-amd64.tar.gz

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 ---
 dependencies:
   - name: cri-tools
-    version: v1.36.0
+    version: v1.37.0
     refPaths:
       - path: README.md
         match: VERSION

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -7,7 +7,7 @@ CRI performance benchmarking provides a benchmarking framework for CRI-compatibl
 The benchmarking tests binary `critest` can be downloaded from [Releasing page](https://github.com/kubernetes-sigs/cri-tools/releases):
 
 ```sh
-VERSION="v1.36.0"
+VERSION="v1.37.0"
 ARCH="amd64"
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/critest-$VERSION-linux-$ARCH.tar.gz
 sudo tar zxvf critest-$VERSION-linux-$ARCH.tar.gz -C /usr/local/bin

--- a/docs/crictl.1
+++ b/docs/crictl.1
@@ -28,7 +28,7 @@ corresponding container runtime using the CRI API protocol
 using \fBwget\fR:
 
 .EX
-VERSION="v1.36.0"
+VERSION="v1.37.0"
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
 sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
 rm -f crictl-$VERSION-linux-amd64.tar.gz
@@ -38,7 +38,7 @@ rm -f crictl-$VERSION-linux-amd64.tar.gz
 using \fBcurl\fR:
 
 .EX
-VERSION="v1.36.0"
+VERSION="v1.37.0"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
 sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
 rm -f crictl-$VERSION-linux-amd64.tar.gz

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -16,7 +16,7 @@ corresponding container runtime using the [CRI API protocol](/vendor/k8s.io/cri-
 - using `wget`:
 
 ```sh
-VERSION="v1.36.0"
+VERSION="v1.37.0"
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
 sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
 rm -f crictl-$VERSION-linux-amd64.tar.gz
@@ -25,7 +25,7 @@ rm -f crictl-$VERSION-linux-amd64.tar.gz
 - using `curl`:
 
 ```sh
-VERSION="v1.36.0"
+VERSION="v1.37.0"
 curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
 sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
 rm -f crictl-$VERSION-linux-amd64.tar.gz

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -9,7 +9,7 @@ CRI validation testing is GA since v1.11.0. We encourage the CRI developers to r
 The benchmarking tests binary `critest` can be downloaded from [Releasing page](https://github.com/kubernetes-sigs/cri-tools/releases):
 
 ```sh
-VERSION="v1.36.0"
+VERSION="v1.37.0"
 ARCH="amd64"
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/critest-$VERSION-linux-$ARCH.tar.gz
 sudo tar zxvf critest-$VERSION-linux-$ARCH.tar.gz -C /usr/local/bin


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Update version references in docs from v1.36.0 to v1.37.0 after the v1.37.0 release.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```