### PR TITLE
WIP: Bump runc from v1.4.3 to v1.5.1 in CRI-O CI

### DIFF
--- a/.github/workflows/crio.yml
+++ b/.github/workflows/crio.yml
@@ -96,14 +96,11 @@ jobs:
         run: |
           sudo sed -i -E 's;(monitor_path = ).*;\1"/usr/libexec/crio/conmonrs"\nruntime_type = "pod";g' /etc/crio/crio.conf.d/10-crio.conf
 
-      - name: Install runc 1.4.3
+      - name: Install runc
         if: ${{matrix.oci-runtime == 'runc'}}
         run: |
-          # runc 1.5.x has a regression causing privileged and host-namespace
-          # pods to fail ("cannot start a container that has stopped"). Pin to
-          # 1.4.3 until the upstream issue is resolved.
           sudo curl -o /usr/libexec/crio/runc -fsSL \
-            https://github.com/opencontainers/runc/releases/download/v1.4.3/runc.amd64
+            https://github.com/opencontainers/runc/releases/download/v1.5.1/runc.amd64
           sudo chmod +x /usr/libexec/crio/runc
           /usr/libexec/crio/runc --version
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The pin to runc v1.4.3 was a workaround for a regression (opencontainers/runc#5151) that caused "cannot start a container that has stopped" errors. That regression was fixed in runc v1.4.1.
Bump to v1.5.1 (latest stable), which is also what CRI-O uses in its own Prow CI.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
CI will validate whether runc v1.5.1 works on GitHub Actions ubuntu-24.04 runners.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```