### PR TITLE
Remove deprecated --required-author flag from release-notes

### DIFF
--- a/hack/release-notes.sh
+++ b/hack/release-notes.sh
@@ -31,7 +31,6 @@ LATEST_TAG=$(git tag | tail -1)
 $BINARY \
     --org kubernetes-sigs \
     --repo cri-tools \
-    --required-author "" \
     --branch master \
     --start-rev "$PREVIOUS_TAG" \
     --end-rev "$LATEST_TAG" \


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Removes the `--required-author ""` flag from `hack/release-notes.sh`. The flag was removed from the kubernetes/release release-notes tool in kubernetes/release#4343 as part of the v1 generator cleanup. The v2 generator includes all authors by default, so this flag is no longer needed and would cause the release workflow to fail.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Verified by running the v0.21.1 release-notes binary against v1.36.0..v1.37.0 without the flag. It successfully generated notes from all authors.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```