### PR TITLE
Add release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,34 @@
+---
+name: Release
+about: Track a new cri-tools release
+labels: sig/release, sig/node
+---
+
+## Release cri-tools v1.Y.Z
+
+### Pre-release
+
+- [ ] Vendor the final Kubernetes release candidate so that cri-tools can be released before Kubernetes
+- [ ] Create a new signed tag (`git tag -s -m v1.Y.Z v1.Y.Z`) and push it. Wait for the [release GitHub Actions CI](https://github.com/kubernetes-sigs/cri-tools/actions/workflows/release.yml) to finish. The release actions job adds the notes to the release and attaches the artifacts.
+
+### Post-release
+
+- [ ] Update cri-tools version references in the repo ([example](https://github.com/kubernetes-sigs/cri-tools/pull/2172))
+- [ ] Ask a [Kubernetes Release Manager](https://k8s.io/releases/release-managers/) to update the official OBS packages using [`krel`](https://github.com/kubernetes/release/releases/latest):
+  ```
+  krel obs stage \
+      --packages cri-tools \
+      --version 1.Y.Z \
+      --project isv:kubernetes:core:stable:v1.Y:build \
+      --stream \
+      --nomock
+  ```
+  ```
+  krel obs release \
+      --packages cri-tools \
+      --stream \
+      --project isv:kubernetes:core:stable:v1.Y:build \
+      --nomock
+  ```
+- [ ] Update cri-tools in k/kubernetes ([example](https://github.com/kubernetes/kubernetes/pull/122271))
+- [ ] Update cri-tools in [cri-o/packaging](https://github.com/cri-o/packaging)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,4 @@
 # Release Process
 
-The Kubernetes cri-tools Project is released for every Kubernetes release. The
-process is as follows:
-
-1. An OWNER runs `git tag -m $VERSION -s $VERSION` and pushes the tag with `git push $VERSION`, where `$VERSION` follows the Kubernetes minor version.
-1. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] cri-tools $VERSION is released`
+The cri-tools project is released for every Kubernetes release. To track a new
+release, create a [release issue](https://github.com/kubernetes-sigs/cri-tools/issues/new?template=release.md).


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Adds a GitHub issue template for tracking cri-tools releases. It provides a checklist covering vendoring, tagging, OBS packaging, and downstream updates so that nothing gets missed during the release process.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```